### PR TITLE
adjust collaterals to use fiatcoins as reference

### DIFF
--- a/contracts/p0/interfaces/IAsset.sol
+++ b/contracts/p0/interfaces/IAsset.sol
@@ -47,7 +47,7 @@ interface ICollateral is IAsset {
     /// Disable the collateral so it cannot be used as backing
     function disable() external;
 
-    /// @return {attoRef/qTok} The price of the asset in a (potentially non-USD) reference asset
+    /// @return {qRef/qTok} The price of the asset in a (potentially non-USD) reference asset
     function referencePrice() external view returns (Fix);
 
     /// @return {basket quantity/tok} At basket selection time, how many of the reference token does

--- a/contracts/p0/interfaces/IMain.sol
+++ b/contracts/p0/interfaces/IMain.sol
@@ -212,7 +212,7 @@ interface IBasketHandler {
     // /// @param newBasket The address of the new vault
     // // event NewBasketSet(address indexed oldBasket, address indexed newBasket);
 
-    function setBasket(ICollateral[] calldata collateral, Fix[] calldata amounts) external;
+    function setBasket() external;
 
     function baseFactor() external view returns (Fix);
 
@@ -221,9 +221,6 @@ interface IBasketHandler {
     function worstCollateralStatus() external view returns (CollateralStatus status);
 
     function basketPrice() external view returns (Fix);
-
-    // This is only here for the Adapter (generic tests)
-    function basketReferenceAmounts() external view returns (Fix[] memory);
 }
 
 interface IAuctioneerEvents {

--- a/contracts/p0/interfaces/IMain.sol
+++ b/contracts/p0/interfaces/IMain.sol
@@ -26,7 +26,7 @@ struct Config {
     Fix minRevenueAuctionSize; // min size of a revenue auction / (RToken supply)
     Fix migrationChunk; // how much backing to migrate at a time / (RToken supply)
     Fix issuanceRate; // number of RToken to issue per block / (RToken supply)
-    Fix defaultThreshold; // {ref/tok} multiplier beyond which a token is marked as in-default
+    Fix defaultThreshold; // multiplier beyond which a token is marked as in-default
 
     // Sample values
     //
@@ -43,7 +43,7 @@ struct Config {
     // minRevenueAuctionSize = 0.0001 (0.01%)
     // migrationChunk = 0.2 (20%)
     // issuanceRate = 0.00025 (0.025% per block, or ~0.1% per minute)
-    // defaultThreshold = 0.05 (5% deviation)
+    // defaultThreshold = 0.05 (5% deviation, either above or below)
 }
 
 struct RevenueShare {

--- a/contracts/p0/libraries/Basket.sol
+++ b/contracts/p0/libraries/Basket.sol
@@ -7,11 +7,11 @@ import "contracts/p0/interfaces/IMain.sol";
 import "contracts/libraries/Fixed.sol";
 
 /// @param collateral Mapping from an incremental index to asset
-/// @param amounts {attoRef/BU}
+/// @param amounts {qRef/BU}
 /// @param size The number of collateral in the basket
 struct Basket {
     mapping(uint256 => ICollateral) collateral; // index -> asset
-    mapping(ICollateral => Fix) amounts; // {attoRef/BU}
+    mapping(ICollateral => Fix) amounts; // {qRef/BU}
     uint256 size;
 }
 
@@ -83,7 +83,7 @@ library BasketLib {
 
     /// @return {qTok/BU} The quantity of collateral asset targeted per BU
     function quantity(Basket storage self, ICollateral collateral) internal view returns (Fix) {
-        // {qTok/BU} = {attoRef/BU} / {attoRef/qTok}
+        // {qTok/BU} = {qRef/BU} / {qRef/qTok}
         return self.amounts[collateral].div(collateral.referencePrice());
     }
 

--- a/contracts/p0/libraries/Basket.sol
+++ b/contracts/p0/libraries/Basket.sol
@@ -7,11 +7,11 @@ import "contracts/p0/interfaces/IMain.sol";
 import "contracts/libraries/Fixed.sol";
 
 /// @param collateral Mapping from an incremental index to asset
-/// @param amounts {qRef/BU}
+/// @param refTargets {ref/BU}
 /// @param size The number of collateral in the basket
 struct Basket {
     mapping(uint256 => ICollateral) collateral; // index -> asset
-    mapping(ICollateral => Fix) amounts; // {qRef/BU}
+    mapping(ICollateral => Fix) refTargets; // {ref/BU}
     uint256 size;
 }
 
@@ -83,8 +83,11 @@ library BasketLib {
 
     /// @return {qTok/BU} The quantity of collateral asset targeted per BU
     function quantity(Basket storage self, ICollateral collateral) internal view returns (Fix) {
-        // {qTok/BU} = {qRef/BU} / {qRef/qTok}
-        return self.amounts[collateral].div(collateral.referencePrice());
+        // {qTok/BU} = {ref/BU} * {qRef/ref} / {qRef/qTok}
+        return
+            self.refTargets[collateral].shiftLeft(int8(collateral.erc20().decimals())).div(
+                collateral.referencePrice()
+            );
     }
 
     /// @return max {BU} The maximum number of basket units that `account` can create

--- a/contracts/p0/main/BasketHandler.sol
+++ b/contracts/p0/main/BasketHandler.sol
@@ -135,7 +135,7 @@ contract BasketHandlerP0 is
         return supply.eq(FIX_ZERO) ? FIX_ONE : supply.plus(melted).div(supply);
     }
 
-    /// @return amounts {attoRef/BU} The amounts of collateral required per BU
+    /// @return amounts {qRef/BU} The amounts of collateral required per BU
     function basketReferenceAmounts() external view override returns (Fix[] memory amounts) {
         amounts = new Fix[](_basket.size);
         for (uint256 i = 0; i < _basket.size; i++) {

--- a/contracts/p0/main/BasketHandler.sol
+++ b/contracts/p0/main/BasketHandler.sol
@@ -64,18 +64,8 @@ contract BasketHandlerP0 is
         _updateBasket();
     }
 
-    function setBasket(ICollateral[] calldata collateral, Fix[] calldata amounts)
-        public
-        override
-        onlyOwner
-    {
-        require(collateral.length == amounts.length, "must be same lengths");
-        for (uint256 i = 0; i < collateral.length; i++) {
-            _basket.collateral[i] = collateral[i];
-            _basket.amounts[collateral[i]] = amounts[i];
-        }
-        _basket.size = collateral.length;
-        _blockBasketLastUpdated = block.number;
+    function setBasket() public override onlyOwner {
+        // TODO
     }
 
     // Govern set of templates
@@ -133,14 +123,6 @@ contract BasketHandlerP0 is
         Fix supply = toFix(rToken().totalSupply()); // {qRTok}
         Fix melted = toFix(rToken().totalMelted()); // {qRTok}
         return supply.eq(FIX_ZERO) ? FIX_ONE : supply.plus(melted).div(supply);
-    }
-
-    /// @return amounts {qRef/BU} The amounts of collateral required per BU
-    function basketReferenceAmounts() external view override returns (Fix[] memory amounts) {
-        amounts = new Fix[](_basket.size);
-        for (uint256 i = 0; i < _basket.size; i++) {
-            amounts[i] = _basket.amounts[_basket.collateral[i]];
-        }
     }
 
     // ==== Internal ====
@@ -286,7 +268,7 @@ contract BasketHandlerP0 is
 
         // Clear the old basket
         for (uint256 i = 0; i < _basket.size; i++) {
-            _basket.amounts[_basket.collateral[i]] = FIX_ZERO;
+            _basket.refTargets[_basket.collateral[i]] = FIX_ZERO;
             delete _basket.collateral[i];
         }
 
@@ -339,7 +321,7 @@ contract BasketHandlerP0 is
                     Fix basketWeight = slotColl[collIdx].weight.mul(coll.roleCoefficient()).mul(
                         slotWeightFactor
                     );
-                    _basket.amounts[coll] = _basket.amounts[coll].plus(basketWeight);
+                    _basket.refTargets[coll] = _basket.refTargets[coll].plus(basketWeight);
                 }
             }
         }
@@ -350,9 +332,9 @@ contract BasketHandlerP0 is
         if (!totalTemplateWeight.eq(fulfilledTemplateWeight)) {
             Fix roleWeightFactor = totalTemplateWeight.div(fulfilledTemplateWeight);
             for (uint256 i = 0; i < basketSize; i++) {
-                _basket.amounts[_basket.collateral[i]] = _basket.amounts[_basket.collateral[i]].mul(
-                    roleWeightFactor
-                );
+                _basket.refTargets[_basket.collateral[i]] = _basket
+                .refTargets[_basket.collateral[i]]
+                .mul(roleWeightFactor);
             }
         }
 

--- a/contracts/p0/main/SettingsHandler.sol
+++ b/contracts/p0/main/SettingsHandler.sol
@@ -227,7 +227,7 @@ contract SettingsHandlerP0 is Ownable, Mixin, AssetRegistryP0, ISettingsHandler 
         return _market;
     }
 
-    // Useful view functions for reading portions of the state
+    // Useful view functions for reading refTargets of the state
     /// @return The RToken deployment
     function rToken() public view override returns (IRToken) {
         return IRToken(address(_rTokenAsset.erc20()));

--- a/contracts/test/Lib.sol
+++ b/contracts/test/Lib.sol
@@ -212,11 +212,11 @@ library Lib {
     function _assertBUEq(BU memory a, BU memory b) internal pure returns (bool ok) {
         ok =
             assertEq(a.assets.length, b.assets.length, "Tokens size mismatch") &&
-            assertEq(a.amounts.length, b.amounts.length, "Amounts size mismatch") &&
-            assertEq(a.assets.length, a.amounts.length, "invalid input");
+            assertEq(a.refTargets.length, b.refTargets.length, "Portions size mismatch") &&
+            assertEq(a.assets.length, a.refTargets.length, "invalid input");
 
-        for (uint256 i = 0; ok && i < a.amounts.length; i++) {
-            ok = assertEq(a.amounts[i], b.amounts[i], "BU quantities mismatch");
+        for (uint256 i = 0; ok && i < a.refTargets.length; i++) {
+            ok = assertEq(a.refTargets[i], b.refTargets[i], "BU quantities mismatch");
         }
     }
 

--- a/contracts/test/ProtoState.sol
+++ b/contracts/test/ProtoState.sol
@@ -48,7 +48,7 @@ struct RevenueDestination {
 /// Basket Unit, ie 1e18{qBU}
 struct BU {
     AssetName[] assets;
-    Fix[] amounts; // {attoRef/BU}
+    Fix[] amounts; // {qRef/BU}
 }
 
 struct Price {

--- a/contracts/test/ProtoState.sol
+++ b/contracts/test/ProtoState.sol
@@ -48,7 +48,7 @@ struct RevenueDestination {
 /// Basket Unit, ie 1e18{qBU}
 struct BU {
     AssetName[] assets;
-    Fix[] amounts; // {qRef/BU}
+    Fix[] refTargets; // {qRef/BU}
 }
 
 struct Price {

--- a/contracts/test/p0/Adapter.sol
+++ b/contracts/test/p0/Adapter.sol
@@ -498,7 +498,7 @@ contract AdapterP0 is ProtoAdapter {
                 bytes32(bytes(erc20.symbol())),
                 FIX_ONE,
                 toFixWithShift(2, -2),
-                underlying.erc20().decimals()
+                underlying.erc20()
             );
         } else if (erc20.symbol().toSlice().startsWith(a.toSlice())) {
             ICollateral underlying = ICollateral(
@@ -518,7 +518,8 @@ contract AdapterP0 is ProtoAdapter {
                 underlying.oracle(),
                 bytes32(bytes(erc20.symbol())),
                 FIX_ONE,
-                FIX_ONE
+                FIX_ONE,
+                underlying.erc20()
             );
         } else {
             _assets[collateralAsset] = new CollateralP0(

--- a/contracts/test/p0/Adapter.sol
+++ b/contracts/test/p0/Adapter.sol
@@ -293,12 +293,9 @@ contract AdapterP0 is ProtoAdapter {
 
         // Set basket + unpause
         {
-            ICollateral[] memory backing = new ICollateral[](s.bu_s[0].assets.length);
-            for (uint256 i = 0; i < s.bu_s[0].assets.length; i++) {
-                backing[i] = collateral[uint256(s.bu_s[0].assets[i])];
-            }
+            // TODO Basket Templating
 
-            _main.setBasket(backing, s.bu_s[0].amounts);
+            _main.setBasket();
             _main.unpause();
         }
     }
@@ -324,7 +321,7 @@ contract AdapterP0 is ProtoAdapter {
             backingCollateral[i] = _reverseAssets[ERC20Mock(backingTokens[i])];
         }
         s.distribution = _main.STATE_revenueDistribution();
-        s.rTokenDefinition = BU(backingCollateral, _main.basketReferenceAmounts());
+        s.rTokenDefinition = BU(backingCollateral, _main.basketRefTargets());
         s.rToken = _dumpERC20(_main.rToken());
         s.rsr = _dumpERC20(_main.rsr());
         s.stRSR = _dumpERC20(_main.stRSR());
@@ -595,7 +592,7 @@ contract AdapterP0 is ProtoAdapter {
         }
 
         bu_s = new BU[](1);
-        bu_s[0] = BU(assets, _main.basketReferenceAmounts());
+        bu_s[0] = BU(assets, _main.basketRefTargets());
     }
 
     /// Account index -> address

--- a/contracts/test/p0/MainExtension.sol
+++ b/contracts/test/p0/MainExtension.sol
@@ -38,6 +38,14 @@ contract MainExtension is ContextMixin, MainP0, IExtension {
         require(rTokenAsset().erc20().balanceOf(account) - start == amount, "issue failure");
     }
 
+    /// @return targets {ref/BU} The reference targets targeted per BU
+    function basketRefTargets() external view returns (Fix[] memory targets) {
+        targets = new Fix[](_basket.size);
+        for (uint256 i = 0; i < _basket.size; i++) {
+            targets[i] = _basket.refTargets[_basket.collateral[i]];
+        }
+    }
+
     function STATE_revenueDistribution()
         external
         view

--- a/test/p0/utils/fixtures.ts
+++ b/test/p0/utils/fixtures.ts
@@ -222,7 +222,7 @@ async function collateralFixture(
           ethers.utils.formatBytes32String(symbol),
           fp('1'),
           fp('1'),
-          underlyingDecimals
+          underlyingAddress
         )
       ),
     ]
@@ -243,7 +243,8 @@ async function collateralFixture(
           aaveOracle.address,
           ethers.utils.formatBytes32String(symbol),
           fp('1'),
-          fp('1')
+          fp('1'),
+          underlyingAddress
         )
       ),
     ]


### PR DESCRIPTION
- Change collateral to use the (maybe underlying) fiatcoin as the reference unit in all cases
- Do fiatcoin default detection in both the upwards and downwards directions