### PR TITLE
Ensure strong basket invariant of no defaulted or unregistered collateral

### DIFF
--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -9,11 +9,9 @@ import "./IComponent.sol";
 /**
  * @title IBasketHandler
  * @notice The BasketHandler aims to maintain a reference basket of constant target unit amounts.
- *   When a collateral token defaults, it automatically swaps the bad collateral for backup collateral.
- *   When _all_ collateral tokens default for a target unit, only then is the value of the basket
- *   allowed to change in terms of target unit amounts.
- *
- * View functions should ignore bad collateral.
+ * When a collateral token defaults, a new reference basket of equal target units is set.
+ * When _all_ collateral tokens default for a target unit, only then is the basket allowed to fall
+ *   in terms of target unit amounts. The basket is considered defaulted in this case.
  */
 interface IBasketHandler is IComponent {
     /// Emitted when the prime basket is set
@@ -25,7 +23,8 @@ interface IBasketHandler is IComponent {
     /// Emitted when the reference basket is set
     /// @param erc20s The list of collateral tokens in the reference basket
     /// @param refAmts {ref/BU} The reference amounts of the basket collateral tokens
-    event BasketSet(IERC20[] erc20s, int192[] refAmts);
+    /// @param defaulted True when there is no more backup collateral for a target
+    event BasketSet(IERC20[] erc20s, int192[] refAmts, bool defaulted);
 
     /// Emitted when a backup config is set for a target unit
     /// @param targetName The name of the target unit as a bytes32
@@ -78,11 +77,9 @@ interface IBasketHandler is IComponent {
         returns (address[] memory erc20s, uint256[] memory quantities);
 
     /// @return baskets {BU} The quantity of complete baskets at an address. A balance for BUs
-    /// Excludes defaulted/unregistered collateral
     function basketsHeldBy(address account) external view returns (int192 baskets);
 
     /// @return p {UoA/BU} The protocol's best guess at what a BU would be priced at in UoA
-    /// Excludes defaulted/unregistered collateral
     function price() external view returns (int192 p);
 
     /// @return nonce The basket nonce, a monotonically increasing unique identifier

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -8,8 +8,12 @@ import "./IComponent.sol";
 
 /**
  * @title IBasketHandler
- * @notice The BasketHandler maintains a notion of the reference basket that it evolves
- *   over time according to the rules described by the prime basket and backup configurations.
+ * @notice The BasketHandler aims to maintain a reference basket of constant target unit amounts.
+ *   When a collateral token defaults, it automatically swaps the bad collateral for backup collateral.
+ *   When _all_ collateral tokens default for a target unit, only then is the value of the basket
+ *   allowed to change in terms of target unit amounts.
+ *
+ * View functions should ignore bad collateral.
  */
 interface IBasketHandler is IComponent {
     /// Emitted when the prime basket is set
@@ -74,9 +78,11 @@ interface IBasketHandler is IComponent {
         returns (address[] memory erc20s, uint256[] memory quantities);
 
     /// @return baskets {BU} The quantity of complete baskets at an address. A balance for BUs
+    /// Excludes defaulted/unregistered collateral
     function basketsHeldBy(address account) external view returns (int192 baskets);
 
     /// @return p {UoA/BU} The protocol's best guess at what a BU would be priced at in UoA
+    /// Excludes defaulted/unregistered collateral
     function price() external view returns (int192 p);
 
     /// @return nonce The basket nonce, a monotonically increasing unique identifier

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -113,9 +113,6 @@ interface IRToken is IRewardable, IERC20Metadata, IERC20Permit {
     /// @return {BU} How many baskets are being targeted
     function basketsNeeded() external view returns (int192);
 
-    /// @return {qRTok} How much RToken `account` can issue given their current holdings
-    function maxIssuable(address account) external view returns (uint256);
-
     /// @return p {UoA/rTok} The price of 1 whole RToken in the unit of account
     function price() external view returns (int192 p);
 }

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -43,6 +43,9 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
         // Call keepers before
         main.poke();
 
+        // Do not trade when DISABLED or IFFY
+        if (main.basketHandler().status() != CollateralStatus.SOUND) return;
+
         (, uint256 basketTimestamp) = main.basketHandler().lastSet();
         if (block.timestamp < basketTimestamp + tradingDelay) return;
 
@@ -78,6 +81,8 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
 
     /// Send excess assets to the RSR and RToken traders
     function handoutExcessAssets() private {
+        assert(main.basketHandler().status() == CollateralStatus.SOUND);
+
         // Special-case RSR to forward to StRSR pool
         uint256 rsrBal = main.rsr().balanceOf(address(this));
         if (rsrBal > 0) {

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -26,9 +26,9 @@ struct BasketConfig {
     mapping(bytes32 => BackupConfig) backups;
 }
 
-/// A specific definition of a BU that evolves over time according to the BasketConfig
+/// A reference basket specific definition of a BU that evolves over time according to the BasketConfig
 struct Basket {
-    // Invariant: all reference basket collateral must be registered with the registry
+    // Invariant: no defaulted or unregistered collateral
     IERC20[] erc20s;
     mapping(IERC20 => int192) refAmts; // {ref/BU}
     uint256 nonce;

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -26,13 +26,15 @@ struct BasketConfig {
     mapping(bytes32 => BackupConfig) backups;
 }
 
-/// A reference basket specific definition of a BU that evolves over time according to the BasketConfig
+/// A reference basket that provides a dynamic definition of a basket unit (BU)
+/// Can be empty if all collateral defaults
 struct Basket {
-    // Invariant: no defaulted or unregistered collateral
-    IERC20[] erc20s;
+    IERC20[] erc20s; // Invariant: no defaulted or unregistered collateral
     mapping(IERC20 => int192) refAmts; // {ref/BU}
     uint256 nonce;
     uint256 timestamp;
+    bool defaulted;
+    // Invariant: defaulted XOR targetAmts == refAmts.map(amt => amt * coll.targetPerRef()
 }
 
 /*
@@ -50,6 +52,7 @@ library BasketLib {
         delete self.erc20s;
         self.nonce++;
         self.timestamp = block.timestamp;
+        self.defaulted = false;
     }
 
     /// Set `self` equal to `other`
@@ -61,6 +64,7 @@ library BasketLib {
         }
         self.nonce++;
         self.timestamp = block.timestamp;
+        self.defaulted = other.defaulted;
     }
 
     /// Add `weight` to the refAmount of collateral token `tok` in the basket `self`
@@ -94,6 +98,7 @@ contract BasketHandlerP0 is Component, IBasketHandler {
     Basket private basket;
 
     /// Try to ensure the current basket is valid, switching it if necessary
+    /// If there are no available collateral tokens, the basket becomes empty and defaulted
     function ensureBasket() external notPaused {
         main.assetRegistry().forceUpdates();
 
@@ -125,7 +130,7 @@ contract BasketHandlerP0 is Component, IBasketHandler {
         emit PrimeBasketSet(erc20s, targetAmts, names);
     }
 
-    /// Set the backup configuration for some target name.
+    /// Set the backup configuration for some target name
     function setBackupConfig(
         bytes32 targetName,
         uint256 max,
@@ -165,22 +170,19 @@ contract BasketHandlerP0 is Component, IBasketHandler {
 
     /// @return status_ The maximum CollateralStatus among basket collateral
     function status() public view returns (CollateralStatus status_) {
-        IAssetRegistry reg = main.assetRegistry();
+        if (basket.defaulted) return CollateralStatus.DISABLED;
 
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
-            IERC20 erc20 = basket.erc20s[i];
-            CollateralStatus statusI;
-            if (!reg.isRegistered(erc20) || !reg.toAsset(erc20).isCollateral()) {
-                return CollateralStatus.DISABLED;
-            } else statusI = reg.toColl(erc20).status();
+            if (!goodCollateral(basket.erc20s[i])) return CollateralStatus.DISABLED;
 
-            if (uint256(statusI) > uint256(status_)) {
-                status_ = statusI;
+            CollateralStatus s = main.assetRegistry().toColl(basket.erc20s[i]).status();
+            if (uint256(s) > uint256(status_)) {
+                status_ = s;
             }
         }
     }
 
-    /// @return {tok/BU} The quantity of collateral in the basket
+    /// @return {tok/BU} The quantity of an ERC20 token in the basket; 0 if not in the basket
     function quantity(IERC20 erc20) public view returns (int192) {
         IAssetRegistry reg = main.assetRegistry();
         if (!reg.isRegistered(erc20) || !reg.toAsset(erc20).isCollateral()) return FIX_ZERO;
@@ -191,18 +193,11 @@ contract BasketHandlerP0 is Component, IBasketHandler {
 
     /// @return p {UoA/BU} The protocol's best guess at what a BU would be priced at in UoA
     function price() public view returns (int192 p) {
-        IAssetRegistry reg = main.assetRegistry();
-
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
-            IERC20 erc20 = basket.erc20s[i];
+            if (!goodCollateral(basket.erc20s[i])) continue;
 
-            if (
-                reg.isRegistered(erc20) &&
-                reg.toAsset(erc20).isCollateral() &&
-                reg.toColl(erc20).status() != CollateralStatus.DISABLED
-            ) {
-                p = p.plus(reg.toColl(erc20).price().mul(quantity(erc20)));
-            }
+            IERC20 erc20 = basket.erc20s[i];
+            p = p.plus(main.assetRegistry().toColl(erc20).price().mul(quantity(erc20)));
         }
     }
 
@@ -227,13 +222,11 @@ contract BasketHandlerP0 is Component, IBasketHandler {
     }
 
     /// @return baskets {BU} The balance of basket units held by `account`
+    /// @dev Returns FIX_MAX for an empty basket
     function basketsHeldBy(address account) public view returns (int192 baskets) {
         baskets = FIX_MAX;
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
-            uint8 decimals = IERC20Metadata(address(basket.erc20s[i])).decimals();
-
-            // {tok}
-            int192 bal = toFix(basket.erc20s[i].balanceOf(account)).shiftLeft(-int8(decimals));
+            int192 bal = main.assetRegistry().toColl(basket.erc20s[i]).bal(account); // {tok}
             int192 q = quantity(basket.erc20s[i]); // {tok/BU}
 
             // baskets {BU} = bal {tok} / q {tok/BU}
@@ -284,11 +277,7 @@ contract BasketHandlerP0 is Component, IBasketHandler {
             int192 targetWeight = config.targetAmts[erc20];
             totalWeights[targetIndex] = totalWeights[targetIndex].plus(targetWeight);
 
-            if (
-                reg.isRegistered(erc20) &&
-                reg.toAsset(erc20).isCollateral() &&
-                reg.toColl(erc20).status() != CollateralStatus.DISABLED
-            ) {
+            if (goodCollateral(erc20) && targetWeight.gt(FIX_ZERO)) {
                 goodWeights[targetIndex] = goodWeights[targetIndex].plus(targetWeight);
                 newBasket.add(erc20, targetWeight.div(reg.toColl(erc20).targetPerRef()));
             }
@@ -304,37 +293,25 @@ contract BasketHandlerP0 is Component, IBasketHandler {
 
             // Find the backup basket size: min(backup.max, # of good backup collateral)
             for (uint256 j = 0; j < backup.erc20s.length && size < backup.max; j++) {
-                IERC20 erc20 = backup.erc20s[j];
-                if (
-                    reg.isRegistered(erc20) &&
-                    reg.toAsset(erc20).isCollateral() &&
-                    reg.toColl(erc20).status() != CollateralStatus.DISABLED
-                ) {
-                    size++;
-                }
+                if (goodCollateral(backup.erc20s[j])) size++;
             }
 
-            // If we need backup collateral, but there's no good backup collateral, it's a bad case!
-            // Do not set the basket; the protocol will stay issuance-paused until governance acts.
-            if (size == 0) return false;
+            // If we need backup collateral, but there's no good backup collateral, basket default!
+            // Remove bad collateral and mark basket defaulted; pauses most protocol functions
+            if (size == 0) newBasket.defaulted = true;
 
             // Set backup basket weights
             uint256 assigned = 0;
             int192 needed = totalWeights[i].minus(goodWeights[i]);
             for (uint256 j = 0; j < backup.erc20s.length && assigned < size; j++) {
                 IERC20 erc20 = backup.erc20s[j];
-                if (
-                    reg.isRegistered(erc20) &&
-                    reg.toAsset(erc20).isCollateral() &&
-                    reg.toColl(erc20).status() != CollateralStatus.DISABLED
-                ) {
+                if (goodCollateral(erc20)) {
                     newBasket.add(erc20, needed.divu(size).div(reg.toColl(erc20).targetPerRef()));
                     assigned++;
                 }
             }
         }
 
-        // If we haven't already given up, then commit the new basket!
         basket.copy(newBasket);
 
         // Keep records, emit event
@@ -342,8 +319,17 @@ contract BasketHandlerP0 is Component, IBasketHandler {
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
             refAmts[i] = basket.refAmts[basket.erc20s[i]];
         }
-        emit BasketSet(basket.erc20s, refAmts);
+        emit BasketSet(basket.erc20s, refAmts, basket.defaulted);
 
         return true;
+    }
+
+    /// Good collateral is both (i) registered, and (2) not CollateralStatus.DISABLED
+    function goodCollateral(IERC20 erc20) private view returns (bool) {
+        IAssetRegistry reg = main.assetRegistry();
+        return
+            reg.isRegistered(erc20) &&
+            reg.toAsset(erc20).isCollateral() &&
+            reg.toColl(erc20).status() != CollateralStatus.DISABLED;
     }
 }

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -246,18 +246,6 @@ contract RTokenP0 is Component, RewardableP0, ERC20Permit, IRToken {
         basketsNeeded = basketsNeeded_;
     }
 
-    /// @return {qRTok} How much RToken `account` can issue given current holdings
-    function maxIssuable(address account) external view returns (uint256) {
-        // {BU}
-        int192 held = main.basketHandler().basketsHeldBy(account);
-
-        // return {qRTok} = {BU} * {(1 RToken) qRTok/BU)}
-        if (basketsNeeded.eq(FIX_ZERO)) return held.shiftLeft(int8(decimals())).floor();
-
-        // {qRTok} = {BU} * {qRTok} / {BU}
-        return held.mulu(totalSupply()).div(basketsNeeded).floor();
-    }
-
     /// @return p {UoA/rTok} The protocol's best guess of the RToken price on markets
     function price() external view returns (int192 p) {
         if (totalSupply() == 0) return main.basketHandler().price();

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -291,18 +291,6 @@ contract RToken is RewardableP0, ERC20Permit, IRToken {
         basketsNeeded = basketsNeeded_;
     }
 
-    /// @return {qRTok} How much RToken `account` can issue given current holdings
-    function maxIssuable(address account) external view returns (uint256) {
-        // {BU}
-        int192 held = main.basketHandler().basketsHeldBy(account);
-
-        // return {qRTok} = {BU} * {(1 RToken) qRTok/BU)}
-        if (basketsNeeded.eq(FIX_ZERO)) return held.shiftLeft(int8(decimals())).floor();
-
-        // {qRTok} = {BU} * {qRTok} / {BU}
-        return held.mulu(totalSupply()).div(basketsNeeded).floor();
-    }
-
     /// @return p {UoA/rTok} The protocol's best guess of the RToken price on markets
     function price() external view returns (int192 p) {
         if (totalSupply() == 0) return main.basketHandler().price();

--- a/test/p0/RecapitalizationP0.test.ts
+++ b/test/p0/RecapitalizationP0.test.ts
@@ -265,7 +265,7 @@ describe('MainP0 contract', () => {
         ]
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, basketsNeededAmts)
+          .withArgs(newTokens, basketsNeededAmts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -329,7 +329,7 @@ describe('MainP0 contract', () => {
         ]
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, newRefAmounts)
+          .withArgs(newTokens, newRefAmounts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -395,7 +395,7 @@ describe('MainP0 contract', () => {
 
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, newRefAmounts)
+          .withArgs(newTokens, newRefAmounts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -440,7 +440,7 @@ describe('MainP0 contract', () => {
         ]
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, newRefAmounts)
+          .withArgs(newTokens, newRefAmounts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -477,15 +477,19 @@ describe('MainP0 contract', () => {
         // Confirm default
         await collateral1.forceUpdates()
 
-        // Basket cannot switch because there is no valid backup
-        await expect(basketHandler.ensureBasket()).to.not.emit(basketHandler, 'BasketSet')
+        // Basket switches to empty basket
+        await expect(basketHandler.ensureBasket())
+          .to.emit(basketHandler, 'BasketSet')
+          .withArgs([], [], true)
 
-        // Check state - Basket remains the same
+        // Check state - Basket is disabled even though fully capitalized
         expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
         expect(await basketHandler.fullyCapitalized()).to.equal(true)
+
+        // Should exclude bad token
         await expectCurrentBacking({
-          tokens: initialTokens,
-          quantities: initialQuantities,
+          tokens: [initialTokens[0], initialTokens[2], initialTokens[3]],
+          quantities: [initialQuantities[0], initialQuantities[2], initialQuantities[3]],
         })
 
         // Cannot issue because collateral is not sound
@@ -546,7 +550,7 @@ describe('MainP0 contract', () => {
         ]
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, newRefAmounts)
+          .withArgs(newTokens, newRefAmounts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -595,7 +599,7 @@ describe('MainP0 contract', () => {
         // Unregister an asset in basket
         await expect(assetRegistry.connect(owner).unregister(collateral1.address))
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, basketsNeededAmts)
+          .withArgs(newTokens, basketsNeededAmts, false)
 
         // Check state - Basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -718,7 +722,7 @@ describe('MainP0 contract', () => {
         const newRefAmounts = [fp('0.5'), fp('0.5')]
         await expect(basketHandler.ensureBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs(newTokens, newRefAmounts)
+          .withArgs(newTokens, newRefAmounts, false)
 
         // Check state - Basket switch in EUR targets
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -771,15 +775,19 @@ describe('MainP0 contract', () => {
           quantities: initialQuantities,
         })
 
-        //  Basket cannot switch because there is no USD backup
-        await expect(basketHandler.ensureBasket()).to.not.emit(basketHandler, 'BasketSet')
+        //  Basket should switch to empty and defaulted
+        await expect(basketHandler.ensureBasket())
+          .to.emit(basketHandler, 'BasketSet')
+          .withArgs([], [], true)
 
-        // Check state - Basket remains the same
+        // Check state - Basket is disabled but fully capitalized
         expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
         expect(await basketHandler.fullyCapitalized()).to.equal(true)
+
+        // Should exclude bad token
         await expectCurrentBacking({
-          tokens: initialTokens,
-          quantities: initialQuantities,
+          tokens: [initialTokens[1]],
+          quantities: [initialQuantities[1]],
         })
 
         // Cannot issue because collateral is not sound
@@ -830,7 +838,7 @@ describe('MainP0 contract', () => {
         // Switch Basket
         await expect(basketHandler.connect(owner).switchBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs([token1.address], [fp('1')])
+          .withArgs([token1.address], [fp('1')], false)
 
         // Check state remains SOUND
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -934,7 +942,7 @@ describe('MainP0 contract', () => {
         // Switch Basket
         await expect(basketHandler.connect(owner).switchBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs([token1.address], [fp('1')])
+          .withArgs([token1.address], [fp('1')], false)
 
         // Check state remains SOUND
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -1044,7 +1052,7 @@ describe('MainP0 contract', () => {
         // Switch Basket
         await expect(basketHandler.connect(owner).switchBasket())
           .to.emit(basketHandler, 'BasketSet')
-          .withArgs([token1.address], [fp('1')])
+          .withArgs([token1.address], [fp('1')], false)
 
         // Check state remains SOUND
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)


### PR DESCRIPTION
The BasketHandler guarantees two invariants: (i) the reference basket should not contain defaulted or unregistered collateral, and (ii) the reference basket is either worth the number of target units in the prime basket, or it is defaulted. 

Changes:
- Do not leave bad collateral in reference basket; remove as soon as collateral becomes bad
- Emit `BasketSet` whenever `_switchBasket` happens, including default status
- Exclude defaulted ERC20s from all BasketHandler views
- Prevent BackingManager from trading if the basket is defaulted or iffy (TO CHECK: Do we agree that it shouldn't trade when iffy?)
- minor and unrelated: I noticed we could eliminate `maxIssuable` from our system and move it out to the facade, so I did that