### PR TITLE
chore: handle compilation path by env

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,14 +10,20 @@ import './tasks'
 import dotenv from 'dotenv'
 dotenv.config()
 
+const PATHS: { [x: string]: string } = {
+  p0: './contracts/p0',
+  default: './contracts'
+}
+
 const MAINNET_RPC_URL = process.env.MAINNET_RPC_URL || process.env.ALCHEMY_MAINNET_RPC_URL || ''
 const ROPSTEN_RPC_URL = process.env.ROPSTEN_RPC_URL || ''
 const MNEMONIC = process.env.MNEMONIC || ''
 
+
 export default <HardhatUserConfig>{
   defaultNetwork: 'hardhat',
   networks: {
-    hardhat: {
+  hardhat: {
       // // To do Mainnet Forking, uncomment this section
       // forking: {
       //   url: MAINNET_RPC_URL
@@ -47,6 +53,9 @@ export default <HardhatUserConfig>{
         runs: 2000,
       },
     },
+  },
+  paths: {
+    sources: process.env.NODE_ENV_PROTO ? PATHS[process.env.NODE_ENV_PROTO] : PATHS.default
   },
   mocha: {
     timeout: 50000,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "devchain": "npx hardhat node",
         "test": "npx hardhat test",
         "test:generic": "npx hardhat test test/generic/*.test.ts",
-        "test:p0": "npx hardhat test test/p0/*.test.ts",
+        "test:p0": "NODE_ENV_PROTO=p0 npx hardhat test test/p0/*.test.ts",
         "test:parallel": "mocha --require hardhat/register --recursive --parallel --exit",
         "test:recompile": "npx hardhat compile --force && mocha --require hardhat/register --recursive --exit",
         "lint:sol": "npx solhint 'contracts/**/*.sol'",


### PR DESCRIPTION
## Description of changes
Hardhat allows the paths to be configured (https://hardhat.org/config/#path-configuration), sending the specific prototype using environment variables we can specify this path to be the specific prototype path.

These changes are a test, on which only contracts at `/contracts/p0` are compiled when running `npx test:proto0`