### PR TITLE
Broker-Trade gas optimizations

### DIFF
--- a/contracts/interfaces/IBroker.sol
+++ b/contracts/interfaces/IBroker.sol
@@ -20,14 +20,15 @@ struct TradeRequest {
  *   the continued proper functioning of trading platforms.
  */
 interface IBroker is IComponent {
-    event AuctionLengthSet(uint256 indexed oldVal, uint256 indexed newVal);
+    event AuctionLengthSet(uint32 indexed oldVal, uint32 indexed newVal);
     event DisabledSet(bool indexed prevVal, bool indexed newVal);
 
     // Initialization
     function init(
         IMain main_,
         IGnosis gnosis_,
-        uint256 auctionLength_
+        ITrade tradeImplementation_,
+        uint32 auctionLength_
     ) external;
 
     /// Request a trade from the broker
@@ -43,9 +44,9 @@ interface IBroker is IComponent {
 interface TestIBroker is IBroker {
     function gnosis() external view returns (IGnosis);
 
-    function auctionLength() external view returns (uint256);
+    function auctionLength() external view returns (uint32);
 
-    function setAuctionLength(uint256 newAuctionLength) external;
+    function setAuctionLength(uint32 newAuctionLength) external;
 
     function setDisabled(bool disabled_) external;
 }

--- a/contracts/interfaces/IDeployer.sol
+++ b/contracts/interfaces/IDeployer.sol
@@ -10,6 +10,7 @@ import "./IMain.sol";
 import "./IRToken.sol";
 import "./IStRSR.sol";
 import "./IDistributor.sol";
+import "./ITrade.sol";
 
 /**
  * @title DeploymentParams
@@ -32,7 +33,7 @@ struct DeploymentParams {
     //
     // === BackingManager ===
     uint256 tradingDelay; // {s} how long to wait until starting auctions after switching basket
-    uint256 auctionLength; // {s} the length of an auction
+    uint32 auctionLength; // {s} the length of an auction
     int192 backingBuffer; // {%} how much extra backing collateral to keep
     int192 maxTradeSlippage; // {%} max slippage acceptable in a trade
     int192 dustAmount; // {UoA} value below which it is not worth wasting time trading
@@ -48,6 +49,7 @@ struct DeploymentParams {
 struct Implementations {
     IMain main;
     Components components;
+    ITrade trade;
 }
 
 /**

--- a/contracts/interfaces/ITrade.sol
+++ b/contracts/interfaces/ITrade.sol
@@ -14,7 +14,7 @@ interface ITrade {
     function buy() external view returns (IERC20);
 
     /// @return The timestamp at which the trade is projected to become settle-able
-    function endTime() external view returns (uint256);
+    function endTime() external view returns (uint32);
 
     /// @return True if the trade can be settled
     /// @dev Should be guaranteed to be true eventually as an invariant

--- a/contracts/p0/Broker.sol
+++ b/contracts/p0/Broker.sol
@@ -19,14 +19,17 @@ contract BrokerP0 is ComponentP0, IBroker {
 
     mapping(address => bool) private trades;
 
-    uint256 public auctionLength; // {s} the length of an auction
+    uint32 public auctionLength; // {s} the length of an auction
 
     bool public disabled;
 
+    // solhint-disable-next-line no-unused-vars
     function init(
         IMain main_,
         IGnosis gnosis_,
-        uint256 auctionLength_
+        // solhint-disable-next-line no-unused-vars
+        ITrade tradeImplementation_, // Added for Interface compatibility with P1
+        uint32 auctionLength_
     ) public initializer {
         __Component_init(main_);
         gnosis = gnosis_;
@@ -61,7 +64,7 @@ contract BrokerP0 is ComponentP0, IBroker {
 
     // === Setters ===
 
-    function setAuctionLength(uint256 newAuctionLength) external onlyOwner {
+    function setAuctionLength(uint32 newAuctionLength) external onlyOwner {
         emit AuctionLengthSet(auctionLength, newAuctionLength);
         auctionLength = newAuctionLength;
     }

--- a/contracts/p0/aux/Deployer.sol
+++ b/contracts/p0/aux/Deployer.sol
@@ -127,7 +127,7 @@ contract DeployerP0 is IDeployer {
         // Init Furnace
         main.furnace().init(main, params.rewardPeriod, params.rewardRatio);
 
-        main.broker().init(main, gnosis, params.auctionLength);
+        main.broker().init(main, gnosis, ITrade(address(0)), params.auctionLength);
 
         string memory stRSRName = string(abi.encodePacked("st", symbol, "RSR Token"));
         string memory stRSRSymbol = string(abi.encodePacked("st", symbol, "RSR"));

--- a/contracts/p1/aux/Deployer.sol
+++ b/contracts/p1/aux/Deployer.sol
@@ -177,7 +177,7 @@ contract DeployerP1 is IDeployer {
         // Init Furnace
         main.furnace().init(main, params.rewardPeriod, params.rewardRatio);
 
-        main.broker().init(main, gnosis, params.auctionLength);
+        main.broker().init(main, gnosis, implementations.trade, params.auctionLength);
 
         // Init StRSR
         string memory stRSRName = string(abi.encodePacked("st", symbol, "RSR Token"));

--- a/contracts/plugins/mocks/InvalidBrokerMock.sol
+++ b/contracts/plugins/mocks/InvalidBrokerMock.sol
@@ -19,14 +19,15 @@ contract InvalidBrokerMock is ComponentP0, IBroker {
 
     mapping(address => bool) private trades;
 
-    uint256 public auctionLength; // {s} the length of an auction
+    uint32 public auctionLength; // {s} the length of an auction
 
     bool public disabled = false;
 
     function init(
         IMain main_,
         IGnosis gnosis_,
-        uint256 auctionLength_
+        ITrade tradeImplementation_,
+        uint32 auctionLength_
     ) public initializer {
         __Component_init(main_);
         gnosis = gnosis_;
@@ -55,7 +56,7 @@ contract InvalidBrokerMock is ComponentP0, IBroker {
 
     /// Dummy implementation
     /* solhint-disable no-empty-blocks */
-    function setAuctionLength(uint256 newAuctionLength) external onlyOwner {}
+    function setAuctionLength(uint32 newAuctionLength) external onlyOwner {}
 
     /// Dummy implementation
     /* solhint-disable no-empty-blocks */

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
-import { BigNumber, ContractFactory, Wallet } from 'ethers'
+import { BigNumber, Contract, ContractFactory, Wallet } from 'ethers'
 import { ethers, waffle } from 'hardhat'
 import { CollateralStatus, ZERO_ADDRESS, MAX_UINT256 } from '../common/constants'
 import { expectInIndirectReceipt, expectInReceipt, expectEvents } from '../common/events'
@@ -17,6 +17,7 @@ import {
   ERC20Mock,
   FacadeP0,
   GnosisMock,
+  GnosisTrade,
   IBasketHandler,
   RTokenAsset,
   StaticATokenMock,
@@ -329,8 +330,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       ).to.be.revertedWith('Initializable: contract is already initialized')
 
       // Attempt to reinitialize - Broker
+      const TradeFactory: ContractFactory = await ethers.getContractFactory('GnosisTrade')
+      const trade: GnosisTrade = <GnosisTrade>await TradeFactory.deploy()
       await expect(
-        broker.init(main.address, gnosis.address, config.auctionLength)
+        broker.init(main.address, gnosis.address, trade.address, config.auctionLength)
       ).to.be.revertedWith('Initializable: contract is already initialized')
 
       // Attempt to reinitialize - RToken

--- a/test/Recapitalization.test.ts
+++ b/test/Recapitalization.test.ts
@@ -23,13 +23,7 @@ import {
   USDCMock,
 } from '../typechain'
 import { advanceTime, getLatestBlockTimestamp } from './utils/time'
-import {
-  Collateral,
-  defaultFixture,
-  IConfig,
-  Implementation,
-  IMPLEMENTATION,
-} from './fixtures'
+import { Collateral, defaultFixture, IConfig, Implementation, IMPLEMENTATION } from './fixtures'
 import snapshotGasCost from './utils/snapshotGasCost'
 import { expectTrade } from './utils/trades'
 

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -1322,7 +1322,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const invalidBroker: TestIBroker = <TestIBroker>await InvalidBrokerFactory.deploy()
 
         // Set broker
-        await invalidBroker.init(main.address, gnosis.address, config.auctionLength)
+        await invalidBroker.init(main.address, gnosis.address, ZERO_ADDRESS, config.auctionLength)
         await main.connect(owner).setBroker(invalidBroker.address)
 
         rewardAmountAAVE = bn('0.5e18')

--- a/test/Upgradeability.test.ts
+++ b/test/Upgradeability.test.ts
@@ -20,6 +20,7 @@ import {
   FurnaceP1,
   FurnaceP1V2,
   GnosisMock,
+  GnosisTrade,
   IBasketHandler,
   MainP1,
   MainP1V2,
@@ -90,6 +91,7 @@ describeP1(`Upgradeability - P${IMPLEMENTATION}`, () => {
   let BasketHandlerFactory: ContractFactory
   let DistributorFactory: ContractFactory
   let BrokerFactory: ContractFactory
+  let TradeFactory: ContractFactory
   let StRSRFactory: ContractFactory
 
   let loadFixture: ReturnType<typeof createFixtureLoader>
@@ -144,6 +146,7 @@ describeP1(`Upgradeability - P${IMPLEMENTATION}`, () => {
     BasketHandlerFactory = await ethers.getContractFactory('BasketHandlerP1')
     DistributorFactory = await ethers.getContractFactory('DistributorP1')
     BrokerFactory = await ethers.getContractFactory('BrokerP1')
+    TradeFactory = await ethers.getContractFactory('GnosisTrade')
     StRSRFactory = await ethers.getContractFactory('StRSRP1')
 
     // Import deployed proxies
@@ -258,10 +261,12 @@ describeP1(`Upgradeability - P${IMPLEMENTATION}`, () => {
       expect(await newBasketHandler.main()).to.equal(main.address)
     })
 
-    it('Should deploy valid implementation - Broker', async () => {
+    it('Should deploy valid implementation - Broker / Trade', async () => {
+      const trade: GnosisTrade = <GnosisTrade>await TradeFactory.deploy()
+
       const newBroker: BrokerP1 = <BrokerP1>await upgrades.deployProxy(
         BrokerFactory,
-        [main.address, gnosis.address, config.auctionLength],
+        [main.address, gnosis.address, trade.address, config.auctionLength],
         {
           initializer: 'init',
           kind: 'uups',

--- a/test/__snapshots__/Broker.test.ts.snap
+++ b/test/__snapshots__/Broker.test.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrokerP1 contract Gas Reporting Initialize Trade  1`] = `423211`;
+exports[`BrokerP1 contract Gas Reporting Initialize Trade  1`] = `421350`;
 
-exports[`BrokerP1 contract Gas Reporting Open Trade  1`] = `2089764`;
+exports[`BrokerP1 contract Gas Reporting Open Trade  1`] = `519685`;
 
-exports[`BrokerP1 contract Gas Reporting Open Trade  2`] = `2078983`;
+exports[`BrokerP1 contract Gas Reporting Open Trade  2`] = `508903`;
 
-exports[`BrokerP1 contract Gas Reporting Open Trade  3`] = `2082480`;
+exports[`BrokerP1 contract Gas Reporting Open Trade  3`] = `512399`;
 
-exports[`BrokerP1 contract Gas Reporting Settle Trade  1`] = `116512`;
+exports[`BrokerP1 contract Gas Reporting Settle Trade  1`] = `116521`;

--- a/test/__snapshots__/Recapitalization.test.ts.snap
+++ b/test/__snapshots__/Recapitalization.test.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `30508`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `4454731`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `2885149`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `40422`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `43122`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `739305`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `742005`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `193794`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `195021`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `4516057`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `2926575`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `176717`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `177944`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 8`] = `5856091`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 8`] = `4266609`;
 
-exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 9`] = `196873`;
+exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 9`] = `197855`;
 
 exports[`Recapitalization - P1 Gas Reporting Settle Trades / Manage Funds 10`] = `1417401`;

--- a/test/__snapshots__/Revenues.test.ts.snap
+++ b/test/__snapshots__/Revenues.test.ts.snap
@@ -20,19 +20,19 @@ exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `30508`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `30508`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `2759182`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `1169699`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `3128566`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `1539282`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `215617`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `216844`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `199439`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `200666`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `2793328`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `1203845`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 8`] = `571832`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 8`] = `574532`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 9`] = `176617`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 9`] = `177844`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 10`] = `30508`;
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -25,6 +25,7 @@ import {
   DistributorP1,
   FurnaceP1,
   GnosisMock,
+  GnosisTrade,
   IBasketHandler,
   MainP1,
   RevenueTradingP1,
@@ -94,6 +95,7 @@ export interface IComponents {
 export interface IImplementations {
   main: string
   components: IComponents
+  trade: string
 }
 
 interface RSRFixture {
@@ -458,6 +460,9 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
     const FurnaceImplFactory: ContractFactory = await ethers.getContractFactory('FurnaceP1')
     const furnaceImpl: FurnaceP1 = <FurnaceP1>await FurnaceImplFactory.deploy()
 
+    const TradeImplFactory: ContractFactory = await ethers.getContractFactory('GnosisTrade')
+    const tradeImpl: GnosisTrade = <GnosisTrade>await TradeImplFactory.deploy()
+
     const BrokerImplFactory: ContractFactory = await ethers.getContractFactory('BrokerP1')
     const brokerImpl: BrokerP1 = <BrokerP1>await BrokerImplFactory.deploy()
 
@@ -482,6 +487,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
         rsrTrader: revTraderImpl.address,
         rTokenTrader: revTraderImpl.address,
       },
+      trade: tradeImpl.address,
     }
 
     const DeployerFactory: ContractFactory = await ethers.getContractFactory('DeployerP1')


### PR DESCRIPTION
* Adds optimizations for `BrokerP1` and `GnosisTrade`
* Main advantages are related to using `Clones` instead of instantiating a Trade using full bytecode (Reductions of 75% of gas cost)
* This required to add also the `implementation` parameter in P0, to keep the interface consistent (Even though the value is not used in P0). The other option makes the code very cumbersome and requires to avoid the common interface and go back to differentiate `BrokerP0` and `BrokerP1`. I think this is the best way to keep it simpler.
* Other optimizations (packing) provide less value but also contribute.

Attaching table with gas analysis

![image](https://user-images.githubusercontent.com/56316686/164548572-7bff313e-250c-4c82-b4ce-ab92e89faa97.png)
