### PR TITLE
Refactor Auction Structure

### DIFF
--- a/contracts/proto0/AssetManagerP0.sol
+++ b/contracts/proto0/AssetManagerP0.sol
@@ -163,10 +163,12 @@ contract AssetManagerP0 is IAssetManager, Ownable {
     // Algorithm:
     //     1. Closeout previous auctions
     //     2. Create BUs from spare assets
-    //     3. Break off BUs from the old vault for more assets, if we
-    //     4. Launch a asset-for-asset auction until we are left with dust
+    //     3. Break off BUs from the old vault for more assets if we are undercapitalized
+    //     4. Launch asset-for-asset auctions until we are left with only dust
     //     5. If it's all dust: sell RSR and buy RToken and burn it
     //     6. If we run out of RSR: give RToken holders a haircut to get back to capitalized
+    // That's all just to get to the point of capitalization. 
+    // Once we are capitalized we perform revenue auctions. 
     function runAuctions() external override onlyMain always returns (State) {
         // Closeout open auctions or sleep if they are still ongoing.
         for (uint256 i = 0; i < auctionCount; i++) {
@@ -229,6 +231,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
                     Fate.Stay
                 );
             } else if (!worth && main.rsr().balanceOf(address(main.stRSR())) > 0) {
+                // Recapitalization: RSR -> RToken
                 (worth, auction) = _prepareTargetBuyAuction(
                     config.minRecapitalizationAuctionSize,
                     main.rsrAsset(),

--- a/contracts/proto0/AssetManagerP0.sol
+++ b/contracts/proto0/AssetManagerP0.sol
@@ -229,7 +229,8 @@ contract AssetManagerP0 is IAssetManager, Ownable {
                     targetBuy,
                     Fate.Stay
                 );
-            } else if (!trade && main.rsr().balanceOf(address(main.stRSR())) > 0) {
+            } 
+            if (!trade && main.rsr().balanceOf(address(main.stRSR())) > 0) {
                 // Recapitalization: RSR -> RToken
                 (trade, auction) = _prepareAuctionTargetBuy(
                     config.minRecapitalizationAuctionSize,
@@ -243,7 +244,8 @@ contract AssetManagerP0 is IAssetManager, Ownable {
                 if (trade) {
                     main.stRSR().seizeRSR(auction.sellAmount - main.rsr().balanceOf(address(this)));
                 }
-            } else if (!trade) {
+            } 
+            if (!trade) {
                 // We've reached the endgame...time to concede and give RToken holders a haircut.
                 _accumulate();
                 uint256 melting = (SCALE * (totalSupply + main.furnace().totalBurnt())) / totalSupply;

--- a/contracts/proto0/AssetManagerP0.sol
+++ b/contracts/proto0/AssetManagerP0.sol
@@ -62,8 +62,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
 
     // Append-only record keeping
     IVault[] public pastVaults;
-    mapping(uint256 => Auction.Info) public auctions;
-    uint256 public auctionCount;
+    Auction.Info[] public auctions;
 
     constructor(
         IMain main_,
@@ -171,7 +170,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
     // Once we are capitalized we perform revenue auctions. 
     function runAuctions() external override onlyMain always returns (State) {
         // Closeout open auctions or sleep if they are still ongoing.
-        for (uint256 i = 0; i < auctionCount; i++) {
+        for (uint256 i = 0; i < auctions.length; i++) {
             Auction.Info storage auction = auctions[i];
             if (auction.open) {
                 if (block.timestamp <= auction.endTime) {
@@ -252,9 +251,8 @@ contract AssetManagerP0 is IAssetManager, Ownable {
                 return State.CALM;
             }
 
-            auctions[auctionCount] = auction;
-            auctions[auctionCount].launch();
-            auctionCount++;
+            auctions.push(auction);
+            auctions[auctions.length - 1].launch();
             return State.TRADING;
         }
 
@@ -274,9 +272,8 @@ contract AssetManagerP0 is IAssetManager, Ownable {
             Fate.Stake
         );
         if (worth) {
-            auctions[auctionCount] = auction;
-            auctions[auctionCount].launch();
-            auctionCount++;
+            auctions.push(auction);
+            auctions[auctions.length - 1].launch();
             return State.TRADING;
         }
 
@@ -319,12 +316,10 @@ contract AssetManagerP0 is IAssetManager, Ownable {
         }
 
         if (worth && worth2) {
-            auctions[auctionCount] = auction;
-            auctions[auctionCount].launch();
-            auctionCount++;
-            auctions[auctionCount] = auction2;
-            auctions[auctionCount].launch();
-            auctionCount++;
+            auctions.push(auction);
+            auctions[auctions.length - 1].launch();
+            auctions.push(auction2);
+            auctions[auctions.length - 1].launch();
             return State.TRADING;
         }
         return State.CALM;

--- a/contracts/proto0/AssetManagerP0.sol
+++ b/contracts/proto0/AssetManagerP0.sol
@@ -125,7 +125,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
     // Transfers collateral to the redeemers account at the current BU exchange rate.
     function redeem(address redeemer, uint256 amount) external override onlyMain always {
         main.rToken().burn(redeemer, amount);
-        _oldestNonEmptyVault().redeem(redeemer, _toBUs(amount));
+        _oldestVault().redeem(redeemer, _toBUs(amount));
     }
 
     // Claims COMP + AAVE from Vault + Manager and expands the RToken supply.
@@ -197,7 +197,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
         bool worth;
         Auction.Info memory auction;
         Config memory config = main.config();
-        IVault oldVault = _oldestNonEmptyVault();
+        IVault oldVault = _oldestVault();
 
         // If we are not fully capitalized, prioritize recapitalization auctions
         if (!fullyCapitalized()) {
@@ -381,7 +381,7 @@ contract AssetManagerP0 is IAssetManager, Ownable {
     // Returns the oldest vault that contains nonzero BUs.
     // Note that this will pass over vaults with uneven holdings, it does not necessarily mean the vault
     // contains no asset tokens.
-    function _oldestNonEmptyVault() internal view returns (IVault) {
+    function _oldestVault() internal view returns (IVault) {
         for (uint256 i = 0; i < pastVaults.length; i++) {
             if (pastVaults[i].basketUnits(address(this)) > 0) {
                 return pastVaults[i];

--- a/contracts/proto0/DefaultMonitorP0.sol
+++ b/contracts/proto0/DefaultMonitorP0.sol
@@ -68,7 +68,7 @@ contract DefaultMonitorP0 is Context, IDefaultMonitor {
         IVault vault,
         address[] memory approvedCollateral,
         address[] memory fiatcoins
-    ) external view override returns (IVault) {
+    ) external override returns (IVault) {
         uint256 maxRate;
         uint256 indexMax = 0;
 
@@ -76,7 +76,7 @@ contract DefaultMonitorP0 is Context, IDefaultMonitor {
         IVault[] memory backups = vault.getBackups();
         for (uint256 i = 0; i < backups.length; i++) {
             if (backups[i].containsOnly(approvedCollateral) && checkForSoftDefault(backups[i], fiatcoins).length == 0) {
-                uint256 rate = backups[i].basketFiatcoinRate();
+                uint256 rate = backups[i].basketRate();
 
                 // See if it has the highest basket rate
                 if (rate > maxRate) {

--- a/contracts/proto0/MainP0.sol
+++ b/contracts/proto0/MainP0.sol
@@ -124,7 +124,7 @@ contract MainP0 is IMain, Ownable {
                 rewardsClaimed[prevRewards] = true;
             }
         }
-        state = manager.runAuctions();
+        state = manager.doAuctions();
     }
 
     // Default check

--- a/contracts/proto0/MainP0.sol
+++ b/contracts/proto0/MainP0.sol
@@ -88,7 +88,7 @@ contract MainP0 is IMain, Ownable {
     }
 
     function issue(uint256 amount) external override notPaused always {
-        require(state == State.CALM || state == State.TRADING, "only during calm + migration");
+        require(state == State.CALM || state == State.TRADING, "only during calm + trading");
         require(amount > 0, "Cannot issue zero");
         _processSlowIssuance();
 
@@ -116,7 +116,7 @@ contract MainP0 is IMain, Ownable {
 
     // Runs auctions
     function poke() external override notPaused always {
-        require(state == State.CALM || state == State.TRADING, "only during calm + migration");
+        require(state == State.CALM || state == State.TRADING, "only during calm + trading");
         _processSlowIssuance();
 
         if (state == State.CALM) {

--- a/contracts/proto0/MainP0.sol
+++ b/contracts/proto0/MainP0.sol
@@ -94,7 +94,7 @@ contract MainP0 is IMain, Ownable {
 
         // During SlowIssuance, BUs are created up front and held by `Main` until the issuance vests,
         // at which point the BUs are transferred to the AssetManager and RToken is minted to the issuer.
-        issuances[issuanceCount] = manager.startIssuance(_msgSender(), amount);
+        issuances[issuanceCount] = manager.beginIssuance(_msgSender(), amount);
         issuances[issuanceCount].blockAvailableAt = _nextIssuanceBlockAvailable(amount);
 
         SlowIssuance storage iss = issuances[issuanceCount];

--- a/contracts/proto0/VaultP0.sol
+++ b/contracts/proto0/VaultP0.sol
@@ -121,8 +121,15 @@ contract VaultP0 is IVault, Ownable {
         }
     }
 
+    // Forces an update in Compound/Aave
+    function updateCompoundAaveRates() external override {
+        for (uint256 i = 0; i < _basket.size; i++) {
+            _basket.assets[i].updateRedemptionRate();
+        }
+    }
+
     // Returns how many fiatcoins a single BU can be redeemed for.
-    function basketFiatcoinRate() external view override returns (uint256 sum) {
+    function basketRate() external view override returns (uint256 sum) {
         for (uint256 i = 0; i < _basket.size; i++) {
             IAsset c = _basket.assets[i];
             sum += (_basket.quantities[i] * c.redemptionRate()) / 10**c.decimals();

--- a/contracts/proto0/VaultP0.sol
+++ b/contracts/proto0/VaultP0.sol
@@ -31,6 +31,8 @@ contract VaultP0 is IVault, Ownable {
 
     IVault[] public backups;
 
+    IMain public main;
+
     constructor(
         IAsset[] memory assets,
         uint256[] memory quantities,
@@ -101,7 +103,9 @@ contract VaultP0 is IVault, Ownable {
     }
 
     // Claims COMP/AAVE and sweeps any balance to the Asset Manager.
-    function claimAndSweepRewardsToManager(IMain main) external override {
+    function claimAndSweepRewardsToManager() external override {
+        require(address(main) != address(0), "main not set");
+
         // Claim
         main.comptroller().claimComp(address(this));
         IStaticAToken(address(main.aaveAsset().erc20())).claimRewardsToSelf(true);
@@ -178,5 +182,9 @@ contract VaultP0 is IVault, Ownable {
 
     function setBackups(IVault[] memory backupVaults) external onlyOwner {
         backups = backupVaults;
+    }
+
+    function setMain(IMain main_) external onlyOwner {
+        main = main_;
     }
 }

--- a/contracts/proto0/assets/AssetP0.sol
+++ b/contracts/proto0/assets/AssetP0.sol
@@ -16,6 +16,8 @@ contract AssetP0 is IAsset {
         _erc20 = erc20_;
     }
 
+    function updateRedemptionRate() external virtual override {}
+
     // Fiatcoins return 1e18. All redemption rates should have 18 zeroes.
     function redemptionRate() public view virtual override returns (uint256) {
         return 1e18;

--- a/contracts/proto0/assets/CTokenAssetP0.sol
+++ b/contracts/proto0/assets/CTokenAssetP0.sol
@@ -6,7 +6,7 @@ import "./AssetP0.sol";
 
 // https://github.com/compound-finance/compound-protocol/blob/master/contracts/CToken.sol
 interface ICToken {
-    // function exchangeRateCurrent() external returns (uint256); // this one is a mutator
+    function exchangeRateCurrent() external returns (uint256);
 
     function exchangeRateStored() external view returns (uint256);
 
@@ -16,6 +16,10 @@ interface ICToken {
 contract CTokenAssetP0 is AssetP0 {
     // All cTokens have 8 decimals, but their underlying may have 18 or 6 or something else.
     constructor(address erc20_) AssetP0(erc20_) {}
+
+    function updateRedemptionRate() external virtual override {
+        ICToken(_erc20).exchangeRateCurrent();
+    }
 
     function redemptionRate() public view override returns (uint256) {
         return ICToken(_erc20).exchangeRateStored() * 10**(18 - fiatcoinDecimals());

--- a/contracts/proto0/interfaces/IAsset.sol
+++ b/contracts/proto0/interfaces/IAsset.sol
@@ -5,6 +5,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IMain.sol";
 
 interface IAsset {
+    function updateRedemptionRate() external;
+
+    // Call `updateRedemptionRate()` before to ensure the latest rates
     function redemptionRate() external view returns (uint256);
 
     function erc20() external view returns (IERC20);

--- a/contracts/proto0/interfaces/IAssetManager.sol
+++ b/contracts/proto0/interfaces/IAssetManager.sol
@@ -6,7 +6,7 @@ import "./IMain.sol";
 import "./IVault.sol";
 
 interface IAssetManager {
-    function startIssuance(address issuer, uint256 amount) external returns (SlowIssuance memory);
+    function beginIssuance(address issuer, uint256 amount) external returns (SlowIssuance memory);
 
     function completeIssuance(SlowIssuance memory issuance) external;
 

--- a/contracts/proto0/interfaces/IAssetManager.sol
+++ b/contracts/proto0/interfaces/IAssetManager.sol
@@ -14,7 +14,7 @@ interface IAssetManager {
 
     function runAuctions() external returns (State);
 
-    function runPeriodicActions() external;
+    function collectRevenue() external;
 
     function accumulate() external;
 

--- a/contracts/proto0/interfaces/IAssetManager.sol
+++ b/contracts/proto0/interfaces/IAssetManager.sol
@@ -6,11 +6,11 @@ import "./IMain.sol";
 import "./IVault.sol";
 
 interface IAssetManager {
-    function beginIssuance(address issuer, uint256 amount) external returns (SlowIssuance memory);
+    function update() external; // block-by-block idempotent updates
 
     function completeIssuance(SlowIssuance memory issuance) external;
 
-    function redeem(address redeemer, uint256 amount) external;
+    function redeem(address redeemer, uint256 rTokenAmount) external;
 
     function doAuctions() external returns (State);
 
@@ -20,7 +20,9 @@ interface IAssetManager {
 
     function switchVaults(IAsset[] memory defaulting) external;
 
-    function quote(uint256 amount) external view returns (uint256[] memory);
+    function toBUs(uint256 rTokenAmount) external view returns (uint256);
+
+    function fromBUs(uint256 BUs) external view returns (uint256);
 
     function fullyCapitalized() external view returns (bool);
 

--- a/contracts/proto0/interfaces/IAssetManager.sol
+++ b/contracts/proto0/interfaces/IAssetManager.sol
@@ -12,7 +12,7 @@ interface IAssetManager {
 
     function redeem(address redeemer, uint256 amount) external;
 
-    function runAuctions() external returns (State);
+    function doAuctions() external returns (State);
 
     function collectRevenue() external;
 

--- a/contracts/proto0/interfaces/IDefaultMonitor.sol
+++ b/contracts/proto0/interfaces/IDefaultMonitor.sol
@@ -13,5 +13,5 @@ interface IDefaultMonitor {
         IVault vault,
         address[] memory approvedCollateral,
         address[] memory fiatcoins
-    ) external view returns (IVault);
+    ) external returns (IVault);
 }

--- a/contracts/proto0/interfaces/IMain.sol
+++ b/contracts/proto0/interfaces/IMain.sol
@@ -89,9 +89,7 @@ interface IMain {
 
     function paused() external view returns (bool);
 
-    function quoteIssue(uint256 amount) external view returns (uint256[] memory);
-
-    function quoteRedeem(uint256 amount) external view returns (uint256[] memory);
+    function quote(uint256 amount) external view returns (uint256[] memory);
 
     function rsr() external view returns (IERC20);
 

--- a/contracts/proto0/interfaces/IMain.sol
+++ b/contracts/proto0/interfaces/IMain.sol
@@ -12,10 +12,10 @@ import "./IStRSR.sol";
 import "./IVault.sol";
 
 enum State {
-    CALM,
-    DOUBT,
-    RECAPITALIZING,
-    PRECAUTIONARY
+    CALM, // 100% capitalized + no auctions
+    DOUBT, // in this state for 24h before default, no auctions or unstaking
+    TRADING, // auctions in progress, no unstaking
+    PRECAUTIONARY // no auctions, no issuance, no unstaking
 }
 
 struct Config {
@@ -28,8 +28,9 @@ struct Config {
     // Percentage values (relative to SCALE)
     uint256 maxTradeSlippage; // the maximum amount of slippage in percentage terms we will accept in a trade
     uint256 auctionClearingTolerance; // the maximum % difference between auction clearing price and oracle data allowed.
-    uint256 maxAuctionSize; // the size of an auction, as a fraction of RToken supply
-    uint256 minAuctionSize; // the size of an auction, as a fraction of RToken supply
+    uint256 maxAuctionSize; // the max size of an auction, as a fraction of RToken supply
+    uint256 minRecapitalizationAuctionSize; // the min size of a recapitalization auction, as a fraction of RToken supply
+    uint256 minRevenueAuctionSize; // the min size of a revenue auction (RToken/COMP/AAVE), as a fraction of RToken supply
     uint256 migrationChunk; // how much backing to migrate at a time, as a fraction of RToken supply
     uint256 issuanceRate; // the number of RToken to issue per block, as a fraction of RToken supply
     uint256 defaultThreshold; // the percent deviation required before a token is marked as in-default
@@ -46,7 +47,8 @@ struct Config {
     // maxTradeSlippage = 1e17 (10%)
     // auctionClearingTolerance = 1e17 (10%)
     // maxAuctionSize = 1e16 (1%)
-    // minAuctionSize = 1e15 (0.1%)
+    // minRecapitalizationAuctionSize = 1e15 (0.1%)
+    // minRevenueAuctionSize = 1e14 (0.01%)
     // migrationChunk = 2e17 (20%)
     // issuanceRate = 25e13 (0.025% per block, or ~0.1% per minute)
     // defaultThreshold = 5e16 (5% deviation)

--- a/contracts/proto0/interfaces/IVault.sol
+++ b/contracts/proto0/interfaces/IVault.sol
@@ -19,7 +19,7 @@ interface IVault {
 
     function pullBUs(address from, uint256 amount) external;
 
-    function claimAndSweepRewardsToManager(IMain main) external;
+    function claimAndSweepRewardsToManager() external;
 
     function basketFiatcoinRate() external view returns (uint256);
 

--- a/contracts/proto0/interfaces/IVault.sol
+++ b/contracts/proto0/interfaces/IVault.sol
@@ -21,7 +21,9 @@ interface IVault {
 
     function claimAndSweepRewardsToManager() external;
 
-    function basketFiatcoinRate() external view returns (uint256);
+    function updateCompoundAaveRates() external;
+
+    function basketRate() external view returns (uint256);
 
     function containsOnly(address[] memory assets) external view returns (bool);
 

--- a/contracts/proto0/libraries/Auction.sol
+++ b/contracts/proto0/libraries/Auction.sol
@@ -28,25 +28,9 @@ library Auction {
         bool open;
     }
 
-    function start(
-        Auction.Info storage self,
-        IAsset sellAsset,
-        IAsset buyAsset,
-        uint256 sellAmount,
-        uint256 minBuyAmount,
-        uint256 endTime,
-        Fate fate
-    ) internal {
-        self.sellAsset = sellAsset;
-        self.buyAsset = buyAsset;
-        self.sellAmount = sellAmount;
-        self.minBuyAmount = minBuyAmount;
-        self.startTime = block.timestamp;
-        self.endTime = endTime;
-        self.fate = fate;
-        self.open = true;
-
+    function launch(Auction.Info storage self) internal {
         // TODO: batchAuction.initiateAuction()
+        self.open = true;
     }
 
     // Returns the buyAmount for the auction after clearing.

--- a/contracts/proto0/libraries/Auction.sol
+++ b/contracts/proto0/libraries/Auction.sol
@@ -25,17 +25,17 @@ library Auction {
         uint256 startTime;
         uint256 endTime;
         Fate fate;
-        bool open;
+        bool isOpen;
     }
 
-    function launch(Auction.Info storage self) internal {
+    function open(Auction.Info storage self) internal {
         // TODO: batchAuction.initiateAuction()
-        self.open = true;
+        self.isOpen = true;
     }
 
     // Returns the buyAmount for the auction after clearing.
-    function process(Auction.Info storage self, IMain main) internal returns (uint256 buyAmount) {
-        require(self.open, "already closed out");
+    function close(Auction.Info storage self, IMain main) internal returns (uint256 buyAmount) {
+        require(self.isOpen, "already closed out");
         require(self.endTime <= block.timestamp, "auction not over");
         // TODO: buyAmount = batchAuction.claim();
         uint256 bal = self.buyAsset.erc20().balanceOf(address(this));
@@ -53,11 +53,11 @@ library Auction {
         } else {
             assert(false);
         }
-        self.open = false;
+        self.isOpen = false;
         return buyAmount;
     }
 
-    // Returns false if the auction buyAmount is > *threshold* of the expected buyAmount.
+    // Returns false if the auction buyAmount is > *auctionClearingTolerance* of the expected buyAmount.
     function clearedCloseToOraclePrice(
         Auction.Info storage self,
         IMain main,

--- a/test/proto0/DeployerP0.test.ts
+++ b/test/proto0/DeployerP0.test.ts
@@ -34,7 +34,8 @@ interface IManagerConfig {
   maxTradeSlippage: BigNumber
   auctionClearingTolerance: BigNumber
   maxAuctionSize: BigNumber
-  minAuctionSize: BigNumber
+  minRecapitalizationAuctionSize: BigNumber
+  minRevenueAuctionSize: BigNumber
   migrationChunk: BigNumber
   issuanceRate: BigNumber
   defaultThreshold: BigNumber
@@ -114,7 +115,8 @@ describe('DeployerP0 contract', () => {
   const maxTradeSlippage: BigNumber = bn(5e16) // 5%
   const auctionClearingTolerance: BigNumber = bn(5e16) // 5%
   const maxAuctionSize: BigNumber = bn(1e16) // 1%
-  const minAuctionSize: BigNumber = bn(1e15) // 0.1%
+  const minRecapitalizationAuctionSize: BigNumber = bn(1e15) // 0.1%
+  const minRevenueAuctionSize: BigNumber = bn(1e14) // 0.01%
   const migrationChunk: BigNumber = bn(2e17) // 20%
   const issuanceRate: BigNumber = bn(25e13) // 0.025% per block or ~0.1% per minute
   const defaultThreshold: BigNumber = bn(5e16) // 5% deviation
@@ -221,7 +223,8 @@ describe('DeployerP0 contract', () => {
       auctionClearingTolerance: auctionClearingTolerance,
       maxTradeSlippage: maxTradeSlippage,
       maxAuctionSize: maxAuctionSize,
-      minAuctionSize: minAuctionSize,
+      minRecapitalizationAuctionSize: minRecapitalizationAuctionSize,
+      minRevenueAuctionSize: minRevenueAuctionSize,
       migrationChunk: migrationChunk,
       issuanceRate: issuanceRate,
       defaultThreshold: defaultThreshold,


### PR DESCRIPTION
- This PR reduces the amount of auction-specific logic to a minimum, making use of one-size-fits-all helper functions to prepare auctions.
- This approach enables a more robust approach to revenue auctions. Previously we were counting on being able to forget about the revenue tokens after launching our revenue auction. This wouldn't work well in situations where the revenue auction fails to clear, though. 