### PR TITLE
distinguish supply expansion from insurance payments

### DIFF
--- a/contracts/interfaces/IInsurancePool.sol
+++ b/contracts/interfaces/IInsurancePool.sol
@@ -14,7 +14,7 @@ interface IInsurancePool {
 
     // ==== Callable only by the RToken ====
 
-    function registerRevenueEvent(uint256 amount) external;
+    function makeInsurancePayment(uint256 amount) external;
 
     // ==== Callable by anyone ====
 

--- a/contracts/modules/InsurancePool.sol
+++ b/contracts/modules/InsurancePool.sol
@@ -31,7 +31,7 @@ contract InsurancePool is IInsurancePool, OwnableUpgradeable, UUPSUpgradeable {
 
     struct RevenueEvent {
         uint256 amount;
-        uint256 totalStaked;
+        uint256 totalWeight;
     }
 
     // Event log pattern
@@ -75,7 +75,6 @@ contract InsurancePool is IInsurancePool, OwnableUpgradeable, UUPSUpgradeable {
     function stake(uint256 amount) external override update(_msgSender()) {
         require(amount > 0, "Cannot stake 0");
         IERC20Upgradeable(address(rsr)).safeTransferFrom(_msgSender(), address(this), amount);
-
         deposits.push(Delayed(_msgSender(), amount, block.timestamp));
         emit DepositInitiated(_msgSender(), amount);
     }
@@ -99,7 +98,7 @@ contract InsurancePool is IInsurancePool, OwnableUpgradeable, UUPSUpgradeable {
     }
 
     // Callable only by RToken address
-    function registerRevenueEvent(uint256 amount) external override update(address(0)) {
+    function makeInsurancePayment(uint256 amount) external override update(address(0)) {
         require(_msgSender() == address(rToken), "Only RToken");
 
         IERC20Upgradeable(address(rToken)).safeTransferFrom(address(rToken), address(this), amount);
@@ -135,7 +134,7 @@ contract InsurancePool is IInsurancePool, OwnableUpgradeable, UUPSUpgradeable {
         if (address(account) != address(0) && weight[account] > 0) {
             uint256 limit = MathUpgradeable.min(lastIndex[account] + numToProcess, revenues.length);
             for (uint256 i = lastIndex[account]; i < limit; i++) {
-                earned[account] += (revenues[i].amount * weight[account]) / revenues[i].totalStaked;
+                earned[account] += (revenues[i].amount * weight[account]) / revenues[i].totalWeight;
             }
 
             lastIndex[account] = limit;

--- a/contracts/test/RTokenMock.sol
+++ b/contracts/test/RTokenMock.sol
@@ -45,9 +45,9 @@ contract RTokenMock is RToken {
         );
     }
 
-    function registerRevenueEvent(uint256 amount) external {
+    function makeInsurancePayment(uint256 amount) external {
         _mint(address(this), amount);
         _approve(address(this), address(config.insurancePool), amount);
-        config.insurancePool.registerRevenueEvent(amount);
+        config.insurancePool.makeInsurancePayment(amount);
     }
 }

--- a/test/InsurancePool.test.js
+++ b/test/InsurancePool.test.js
@@ -546,7 +546,7 @@ describe("InsurancePool contract", function () {
         it("Should not allow to register Revenue if caller is not Rtoken", async function () {
             const amount = BigNumber.from(1000);
 
-            await expect(iPool.connect(owner).registerRevenueEvent(amount))
+            await expect(iPool.connect(owner).makeInsurancePayment(amount))
                 .to.be.revertedWith("Only RToken")
 
             expect(await rToken.balanceOf(iPool.address)).to.equal(0);
@@ -555,7 +555,7 @@ describe("InsurancePool contract", function () {
         it("Should allow to register Revenue if caller is Rtoken", async function () {
             const amount = BigNumber.from(1000);
 
-            await expect(rToken.registerRevenueEvent(amount))
+            await expect(rToken.makeInsurancePayment(amount))
                 .to.emit(iPool, 'RevenueEventSaved')
                 .withArgs(0, amount);
 
@@ -573,7 +573,7 @@ describe("InsurancePool contract", function () {
             const amount1 = BigNumber.from(1000);
             const amount2 = BigNumber.from(2000);
 
-            await expect(rToken.registerRevenueEvent(amount1))
+            await expect(rToken.makeInsurancePayment(amount1))
                 .to.emit(iPool, 'RevenueEventSaved')
                 .withArgs(0, amount1);
 
@@ -583,7 +583,7 @@ describe("InsurancePool contract", function () {
             expect(revAmt).to.equal(amount1);
             expect(stakeAmt).to.equal(await iPool.totalWeight());
 
-            await expect(rToken.registerRevenueEvent(amount2))
+            await expect(rToken.makeInsurancePayment(amount2))
                 .to.emit(iPool, 'RevenueEventSaved')
                 .withArgs(1, amount2);
 


### PR DESCRIPTION
The purpose of this PR is for the InsurancePool to have high confidence that the RToken will not flood it with RevenueEvents and cause degradation of service to users. I also renamed a lot of things along the way, and added a check for the Config struct.