### PR TITLE
Upright generic tests

### DIFF
--- a/contracts/libraries/Fixed.sol
+++ b/contracts/libraries/Fixed.sol
@@ -175,6 +175,15 @@ library FixLib {
         return uint192(n) / FIX_SCALE_U;
     }
 
+        /// Convert this Fix to a uint with rounding.
+    function toRoundUint(Fix x) internal pure returns (uint192) {
+        int192 n = Fix.unwrap(x);
+        if (n < 0) {
+            revert IntOutOfBounds(n);
+        }
+        return uint192(round(x));
+    }
+
     /// Return the Fix shifted to the left by `decimal` digits
     /// Similar to a bitshift but in base 10
     /// Equivalent to multiplying `x` by `10**decimal`
@@ -182,7 +191,7 @@ library FixLib {
         int256 coeff = decimals >= 0 ? int256(10**uint8(decimals)) : int256(10**uint8(-decimals));
         return _safe_wrap(decimals >= 0 ? Fix.unwrap(x) * coeff : Fix.unwrap(x) / coeff);
     }
-
+ 
     /// Round this Fix to the nearest int. If equidistant to both
     /// adjacent ints, round up, away from zero.
     function round(Fix x) internal pure returns (int192) {

--- a/contracts/libraries/test/FixedCallerMock.sol
+++ b/contracts/libraries/test/FixedCallerMock.sol
@@ -38,6 +38,10 @@ contract FixedCallerMock {
         return FixLib.toUint(x);
     }
 
+    function toRoundUint(Fix x) public pure returns (uint192) {
+        return FixLib.toRoundUint(x);
+    }
+
     function shiftLeft(Fix x, int8 shiftLeft_) public pure returns (Fix) {
         return FixLib.shiftLeft(x, shiftLeft_);
     }

--- a/contracts/mocks/ATokenMock.sol
+++ b/contracts/mocks/ATokenMock.sol
@@ -86,6 +86,6 @@ contract StaticATokenMock is ERC20Mock {
     }
 
     function _toExchangeRate(Fix fiatcoinRedemptionRate) internal pure returns (uint256) {
-        return fiatcoinRedemptionRate.mulu(1e27).toUint();
+        return fiatcoinRedemptionRate.mulu(1e27).toRoundUint();
     }
 }

--- a/contracts/mocks/CTokenMock.sol
+++ b/contracts/mocks/CTokenMock.sol
@@ -46,6 +46,6 @@ contract CTokenMock is ERC20Mock {
         /// From Compound Docs: The current exchange rate, scaled by 10^(18 - 8 + Underlying Token Decimals).
         Fix start = toFixWithShift(2, -2); // 0.02
         int8 leftShift = 18 - int8(decimals()) + int8(IERC20Metadata(_underlyingAsset).decimals());
-        return fiatcoinRedemptionRate.shiftLeft(leftShift).mul(start).toUint();
+        return fiatcoinRedemptionRate.shiftLeft(leftShift).mul(start).toRoundUint();
     }
 }

--- a/contracts/mocks/MarketMock.sol
+++ b/contracts/mocks/MarketMock.sol
@@ -95,7 +95,7 @@ contract MarketMock is IMarket, ITrading {
             // The bid is at an acceptable price
             if (a.lte(b)) {
                 clearingSellAmount = Math.min(bid.sellAmount, auction.sellAmount);
-                clearingBuyAmount = b.mulu(clearingSellAmount).toUint();
+                clearingBuyAmount = b.mulu(clearingSellAmount).toRoundUint();
             }
         }
 

--- a/contracts/p0/BackingTrader.sol
+++ b/contracts/p0/BackingTrader.sol
@@ -158,8 +158,8 @@ contract BackingTraderP0 is TraderP0 {
         return (
             assets[surplusIndex],
             assets[deficitIndex],
-            sellAmount.toUint(),
-            buyAmount.toUint()
+            sellAmount.toRoundUint(),
+            buyAmount.toRoundUint()
         );
     }
 

--- a/contracts/p0/Furnace.sol
+++ b/contracts/p0/Furnace.sol
@@ -103,7 +103,11 @@ contract FurnaceP0 is Ownable, IFurnace {
             return batch.amount;
         } else {
             // batch.amount{RTok} * (timestamp - batch.start) / batch.duration
-            return toFix(timestamp - batch.start).divu(batch.duration).mulu(batch.amount).toUint();
+            return
+                toFix(timestamp - batch.start)
+                    .divu(batch.duration)
+                    .mulu(batch.amount)
+                    .toRoundUint();
         }
     }
 }

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -33,7 +33,7 @@ contract RTokenP0 is Ownable, ERC20, IRToken {
     /// @param amount {qTok} The amount to be burned
     /// @return true
     function burn(address from, uint256 amount) external virtual override returns (bool) {
-        require(_msgSender() == from, "only self");
+        require(_msgSender() == from || _msgSender() == address(main), "only self or main");
         _burn(from, amount);
         return true;
     }

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -132,7 +132,7 @@ contract StRSRP0 is IStRSR, Context {
                 Fix amtToAdd = toFix(_balances[_accounts.at(index)]).mulu(overage).divu(
                     _totalStaked
                 );
-                _balances[_accounts.at(index)] += amtToAdd.toUint();
+                _balances[_accounts.at(index)] += amtToAdd.toRoundUint();
             }
             _totalStaked += overage;
             emit RSRAdded(_msgSender(), overage);
@@ -151,7 +151,10 @@ contract StRSRP0 is IStRSR, Context {
         uint256 snapshotTotalStakedPlus = _totalStaked + _amountBeingWithdrawn();
 
         // _totalStaked -= (amount * _totalStaked) / snapshotTotalStakedPlus;
-        _totalStaked -= toFix(amount).mulu(_totalStaked).divu(snapshotTotalStakedPlus).toUint();
+        _totalStaked -= toFix(amount)
+        .mulu(_totalStaked)
+        .divu(snapshotTotalStakedPlus)
+        .toRoundUint();
 
         // Remove RSR for stakers and from withdrawals too
         if (snapshotTotalStakedPlus > 0) {
@@ -159,14 +162,14 @@ contract StRSRP0 is IStRSR, Context {
                 Fix amtToRemove = toFix(_balances[_accounts.at(index)]).mulu(amount).divu(
                     snapshotTotalStakedPlus
                 );
-                _balances[_accounts.at(index)] -= amtToRemove.toUint();
+                _balances[_accounts.at(index)] -= amtToRemove.toRoundUint();
             }
 
             for (uint256 index = withdrawalIndex; index < withdrawals.length; index++) {
                 Fix amtToRemove = toFix(withdrawals[index].amount).mulu(amount).divu(
                     snapshotTotalStakedPlus
                 );
-                withdrawals[index].amount -= amtToRemove.toUint();
+                withdrawals[index].amount -= amtToRemove.toRoundUint();
             }
         }
         // Transfer RSR to caller

--- a/contracts/p0/Vault.sol
+++ b/contracts/p0/Vault.sol
@@ -103,7 +103,7 @@ contract VaultP0 is IVault, Ownable {
             amounts[i] = toFix(amtBUs)
             .divu(1e18)
             .mulu(_basket.quantities[_basket.collateral[i]])
-            .toUint();
+            .toRoundUint();
         }
     }
 
@@ -150,7 +150,7 @@ contract VaultP0 is IVault, Ownable {
                 min = amtBUs;
             }
         }
-        return min.shiftLeft(int8(BU_DECIMALS)).toUint();
+        return min.shiftLeft(int8(BU_DECIMALS)).toRoundUint();
     }
 
     /// @return The collateral asset at `index`

--- a/contracts/p0/assets/RTokenAsset.sol
+++ b/contracts/p0/assets/RTokenAsset.sol
@@ -33,7 +33,7 @@ contract RTokenAssetP0 is IAsset {
         }
 
         // {attoUSD/qBU} = {attoUSD/BU} / {qBU/BU}
-        uint256 perQBU = sum.divu(10**v.BU_DECIMALS()).toUint();
+        uint256 perQBU = sum.divu(10**v.BU_DECIMALS()).toRoundUint();
 
         // {attoUSD/qRTok} = {attoUSD/qBU} * {qBU/qRTok}
         return toFix(main.fromBUs(perQBU));

--- a/contracts/p0/assets/collateral/Collateral.sol
+++ b/contracts/p0/assets/collateral/Collateral.sol
@@ -8,8 +8,6 @@ import "contracts/p0/interfaces/IMain.sol";
 import "contracts/p0/libraries/Oracle.sol";
 import "contracts/libraries/Fixed.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title CollateralP0
  * @notice A vanilla asset such as a fiatcoin, to be extended by more complex assets such as cTokens.

--- a/contracts/p0/main/Auctioneer.sol
+++ b/contracts/p0/main/Auctioneer.sol
@@ -61,7 +61,7 @@ contract AuctioneerP0 is
         // Backing Trader
         backingTrader.poke();
         if (!backingTrader.hasOpenAuctions() && !fullyCapitalized()) {
-            uint256 maxBUs = toBUs(migrationChunk().mulu(rToken().totalSupply()).toUint());
+            uint256 maxBUs = toBUs(migrationChunk().mulu(rToken().totalSupply()).toRoundUint());
             uint256 crackedBUs = _crackOldVaults(address(backingTrader), maxBUs);
             uint256 buShortfall = toBUs(rToken().totalSupply()) -
                 vault().basketUnits(address(this));

--- a/contracts/p0/main/DefaultHandler.sol
+++ b/contracts/p0/main/DefaultHandler.sol
@@ -103,7 +103,7 @@ contract DefaultHandlerP0 is
         }
         _depegged = defaulting;
 
-        if (defaulting.length == 0) {
+        if (count == 0) {
             _setMood(fullyCapitalized() ? Mood.CALM : Mood.TRADING);
         } else if (!_vaultIsOnlyApprovedCollateral(vault())) {
             _switchVault(_selectNextVault());

--- a/contracts/p0/main/RTokenIssuer.sol
+++ b/contracts/p0/main/RTokenIssuer.sol
@@ -147,7 +147,7 @@ contract RTokenIssuerP0 is
     function _nextIssuanceBlockAvailable(uint256 amount) private view returns (uint256) {
         uint256 perBlock = Math.max(
             10_000 * 10**rTokenAsset().decimals(), // lower-bound: 10k whole RToken per block
-            toFix(rTokenAsset().erc20().totalSupply()).mul(issuanceRate()).toUint()
+            toFix(rTokenAsset().erc20().totalSupply()).mul(issuanceRate()).toRoundUint()
         ); // {RToken/block}
         uint256 blockStart = issuances.length == 0
             ? block.number

--- a/contracts/p0/main/RevenueDistributor.sol
+++ b/contracts/p0/main/RevenueDistributor.sol
@@ -51,7 +51,7 @@ contract RevenueDistributorP0 is Ownable, Mixin, SettingsHandlerP0, IRevenueDist
             Fix subshare = erc20 == rsr()
                 ? _distribution[_destinations.at(i)].rsrDist
                 : _distribution[_destinations.at(i)].rTokenDist;
-            uint256 slice = subshare.mulu(amount).div(total).toUint();
+            uint256 slice = subshare.mulu(amount).div(total).toRoundUint();
 
             address addrTo = _destinations.at(i);
             if (addrTo == FURNACE) {

--- a/contracts/p0/main/RevenueHandler.sol
+++ b/contracts/p0/main/RevenueHandler.sol
@@ -96,7 +96,7 @@ contract RevenueHandlerP0 is
     function _splitRewardsToTraders(IAsset asset) private {
         uint256 bal = asset.erc20().balanceOf(address(this));
         if (bal > 0) {
-            uint256 amtToRSR = rsrCut().mulu(bal).toUint();
+            uint256 amtToRSR = rsrCut().mulu(bal).toRoundUint();
             asset.erc20().safeTransfer(address(rsrStakingTrader), amtToRSR); // cut
             asset.erc20().safeTransfer(address(rTokenMeltingTrader), bal - amtToRSR); // 1 - cut
         }

--- a/contracts/p0/main/VaultHandler.sol
+++ b/contracts/p0/main/VaultHandler.sol
@@ -87,7 +87,7 @@ contract VaultHandlerP0 is Ownable, Mixin, SettingsHandlerP0, RevenueDistributor
         }
 
         // (_meltingFactor() / _basketDilutionFactor()) * amtBUs
-        return _baseFactor().mulu(amount).toUint();
+        return _baseFactor().mulu(amount).toRoundUint();
     }
 
     /// {qBU} -> {qRTok}
@@ -98,7 +98,7 @@ contract VaultHandlerP0 is Ownable, Mixin, SettingsHandlerP0, RevenueDistributor
         }
 
         // (_basketDilutionFactor() / _meltingFactor()) * amount
-        return toFix(amtBUs).div(_baseFactor()).toUint();
+        return toFix(amtBUs).div(_baseFactor()).toRoundUint();
     }
 
     // ==== Internal ====

--- a/contracts/test/Lib.sol
+++ b/contracts/test/Lib.sol
@@ -170,7 +170,6 @@ library Lib {
             assertEq(a.symbol, symbol, "Symbol unexpected") &&
             assertEq(a.totalSupply, b.totalSupply, "TotalSupply mismatch") &&
             _assertBalancesEq(a.balances, b.balances, a.symbol) &&
-            _assertAllowancesEq(a.allowances, b.allowances, a.symbol) &&
             _assertOraclePriceEq(a.price, b.price, a.symbol);
     }
 
@@ -188,25 +187,26 @@ library Lib {
         }
     }
 
-    /// @return ok Whether two 2d allowance mappings are equivalent
-    function _assertAllowancesEq(
-        uint256[][] memory a,
-        uint256[][] memory b,
-        string memory /* symbol */
-    ) internal view returns (bool ok) {
-        string memory message;
-        ok = assertEq(a.length, b.length, "Allowances length mismatch");
-        for (uint256 i = 0; i < a.length; i++) {
-            message = string(abi.encodeWithSignature("Allowances array ", i, " length mismatch"));
-            ok = ok && assertEq(a[i].length, b[i].length, message);
-            for (uint256 j = 0; j < a[i].length; j++) {
-                message = string(
-                    abi.encodeWithSignature("Account ", i, ", spender ", j, " allowance mismatch")
-                );
-                ok = ok && assertEq(a[i][j], b[i][j], message);
-            }
-        }
-    }
+    /// // @return ok Whether two 2d allowance mappings are equivalent
+    // Not currently used
+    // function _assertAllowancesEq(
+    //     uint256[][] memory a,
+    //     uint256[][] memory b,
+    //     string memory /* symbol */
+    // ) internal view returns (bool ok) {
+    //     string memory message;
+    //     ok = assertEq(a.length, b.length, "Allowances length mismatch");
+    //     for (uint256 i = 0; i < a.length; i++) {
+    //         message = string(abi.encodeWithSignature("Allowances array ", i, " length mismatch"));
+    //         ok = ok && assertEq(a[i].length, b[i].length, message);
+    //         for (uint256 j = 0; j < a[i].length; j++) {
+    //             message = string(
+    //                 abi.encodeWithSignature("Account ", i, ", spender ", j, " allowance mismatch")
+    //             );
+    //             ok = ok && assertEq(a[i][j], b[i][j], message);
+    //         }
+    //     }
+    // }
 
     /// @return ok Whether two BU sets are equal
     function _assertBUEq(BU memory a, BU memory b) internal view returns (bool ok) {

--- a/contracts/test/ProtoState.sol
+++ b/contracts/test/ProtoState.sol
@@ -60,7 +60,6 @@ struct OraclePrice {
 struct TokenState {
     string name;
     string symbol;
-    uint256[][] allowances; // allowances[Account owner][Account spender] = uint256
     uint256[] balances; // balances[Account] = uint256
     uint256 totalSupply;
     //

--- a/contracts/test/README.md
+++ b/contracts/test/README.md
@@ -1,0 +1,6 @@
+# Generic Tests
+
+You may need to increase your javascript-allocated memory in order to run the generic tests successfully. To do this:
+```
+   export NODE_OPTIONS="--max-old-space-size=8192"
+```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -61,6 +61,6 @@ export default <HardhatUserConfig>{
     sources: src_dir,
   },
   mocha: {
-    timeout: 50000,
+    timeout: 300000,
   },
 }

--- a/test/generic/unit.test.ts
+++ b/test/generic/unit.test.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai'
 import { BigNumber, ContractFactory } from 'ethers'
 import { ethers } from 'hardhat'
 
-import { bn, fp } from '../../common/numbers'
 import { Mood } from '../../common/constants'
+import { bn, fp } from '../../common/numbers'
 import { ProtoAdapter } from '../../typechain/ProtoAdapter'
 import { ProtosDriver } from '../../typechain/ProtosDriver'
 import { IManagerConfig } from '../p0/utils/fixtures'
@@ -60,7 +60,6 @@ describe('Unit tests (Generic)', () => {
         migrationChunk: fp('0.2'), // 20%
         issuanceRate: fp('0.00025'), // 0.025% per block or ~0.1% per minute
         defaultThreshold: fp('0.05'), // 5% deviation
-        f: fp('0.60'), // 60% to stakers
       }
       const b1 = { assets: [Asset.cDAI, Asset.USDC], quantities: [bn('5e7'), bn('5e5')] }
       const b2 = { assets: [Asset.USDC], quantities: [bn('1e6')] }
@@ -74,8 +73,9 @@ describe('Unit tests (Generic)', () => {
       const rTokenBal: Balance[] = [[Account.EVE, bn('1e20')]]
       const stRSRBal: Balance[] = [[Account.EVE, bn('1e20')]]
       const defiRates: DefiRate[] = []
+      const rsrCut = fp('0.6')
 
-      initialState = prepareState(config, ethPrice, rTokenBal, stRSRBal, defiRates, baskets)
+      initialState = prepareState(rsrCut, config, ethPrice, rTokenBal, stRSRBal, defiRates, baskets)
       // console.log(initialState)
 
       const Driver = await ethers.getContractFactory('ProtosDriver')

--- a/test/libraries/Fixed.test.ts
+++ b/test/libraries/Fixed.test.ts
@@ -264,6 +264,9 @@ describe('In FixLib,', async () => {
       ]
       for (let [input, result] of table) {
         expect(await caller.round(fp(input)), `fp(${input})`).to.equal(result)
+        if (input > 0) {
+          expect(await caller.toRoundUint(fp(input)), `fp(${input})`).to.equal(result)
+        }
       }
     })
   })


### PR DESCRIPTION
- Fix P0 in a few small key ways in order to get full functionality back
- Get rid of allowances in generic testing
- Remove all staticCalls to speed up generic tests
- Add + test `toRoundUint()` function to FixLib and use. 
- Adjust MainExtension invariants
