### PR TITLE
default immediately after bad oracle price

### DIFF
--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -5,8 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "contracts/libraries/Fixed.sol";
 import "./IMain.sol";
 
-/// Raised if the oracle does not contain a price
 error PriceIsZero();
+error UnknownError(bytes);
 
 /**
  * @title IAsset

--- a/contracts/plugins/assets/abstract/AaveOracleMixin.sol
+++ b/contracts/plugins/assets/abstract/AaveOracleMixin.sol
@@ -38,7 +38,7 @@ abstract contract AaveOracleMixin is CompoundOracleMixin {
     }
 
     /// @return {UoA/erc20}
-    function consultOracle(IERC20Metadata erc20_) internal view override returns (int192) {
+    function consultOracle(IERC20Metadata erc20_) public view override returns (int192) {
         // Aave keeps their prices in terms of ETH
         IAaveOracle aaveOracle = aaveLendingPool.getAddressesProvider().getPriceOracle();
         uint256 p = aaveOracle.getAssetPrice(address(erc20_));

--- a/contracts/plugins/assets/abstract/CompoundOracleMixin.sol
+++ b/contracts/plugins/assets/abstract/CompoundOracleMixin.sol
@@ -30,7 +30,7 @@ abstract contract CompoundOracleMixin {
     }
 
     /// @return {UoA/erc20}
-    function consultOracle(IERC20Metadata erc20) internal view virtual returns (int192) {
+    function consultOracle(IERC20Metadata erc20) public view virtual returns (int192) {
         // Compound stores prices with 6 decimals of precision
 
         uint256 p = comptroller.oracle().price(erc20.symbol());


### PR DESCRIPTION
Multiple collateral assets can present invalid oracle prices simultaneously. If this happens, the protocol gets stuck and is unable to unregister any of the assets. To fix this, we default a token immediately if its oracle price is ever invalid. 

Aside: Error handling in solidity is insanely bad and we should do everything we can to minimize using it. 