### PR TITLE
set pauser for Main

### DIFF
--- a/contracts/proto0/DeployerP0.sol
+++ b/contracts/proto0/DeployerP0.sol
@@ -83,6 +83,7 @@ contract DeployerP0 is IDeployer {
             AssetManagerP0 manager = new AssetManagerP0(main, vault, owner, collateral);
             main.setManager(manager);
         }
+        main.setPauser(owner);
         main.transferOwnership(owner);
 
         emit RTokenCreated(address(main), address(main.rToken()), owner);

--- a/contracts/proto0/MainP0.sol
+++ b/contracts/proto0/MainP0.sol
@@ -67,6 +67,7 @@ contract MainP0 is IMain, Ownable {
         _oracle = oracle_;
         _config = config_;
         rsr = rsr_;
+        pauser = _msgSender();
     }
 
     /// This modifier runs before every function including redemption, so it should be very safe.


### PR DESCRIPTION
* Pauser is not being set for `Main` neither in the Deployer nor in the contract itself, requiring an additional step to setup.  This defaults the `pauser` to the `owner`.

**Disregard if the idea was to leave it blank and explicityl set it later.**