### PR TITLE
Slither workarounds

### DIFF
--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -6,7 +6,7 @@ import "contracts/libraries/Fixed.sol";
 import "./IMain.sol";
 
 /// Raised if the oracle does not contain a price
-error PriceIsZero(string);
+error PriceIsZero();
 
 /**
  * @title IAsset

--- a/contracts/libraries/Fixed.sol
+++ b/contracts/libraries/Fixed.sol
@@ -17,9 +17,9 @@ pragma solidity ^0.8.9;
 */
 
 // An int value passed to this library was out of bounds for int192 operations
-error IntOutOfBounds(int256 value);
+error IntOutOfBounds();
 // A uint value passed to this library was out of bounds for int192 operations
-error UIntOutOfBounds(uint256 value);
+error UIntOutOfBounds();
 
 // If a particular int192 is represented by the int192 n, then the int192 represents the
 // value n/FIX_SCALE.
@@ -56,13 +56,13 @@ enum RoundingApproach {
 
 /// Explicitly convert an int256 to an int192. Revert if the input is out of bounds.
 function _safe_wrap(int256 x) pure returns (int192) {
-    if (x < type(int192).min || type(int192).max < x) revert IntOutOfBounds(x);
+    if (x < type(int192).min || type(int192).max < x) revert IntOutOfBounds();
     return int192(x);
 }
 
 /// Convert a uint to its int192 representation. Fails if x is outside int192's representable range.
 function toFix(uint256 x) pure returns (int192) {
-    if (uint192(FIX_MAX_INT) < x) revert UIntOutOfBounds(x);
+    if (uint192(FIX_MAX_INT) < x) revert UIntOutOfBounds();
     return int192(uint192(x)) * FIX_SCALE;
 }
 
@@ -70,14 +70,14 @@ function toFix(uint256 x) pure returns (int192) {
 /// Fails if the shifted value is outside int192's representable range.
 function toFixWithShift(uint256 x, int8 shiftLeft) pure returns (int192) {
     if (x == 0 || shiftLeft < -95) return 0; // shift would clear a uint256; 0 -> 0
-    if (59 < shiftLeft) revert IntOutOfBounds(shiftLeft); // would unconditionally overflow x
+    if (59 < shiftLeft) revert IntOutOfBounds(); // would unconditionally overflow x
 
     shiftLeft += 18;
     uint256 shifted = (shiftLeft >= 0)
         ? x * 10**uint256(uint8(shiftLeft))
         : x / 10**(uint256(uint8(-shiftLeft)));
 
-    if (uint192(type(int192).max) < shifted) revert UIntOutOfBounds(shifted);
+    if (uint192(type(int192).max) < shifted) revert UIntOutOfBounds();
     return int192(uint192(shifted));
 }
 
@@ -168,14 +168,14 @@ library FixLib {
     /// Convert this int192 to a uint. Fail if x is negative. Round the fractional part towards zero.
     function floor(int192 x) internal pure returns (uint192) {
         int192 n = x;
-        if (n < 0) revert IntOutOfBounds(n);
+        if (n < 0) revert IntOutOfBounds();
         return uint192(n) / FIX_SCALE_U;
     }
 
     /// Convert this int192 to a uint with standard rounding to the nearest integer.
     function round(int192 x) internal pure returns (uint192) {
         int192 n = x;
-        if (n < 0) revert IntOutOfBounds(n);
+        if (n < 0) revert IntOutOfBounds();
         return uint192(intRound(x));
     }
 
@@ -215,8 +215,7 @@ library FixLib {
         int256 x_ = x;
         int256 adjustment = x_ >= 0 ? FIX_SCALE / 2 : -FIX_SCALE / 2;
         int256 rounded = (x_ + adjustment) / FIX_SCALE;
-        if (rounded < type(int192).min || type(int192).max < rounded)
-            revert IntOutOfBounds(rounded);
+        if (rounded < type(int192).min || type(int192).max < rounded) revert IntOutOfBounds();
         return int192(rounded);
     }
 
@@ -227,7 +226,7 @@ library FixLib {
 
     /// Add a uint to this int192.
     function plusu(int192 x, uint256 y) internal pure returns (int192) {
-        if (y > type(uint256).max / 2) revert UIntOutOfBounds(y);
+        if (y > type(uint256).max / 2) revert UIntOutOfBounds();
         int256 y_ = int256(y);
         return _safe_wrap(x + y_ * FIX_SCALE);
     }
@@ -239,7 +238,7 @@ library FixLib {
 
     /// Subtract a uint from this int192.
     function minusu(int192 x, uint256 y) internal pure returns (int192) {
-        if (y > type(uint256).max / 2) revert UIntOutOfBounds(y);
+        if (y > type(uint256).max / 2) revert UIntOutOfBounds();
 
         return _safe_wrap(int256(x) - int256(y * FIX_SCALE_U));
     }
@@ -254,7 +253,7 @@ library FixLib {
 
     /// Multiply this int192 by a uint.
     function mulu(int192 x, uint256 y) internal pure returns (int192) {
-        if (y > type(uint256).max / 2) revert UIntOutOfBounds(y);
+        if (y > type(uint256).max / 2) revert UIntOutOfBounds();
         return _safe_wrap(x * int256(y));
     }
 

--- a/contracts/libraries/test/FixedCallerMock.sol
+++ b/contracts/libraries/test/FixedCallerMock.sol
@@ -1,33 +1,32 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity ^0.8.9;
 
-import "../Fixed.sol" as FixGlobals;
-import { FixLib, RoundingApproach } from "../Fixed.sol";
+import { FixLib, RoundingApproach, toFix, toFixWithShift, intToFix, divFix, fixMin, fixMax } from "../Fixed.sol";
 
 // Simple mock for Fixed library.
 contract FixedCallerMock {
-    function toFix(uint256 x) public pure returns (int192) {
-        return FixGlobals.toFix(x);
+    function toFix_(uint256 x) public pure returns (int192) {
+        return toFix(x);
     }
 
-    function toFixWithShift(uint256 x, int8 shiftLeft_) public pure returns (int192) {
-        return FixGlobals.toFixWithShift(x, shiftLeft_);
+    function toFixWithShift_(uint256 x, int8 shiftLeft_) public pure returns (int192) {
+        return toFixWithShift(x, shiftLeft_);
     }
 
-    function intToFix(int256 x) public pure returns (int192) {
-        return FixGlobals.intToFix(x);
+    function intToFix_(int256 x) public pure returns (int192) {
+        return intToFix(x);
     }
 
-    function divFix(uint256 x, int192 y) public pure returns (int192) {
-        return FixGlobals.divFix(x, y);
+    function divFix_(uint256 x, int192 y) public pure returns (int192) {
+        return divFix(x, y);
     }
 
-    function fixMin(int192 x, int192 y) public pure returns (int192) {
-        return FixGlobals.fixMin(x, y);
+    function fixMin_(int192 x, int192 y) public pure returns (int192) {
+        return fixMin(x, y);
     }
 
-    function fixMax(int192 x, int192 y) public pure returns (int192) {
-        return FixGlobals.fixMax(x, y);
+    function fixMax_(int192 x, int192 y) public pure returns (int192) {
+        return fixMax(x, y);
     }
 
     function toInt(int192 x) public pure returns (int192) {

--- a/contracts/plugins/assets/abstract/AaveOracleMixin.sol
+++ b/contracts/plugins/assets/abstract/AaveOracleMixin.sol
@@ -44,7 +44,7 @@ abstract contract AaveOracleMixin is CompoundOracleMixin {
         uint256 p = aaveOracle.getAssetPrice(address(erc20_));
 
         if (p == 0) {
-            revert PriceIsZero(erc20_.symbol());
+            revert PriceIsZero();
         }
 
         int192 inETH = toFix(p); // {qETH/tok}

--- a/contracts/plugins/assets/abstract/CompoundOracleMixin.sol
+++ b/contracts/plugins/assets/abstract/CompoundOracleMixin.sol
@@ -35,7 +35,7 @@ abstract contract CompoundOracleMixin {
 
         uint256 p = comptroller.oracle().price(erc20.symbol());
         if (p == 0) {
-            revert PriceIsZero(erc20.symbol());
+            revert PriceIsZero();
         }
 
         // {UoA/tok} = {microUoA/tok} / {microUoA/UoA}

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -57,17 +57,16 @@ solc-select use 0.8.9
 
 ### Slither
 
-NOTE: Right now, slither chokes on our code. We're hoping they update to working over solidity 0.8.9 sometime soon; until then, I guess we're just not using this. D:
-
-Slither depends on `solc-select`. Once it's set up, install slither with:
+Slither depends on `solc-select`. Once that's set up, we need to get slither _from its latest github repository_, as we're using language features that aren't supported in its most recent pacakaging release. The easiest way I've found to ensure this works right is to first uninstall any previous versions. You can do all of this as follows:
 
 ```bash
-pip3 install slither-analyzer
+pip uninstall slither-analyzer --yes
+pip3 install -U https://github.com/crytic/slither/archive/refs/heads/master.zip
 ```
 
 ### Echidna
 
-Echidna depends on both `solc-select` and `slither`. To handle recent Solidity language changes, we'll need Echidna 2.0, which is still in beta. Unless you have a Haskell toolchain all set up, you should install Echidna through precompiled binaries.
+Echidna depends on both `solc-select` and `slither`. To handle recent Solidity language changes, we'll need Echidna 2.0. Unless you have a Haskell toolchain all set up, you should install Echidna through precompiled binaries.
 
 Until Echidna 2.0 is fully released, you can get precompiled binaries from that repo's [latest binary build](https://github.com/crytic/echidna/actions/runs/1119937162).
 

--- a/test/libraries/Fixed.test.ts
+++ b/test/libraries/Fixed.test.ts
@@ -57,11 +57,11 @@ describe('In FixLib,', async () => {
 
   describe('intToFix', async () => {
     it('correctly converts int values', async () => {
-      fixable_ints.forEach(async (x) => expect(await caller.intToFix(x), `${x}`).to.equal(fp(x)))
+      fixable_ints.forEach(async (x) => expect(await caller.intToFix_(x), `${x}`).to.equal(fp(x)))
     })
     it('fails on values outside its domain', async () => {
       ;[MAX_FIX_INT.add(1), MIN_FIX_INT.sub(1), MAX_FIX_INT.mul(25)].forEach(
-        async (x) => await expect(caller.intToFix(x)).to.be.revertedWith('IntOutOfBounds')
+        async (x) => await expect(caller.intToFix_(x)).to.be.revertedWith('IntOutOfBounds')
       )
     })
   })
@@ -70,12 +70,12 @@ describe('In FixLib,', async () => {
     it('correctly converts uint values', async () => {
       ;[0, 1, 2, '38326665875765560393', MAX_FIX_INT.sub(1), MAX_FIX_INT]
         .map(bn)
-        .forEach(async (x) => expect(await caller.toFix(x), `${x}`).to.equal(fp(x)))
+        .forEach(async (x) => expect(await caller.toFix_(x), `${x}`).to.equal(fp(x)))
     })
 
     it('fails on inputs outside its domain', async () => {
-      await expect(caller.toFix(MAX_FIX_INT.add(1))).to.be.revertedWith('UIntOutOfBounds')
-      await expect(caller.toFix(MAX_FIX_INT.mul(17))).to.be.revertedWith('UIntOutOfBounds')
+      await expect(caller.toFix_(MAX_FIX_INT.add(1))).to.be.revertedWith('UIntOutOfBounds')
+      await expect(caller.toFix_(MAX_FIX_INT.mul(17))).to.be.revertedWith('UIntOutOfBounds')
     })
   })
 
@@ -83,7 +83,9 @@ describe('In FixLib,', async () => {
     it('correctly converts uint values with no shifting', async () => {
       ;[0, 1, 2, '38326665875765560393', MAX_FIX_INT.sub(1), MAX_FIX_INT]
         .map(bn)
-        .forEach(async (x) => expect(await caller.toFixWithShift(x, bn(0)), `${x}`).to.equal(fp(x)))
+        .forEach(async (x) =>
+          expect(await caller.toFixWithShift_(x, bn(0)), `${x}`).to.equal(fp(x))
+        )
     })
 
     it('correctly converts uint values with some shifting', async () => {
@@ -103,7 +105,7 @@ describe('In FixLib,', async () => {
       ]
         .map(([x, s]) => [bn(x), bn(s)])
         .forEach(async ([x, s]) =>
-          expect(await caller.toFixWithShift(x, s), `toFixWithShift(${x}, ${s})`).to.equal(
+          expect(await caller.toFixWithShift_(x, s), `toFixWithShift(${x}, ${s})`).to.equal(
             s.gte(0) ? fp(x).mul(pow10(s)) : fp(x).div(pow10(neg(s)))
           )
         )
@@ -123,7 +125,7 @@ describe('In FixLib,', async () => {
         [bn('-5e56'), 2],
       ].forEach(
         async ([x, s]) =>
-          await expect(caller.toFixWithShift(x, s), `toFix(${x}, ${s})`).to.be.reverted
+          await expect(caller.toFixWithShift_(x, s), `toFix(${x}, ${s})`).to.be.reverted
       )
     })
   })
@@ -135,7 +137,7 @@ describe('In FixLib,', async () => {
         .flatMap(([x, y, z]) => [[x, y, z], [x, -y, -z], [x, z, y], [x, -z, -y],])
         .concat([[0, 1, 0], [0, -1, 0],])
         .forEach(async ([x, y, result]) =>
-          expect(await caller.divFix(x, fp(y)), `divFix(${x}, ${y}) == ${result}`).to.equal(fp(result))
+          expect(await caller.divFix_(x, fp(y)), `divFix(${x}, ${y}) == ${result}`).to.equal(fp(result))
         )
     })
 
@@ -153,18 +155,18 @@ describe('In FixLib,', async () => {
         [bn('8e60'), fp('-2e30'), fp('-4e30')],
         [bn('5e75'), fp('-2.5e39'), fp('-2e36')],
       ].forEach(async ([x, y, result]) =>
-        expect(await caller.divFix(x, y), `divFix(${x}, ${y}) == ${result}`).to.equal(result)
+        expect(await caller.divFix_(x, y), `divFix(${x}, ${y}) == ${result}`).to.equal(result)
       )
     })
 
     it('fails when results fall outside its range', async () => {
-      await expect(caller.divFix(MAX_INT192.add(1), fp(1))).to.be.reverted
-      await expect(caller.divFix(MAX_INT192.div(5), fp('0.199'))).to.be.reverted
+      await expect(caller.divFix_(MAX_INT192.add(1), fp(1))).to.be.reverted
+      await expect(caller.divFix_(MAX_INT192.div(5), fp('0.199'))).to.be.reverted
     })
     it('fails on division by zero', async () => {
-      await expect(caller.divFix(17, fp(0))).to.be.revertedWith('panic code 0x12')
-      await expect(caller.divFix(0, fp(0))).to.be.revertedWith('panic code 0x12')
-      await expect(caller.divFix(MAX_INT192, fp(0))).to.be.revertedWith('panic code 0x12')
+      await expect(caller.divFix_(17, fp(0))).to.be.revertedWith('panic code 0x12')
+      await expect(caller.divFix_(0, fp(0))).to.be.revertedWith('panic code 0x12')
+      await expect(caller.divFix_(MAX_INT192, fp(0))).to.be.revertedWith('panic code 0x12')
     })
   })
 
@@ -215,12 +217,12 @@ describe('In FixLib,', async () => {
       ]
         .map(([x, s]) => [bn(x), bn(s)])
         .forEach(async ([x, s]) => {
-          const xFix = await caller.toFix(x)
+          const xFix = await caller.toFix_(x)
           const a = await caller.shiftLeft(xFix, s)
-          const b = await caller.toFixWithShift(x, s)
+          const b = await caller.toFixWithShift_(x, s)
 
           await expect(await caller.shiftLeft(xFix, s), `toFix(${x}).shiftLeft(${s})`).to.equal(
-            await caller.toFixWithShift(x, s)
+            await caller.toFixWithShift_(x, s)
           )
         })
     })
@@ -908,7 +910,7 @@ describe('In FixLib,', async () => {
     it('correctly evaluates min', async () => {
       int192s.forEach(async (a) =>
         int192s.forEach(async (b) =>
-          expect(await caller.fixMin(a, b), `fixMin(${a}, ${b})`).to.equal(a.lt(b) ? a : b)
+          expect(await caller.fixMin_(a, b), `fixMin(${a}, ${b})`).to.equal(a.lt(b) ? a : b)
         )
       )
     })
@@ -917,7 +919,7 @@ describe('In FixLib,', async () => {
     it('correctly evaluates max', async () => {
       int192s.forEach(async (a) =>
         int192s.forEach(async (b) =>
-          expect(await caller.fixMax(a, b), `fixMax(${a}, ${b})`).to.equal(a.gt(b) ? a : b)
+          expect(await caller.fixMax_(a, b), `fixMax(${a}, ${b})`).to.equal(a.gt(b) ? a : b)
         )
       )
     })

--- a/test/plugins/Asset.test.ts
+++ b/test/plugins/Asset.test.ts
@@ -180,15 +180,15 @@ describe('AssetsP0 contracts', () => {
       // Check new prices
       // RSR
       let symbol: string = await rsr.symbol()
-      await expect(rsrAsset.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(rsrAsset.price()).to.be.revertedWith(`PriceIsZero()`)
 
       // COMP
       symbol = await compToken.symbol()
-      await expect(compAsset.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(compAsset.price()).to.be.revertedWith(`PriceIsZero()`)
 
       // AAVE
       symbol = await aaveToken.symbol()
-      await expect(aaveAsset.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(aaveAsset.price()).to.be.revertedWith(`PriceIsZero()`)
     })
   })
 })

--- a/test/plugins/CollateralP0.test.ts
+++ b/test/plugins/CollateralP0.test.ts
@@ -271,7 +271,7 @@ describe('Collateral contracts', () => {
       await aaveOracleInternal.setPrice(token.address, bn('0'))
 
       // Check price of token
-      await expect(tokenCollateral.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(tokenCollateral.price()).to.be.revertedWith(`PriceIsZero()`)
     })
   })
 
@@ -574,12 +574,12 @@ describe('Collateral contracts', () => {
       // Fiat token
       symbol = await token.symbol()
       await compoundOracleInternal.setPrice(symbol, bn(0))
-      await expect(compoundTokenAsset.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(compoundTokenAsset.price()).to.be.revertedWith(`PriceIsZero()`)
 
       // Usdc (6 decimals)
       symbol = await usdc.symbol()
       await compoundOracleInternal.setPrice(symbol, bn(0))
-      await expect(compoundUsdcAsset.price()).to.be.revertedWith(`PriceIsZero("${symbol}")`)
+      await expect(compoundUsdcAsset.price()).to.be.revertedWith(`PriceIsZero()`)
     })
   })
 })


### PR DESCRIPTION
In order to get slither to run on this code, this PR:

- Removes parameters from errors
- Avoids `import "../Fixed.sol" as FixGlobals;` which imports one file's top-level namespace into a named namespace of another