### PR TITLE
StRSR extreme bounds tests

### DIFF
--- a/contracts/interfaces/IStRSR.sol
+++ b/contracts/interfaces/IStRSR.sol
@@ -74,7 +74,7 @@ interface IStRSR is IERC20Permit, IERC20Metadata, IComponent {
     function stake(uint256 amount) external;
 
     /// Begins a delayed unstaking for `amount` stRSR
-    /// @param amount {qRSR}
+    /// @param amount {qStRSR}
     /// @custom:action
     function unstake(uint256 amount) external;
 

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -93,6 +93,7 @@ contract StRSRP0 is IStRSR, Component, EIP712 {
 
     function init(ConstructorArgs memory args) internal override {
         payoutLastPaid = block.timestamp;
+        rsrRewardsAtLastPayout = args.rsr.balanceOf(address(this));
         unstakingDelay = args.params.unstakingDelay;
         rewardPeriod = args.params.rewardPeriod;
         rewardRatio = args.params.rewardRatio;

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -127,7 +127,7 @@ contract StRSRP0 is IStRSR, Component, EIP712 {
     }
 
     /// Begins a delayed unstaking for `amount` stRSR
-    /// @param stakeAmount {qRSR}
+    /// @param stakeAmount {qStRSR}
     /// @custom:action
     function unstake(uint256 stakeAmount) external notPaused {
         address account = _msgSender();

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -90,6 +90,7 @@ contract StRSRP1 is IStRSR, Component, EIP712 {
 
     function init(ConstructorArgs memory args) internal override {
         payoutLastPaid = block.timestamp;
+        rsrRewardsAtLastPayout = args.rsr.balanceOf(address(this));
         unstakingDelay = args.params.unstakingDelay;
         rewardPeriod = args.params.rewardPeriod;
         rewardRatio = args.params.rewardRatio;

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -109,8 +109,8 @@ contract StRSRP1 is IStRSR, Component, EIP712 {
         _stake(account, rsrAmount);
     }
 
-    /// Begins a delayed unstaking for `amount` stRSR
-    /// @param stakeAmount {qRSR}
+    /// Begins a delayed unstaking for `amount` StRSR
+    /// @param stakeAmount {qStRSR}
     /// @custom:action
     function unstake(uint256 stakeAmount) external notPaused {
         address account = _msgSender();

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -64,7 +64,7 @@ export default <HardhatUserConfig>{
     sources: src_dir,
   },
   mocha: {
-    timeout: 200000,
+    timeout: 300000,
   },
   contractSizer: {
     alphaSort: false,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "deploy:p0": "TASKS=true hardhat run scripts/proto0/deploy_all.ts --network localhost",
         "devchain": "hardhat node",
         "test": "yarn test:p0 && yarn test:p1",
+        "test:exhaustive": "TURBO=off yarn test:p0 && yarn test:p1",
         "test:p0": "PROTO_IMPL=0 hardhat test test/*.test.ts --parallel",
         "test:p1": "PROTO_IMPL=1 hardhat test test/RToken.test.ts test/StRSR.test.ts test/Deployer.test.ts --parallel",
         "test:coverage": "hardhat coverage --temp artifacts",

--- a/test/Furnace.test.ts
+++ b/test/Furnace.test.ts
@@ -388,7 +388,7 @@ describe('FurnaceP0 contract', () => {
       typical: bn('1e9'),
     }
 
-    const parametrize = async (period: BigNumber, ratio: BigNumber, bal: BigNumber) => {
+    const applyParameters = async (period: BigNumber, ratio: BigNumber, bal: BigNumber) => {
       // Deploy fixture
       ;({ main, rToken, backingManager } = await loadFixture(defaultFixture))
 
@@ -431,10 +431,10 @@ describe('FurnaceP0 contract', () => {
             const period = periodBounds[periodKey as keyof typeof periodBounds]
             const ratio = ratioBounds[ratioKey as keyof typeof ratioBounds]
             const bal = balBounds[balKey as keyof typeof balBounds]
-            await parametrize(period, ratio, bal)
+            await applyParameters(period, ratio, bal)
 
             // Should melt after 1 period
-            await advanceTime(period.mul(1).add(1).toString())
+            await advanceTime(period.add(1).toString())
             await furnace.melt()
 
             // Should melt after 1000 periods

--- a/test/StRSR.test.ts
+++ b/test/StRSR.test.ts
@@ -24,6 +24,7 @@ import { advanceTime, getLatestBlockTimestamp, setNextBlockTimestamp } from './u
 import { whileImpersonating } from './utils/impersonation'
 import { Collateral, defaultFixture, IConfig, Implementation, IMPLEMENTATION } from './fixtures'
 import { makeDecayFn, calcErr } from './utils/rewards'
+import { cartesianProduct } from './utils/cases'
 
 const createFixtureLoader = waffle.createFixtureLoader
 
@@ -1359,6 +1360,144 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
       // Nothing set
       expect(await stRSR.allowance(addr1.address, ZERO_ADDRESS)).to.equal(0)
       expect(await stRSR.allowance(ZERO_ADDRESS, addr2.address)).to.equal(0)
+    })
+  })
+
+  describe('Extreme Bounds', () => {
+    // Dimensions
+    //
+    // StRSR economics can be broken down into 4 "places" that RSR can be.
+    // The StRSR balances and exchange rate is fully determined by these 4 dimensions.
+    //
+    //  1. RSR staked directly {qRSR}
+    //  2. RSR accreted {qRSR}
+    //  3. RSR being withdrawn {qRSR}
+    //  4. RSR being rewarded {qRSR}
+    //  5. Unstaking Delay {seconds}
+    //  6. Reward Period {seconds}
+    //  7. Reward Ratio {%}
+    //
+    //  3^7 = 2187 cases ~= about 2-3min runtime
+    //  2^7 = 128 cases ~= about 10s runtime
+
+    const runSimulation = async (
+      rsrStake: BigNumber,
+      rsrAccreted: BigNumber,
+      rsrWithdrawal: BigNumber,
+      rsrReward: BigNumber,
+      unstakingDelay: BigNumber,
+      rewardPeriod: BigNumber,
+      rewardRatio: BigNumber
+    ) => {
+      // === Setup ===
+
+      ;({ main, rToken, stRSR, rsr, backingManager } = await loadFixture(defaultFixture))
+
+      // addr1 is the staker; addr2 is the withdrawer
+
+      // addr1 - staker
+      if (rsrStake.gt(0)) {
+        await rsr.connect(owner).mint(addr1.address, rsrStake)
+        await rsr.connect(addr1).approve(stRSR.address, rsrStake)
+        await stRSR.connect(addr1).stake(rsrStake)
+      }
+
+      // addr2 - withdrawer
+      if (rsrWithdrawal.gt(0)) {
+        await rsr.connect(owner).mint(addr2.address, rsrWithdrawal)
+        await rsr.connect(addr2).approve(stRSR.address, rsrWithdrawal)
+        await stRSR.connect(addr2).stake(rsrWithdrawal)
+        await stRSR.connect(addr2).unstake(rsrWithdrawal)
+      }
+
+      // Do accretion
+      if (rsrAccreted.gt(0)) {
+        await rsr.connect(owner).mint(stRSR.address, rsrAccreted)
+        await stRSR.connect(owner).setRewardRatio(fp('1'))
+        await advanceTime((await stRSR.rewardPeriod()).add(1).toString())
+        await expect(stRSR.payoutRewards()).to.emit(stRSR, 'ExchangeRateSet')
+      }
+
+      // Config -- note this assumes the gov params have been chosen sensibly
+      await stRSR.connect(owner).setRewardPeriod(rewardPeriod)
+      await stRSR.connect(owner).setUnstakingDelay(unstakingDelay)
+      await stRSR.connect(owner).setRewardRatio(rewardRatio)
+
+      // Rewards
+      await rsr.connect(owner).mint(stRSR.address, rsrReward)
+
+      // === Simulation ===
+
+      // Should payout after 1 period
+      await advanceTime(rewardPeriod.add(1).toString())
+      await stRSR.payoutRewards()
+
+      // Should payout after 1000 period
+      await advanceTime(rewardPeriod.mul(1000).add(1).toString())
+      await stRSR.payoutRewards()
+
+      if (rsrStake.gt(0)) {
+        // Staker should be able to withdraw
+        await stRSR.connect(addr1).unstake(await stRSR.balanceOf(addr1.address))
+      }
+      await advanceTime(unstakingDelay.add(1).toString())
+
+      // Clear both withdrawals
+      if (rsrStake.gt(0)) {
+        const endId = await stRSR.endIdForWithdraw(addr1.address)
+        await expect(stRSR.withdraw(addr1.address, endId)).to.emit(stRSR, 'UnstakingCompleted')
+      }
+      if (rsrWithdrawal.gt(0)) {
+        const endId = await stRSR.endIdForWithdraw(addr2.address)
+        await expect(stRSR.withdraw(addr2.address, endId)).to.emit(stRSR, 'UnstakingCompleted')
+      }
+    }
+
+    it('Should complete issuance + reward + redeem cycle at extreme bounds', async () => {
+      const turboMode = true // cuts off the typical case, which is always the last arg
+
+      // 100B RSR
+      const rsrStakeBounds = [bn('1e29'), bn('0'), bn('1e18')]
+
+      // the amount of RSR that has already been absorbed as profit
+      // has to do with the initial exchange rate
+      const rsrAccretedBounds = [bn('1e29'), bn('0'), bn('1e18')]
+
+      const rsrWithdrawalBounds = [fp('1'), fp('0'), fp('0.5')]
+
+      const rsrRewardBounds = [bn('1e29'), bn('0'), bn('1e18')]
+
+      // max: // 2^40 - 1
+      const unstakingDelayBounds = [bn('1099511627775'), bn('0'), bn('604800')]
+
+      // max: // 2^40 - 1
+      const rewardPeriodBounds = [bn('1099511627775'), bn('1'), bn('604800')]
+
+      const rewardRatioBounds = [fp('1'), fp('0'), fp('0.02284')]
+
+      let bounds = [
+        rsrStakeBounds,
+        rsrAccretedBounds,
+        rsrWithdrawalBounds,
+        rsrRewardBounds,
+        unstakingDelayBounds,
+        rewardPeriodBounds,
+        rewardRatioBounds,
+      ]
+
+      if (turboMode) {
+        bounds = bounds.map((b) => [b[0], b[1]])
+      }
+
+      const cases = cartesianProduct(...bounds)
+      for (let i = 0; i < cases.length; i++) {
+        const args: BigNumber[] = cases[i]
+
+        // if (rewardPeriod * 2 > unstakingDelay)
+        if (args[5].mul(2).gt(args[4])) continue
+
+        await runSimulation(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+      }
     })
   })
 })

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -44,6 +44,8 @@ export enum Implementation {
 export const IMPLEMENTATION: Implementation =
   process.env.PROTO_IMPL == Implementation.P1.toString() ? Implementation.P1 : Implementation.P0
 
+export const TURBO = process.env.TURBO !== 'off'
+
 export type Collateral = AbstractCollateral | CTokenFiatCollateral | ATokenFiatCollateral
 
 export interface IConfig {


### PR DESCRIPTION
tests for extreme values in StRSR

introduces "Turbo Mode", which is enabled by default in the majority of our test targets. When set to false, a larger branching factor is applied to the test, testing ~2100 cases instead of 128