### PR TITLE
Trader closes auctions more efficiently.

### DIFF
--- a/contracts/p0/Trader.sol
+++ b/contracts/p0/Trader.sol
@@ -14,9 +14,17 @@ abstract contract TraderP0 is ITraderEvents {
     using FixLib for Fix;
     using SafeERC20 for IERC20Metadata;
 
+    // All auctions, OPEN and past.
+    // Invariant: if 0 <= i and i+1 < auctions.length,
+    //            then auctions[i].endTime <= auctions[i+1].endTime
     Auction[] public auctions;
 
-    uint256 private countOpenAuctions;
+    // First auction that is not yet closed (or auctions.length if all auctions have been closed)
+    // invariant: auction[i].status == CLOSED iff i <= auctionsStart
+    uint256 private auctionsStart;
+
+    // The latest end time for any auction in `auctions`.
+    uint256 private latestAuctionEnd;
 
     IMain public main;
 
@@ -26,18 +34,17 @@ abstract contract TraderP0 is ITraderEvents {
 
     /// @return true iff this trader now has open auctions.
     function hasOpenAuctions() public view returns (bool) {
-        return countOpenAuctions > 0;
+        return auctions.length > auctionsStart;
     }
 
     /// Settle any auctions that are due (past their end time)
     function closeDueAuctions() internal {
-        // Closeout open auctions or sleep if they are still ongoing.
-        for (uint256 i = 0; i < auctions.length; i++) {
-            Auction storage auction = auctions[i];
-            if (auction.status == AuctionStatus.OPEN && block.timestamp >= auction.endTime) {
-                closeAuction(i);
-            }
+        // Close open auctions
+        uint256 i = auctionsStart;
+        for (; i < auctions.length && block.timestamp >= auctions[i].endTime; i++) {
+            closeAuction(i);
         }
+        auctionsStart = i;
     }
 
     /// Prepare an auction to sell `sellAmount` that guarantees a reasonable closing price,
@@ -77,7 +84,7 @@ abstract contract TraderP0 is ITraderEvents {
                 clearingBuyAmount: 0,
                 externalAuctionId: 0,
                 startTime: block.timestamp,
-                endTime: block.timestamp + main.auctionPeriod(),
+                endTime: Math.max(block.timestamp + main.auctionPeriod(), latestAuctionEnd),
                 status: AuctionStatus.NOT_YET_OPEN
             })
         );
@@ -136,8 +143,8 @@ abstract contract TraderP0 is ITraderEvents {
         auction.externalAuctionId = main.market().initiateAuction(
             auction.sell.erc20(),
             auction.buy.erc20(),
-            block.timestamp + main.auctionPeriod(),
-            block.timestamp + main.auctionPeriod(),
+            auction.endTime,
+            auction.endTime,
             uint96(auction.sellAmount),
             uint96(auction.minBuyAmount),
             0,
@@ -147,7 +154,7 @@ abstract contract TraderP0 is ITraderEvents {
             new bytes(0)
         );
         auction.status = AuctionStatus.OPEN;
-        countOpenAuctions += 1;
+        latestAuctionEnd = auction.endTime;
 
         emit AuctionStarted(
             auctions.length - 1,
@@ -164,15 +171,13 @@ abstract contract TraderP0 is ITraderEvents {
     /// - Emit AuctionEnded event
     function closeAuction(uint256 i) private {
         Auction storage auction = auctions[i];
-        require(auction.status == AuctionStatus.OPEN, "can only close in-progress auctions");
-        require(auction.endTime <= block.timestamp, "auction not over");
+        assert(auction.status == AuctionStatus.OPEN);
+        assert(auction.endTime <= block.timestamp);
 
         bytes32 encodedOrder = main.market().settleAuction(auction.externalAuctionId);
         (auction.clearingSellAmount, auction.clearingBuyAmount) = decodeOrder(encodedOrder);
 
         auction.status = AuctionStatus.DONE;
-
-        countOpenAuctions -= 1;
 
         emit AuctionEnded(
             i,


### PR DESCRIPTION
That is: in order, and encountering at most 1 auction to leave open per call to
closeDueAuctions().

Does this by having the Trader ensure that new auctions close after old
auctions, even if auctionPeriod() has been reduced so that a new auction could
otherwise close before an old auction.

This PR already passes P0 tests, and is a pretty minor change, so it's ready to go
-- assuming we decide this is a fine approach.