### PR TITLE
P1 optimization

### DIFF
--- a/contracts/fuzz/RTokenDiffTest.sol
+++ b/contracts/fuzz/RTokenDiffTest.sol
@@ -240,43 +240,30 @@ contract RTokenDiffTest {
     // Actions and state modifiers
 
     // ==== user actions, performed by 0x[123]0000. Melt
-    function issue(uint256 amount) external fromSender returns (uint256[] memory deposits) {
+    function issue(uint256 amount) external fromSender {
         amount %= 1e36;
 
-        uint256[] memory deposits1;
-        deposits = p0.rToken().issue(amount);
-        deposits1 = p1.rToken().issue(amount);
-
-        assert(deposits.length == deposits1.length);
-        for (uint256 i = 0; i < deposits.length; i++) assert(deposits[i] == deposits1[i]);
+        p0.rToken().issue(amount);
+        p1.rToken().issue(amount);
     }
 
-    function cancel(uint256 endId, bool e) external fromSender returns (uint256[] memory deposits) {
-        deposits = p0.rToken().cancel(endId, e);
-        uint256[] memory deposits1 = p1.rToken().cancel(endId, e);
-
-        assert(deposits.length == deposits1.length);
-        for (uint256 i = 0; i < deposits.length; i++) assert(deposits[i] == deposits1[i]);
+    function cancel(uint256 endId, bool e) external fromSender {
+        p0.rToken().cancel(endId, e);
+        p1.rToken().cancel(endId, e);
     }
 
-    function vest(address acct, uint256 endId) external fromSender returns (uint256 vested) {
-        vested = p0.rToken().vest(acct, endId);
-        uint256 vested1 = p1.rToken().vest(acct, endId);
-        assert(vested == vested1);
+    function vest(address acct, uint256 endId) external fromSender {
+        p0.rToken().vest(acct, endId);
+        p1.rToken().vest(acct, endId);
     }
 
     // TODO: Add "cancel" and "vest" variations that are likely to succeed too
     // i.e, ones that have valid endIDs
-    function redeem(uint256 amount) external fromSender returns (uint256[] memory compensation) {
+    function redeem(uint256 amount) external fromSender {
         amount %= 1e36;
 
-        compensation = p0.rToken().redeem(amount);
-        uint256[] memory compensation1 = p1.rToken().redeem(amount);
-
-        assert(compensation.length == compensation1.length);
-        for (uint256 i = 0; i < compensation.length; i++) {
-            assert(compensation[i] == compensation1[i]);
-        }
+        p0.rToken().redeem(amount);
+        p1.rToken().redeem(amount);
     }
 
     function melt(uint256 amount) external fromSender {

--- a/contracts/interfaces/IFacade.sol
+++ b/contracts/interfaces/IFacade.sol
@@ -37,6 +37,10 @@ interface IFacade {
     /// @custom:static-call
     function totalAssetValue() external returns (int192 total);
 
+    /// @return deposits The deposits necessary to issue `amount` RToken
+    /// @custom:static-call
+    function issue(uint256 amount) external returns (uint256[] memory deposits);
+
     /// @return tokens The addresses of the ERC20s backing the RToken
     /// @custom:view
     function basketTokens() external view returns (address[] memory tokens);

--- a/contracts/interfaces/IMain.sol
+++ b/contracts/interfaces/IMain.sol
@@ -57,7 +57,7 @@ interface IPausable {
  * @notice The central hub for the entire system. Maintains components and an owner singleton role
  */
 interface IMain is IPausable {
-    /// Call all collective state keepers
+    /// Call all collective state keepers -- only necessary for P0
     /// @custom:action
     function poke() external;
 

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -78,9 +78,8 @@ interface IRToken is IRewardable, IERC20MetadataUpgradeable, IERC20PermitUpgrade
 
     /// Begin a time-delayed issuance of RToken for basket collateral
     /// @param amount {qRTok} The quantity of RToken to issue
-    /// @return deposits {qRTok} The quantities of collateral tokens transferred in
     /// @custom:action
-    function issue(uint256 amount) external returns (uint256[] memory deposits);
+    function issue(uint256 amount) external;
 
     /// Cancels a vesting slow issuance of _msgSender
     /// If earliest == true, cancel id if id < endId
@@ -88,13 +87,12 @@ interface IRToken is IRewardable, IERC20MetadataUpgradeable, IERC20PermitUpgrade
     /// @param endId One edge of the issuance range to cancel
     /// @param earliest If true, cancel earliest issuances; else, cancel latest issuances
     /// @custom:action
-    function cancel(uint256 endId, bool earliest) external returns (uint256[] memory deposits);
+    function cancel(uint256 endId, bool earliest) external;
 
     /// Completes vested slow issuances for the account, up to endId.
     /// @param account The address of the account to vest issuances for
-    /// @return vested {qRTok} The total amount of RToken quanta vested
     /// @custom:completion
-    function vest(address account, uint256 endId) external returns (uint256 vested);
+    function vest(address account, uint256 endId) external;
 
     /// Return the highest index that could be completed by a vestIssuances call.
     /// @dev Use with `vest`
@@ -102,9 +100,8 @@ interface IRToken is IRewardable, IERC20MetadataUpgradeable, IERC20PermitUpgrade
 
     /// Redeem RToken for basket collateral
     /// @param amount {qRTok} The quantity {qRToken} of RToken to redeem
-    /// @return compensation {qRTok} The quantities of collateral tokens transferred out
     /// @custom:action
-    function redeem(uint256 amount) external returns (uint256[] memory compensation);
+    function redeem(uint256 amount) external;
 
     /// Mints a quantity of RToken to the `recipient`, callable only by the BackingManager
     /// @param recipient The recipient of the newly minted RToken

--- a/contracts/p0/AssetRegistry.sol
+++ b/contracts/p0/AssetRegistry.sol
@@ -26,7 +26,6 @@ contract AssetRegistryP0 is ComponentP0, IAssetRegistry {
 
     /// Force updates in all collateral assets
     function forceUpdates() external {
-        require(_msgSender() == address(main.basketHandler()), "basket handler only");
         for (uint256 i = 0; i < _erc20s.length(); i++) {
             IAsset asset = assets[IERC20(_erc20s.at(i))];
             if (asset.isCollateral()) ICollateral(address(asset)).forceUpdates();

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -53,7 +53,7 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
         main.poke();
 
         // Do not trade when DISABLED or IFFY
-        if (main.basketHandler().status() != CollateralStatus.SOUND) return;
+        require(main.basketHandler().status() == CollateralStatus.SOUND, "basket defaulted");
 
         (, uint256 basketTimestamp) = main.basketHandler().lastSet();
         if (block.timestamp < basketTimestamp + tradingDelay) return;

--- a/contracts/p0/RevenueTrader.sol
+++ b/contracts/p0/RevenueTrader.sol
@@ -33,6 +33,9 @@ contract RevenueTradingP0 is TradingP0, IRevenueTrader {
         // Call state keepers
         main.poke();
 
+        // Do not trade when DISABLED or IFFY
+        require(main.basketHandler().status() == CollateralStatus.SOUND, "basket defaulted");
+
         IERC20[] memory erc20s = main.assetRegistry().erc20s();
         for (uint256 i = 0; i < erc20s.length; i++) {
             manageERC20(erc20s[i]);

--- a/contracts/p0/mixins/Component.sol
+++ b/contracts/p0/mixins/Component.sol
@@ -18,7 +18,7 @@ abstract contract ComponentP0 is Initializable, ContextUpgradeable, IComponent {
     }
 
     modifier notPaused() {
-        require(!main.paused(), "Component: system is paused");
+        require(!main.paused(), "paused");
         _;
     }
 

--- a/contracts/p1/AssetRegistry.sol
+++ b/contracts/p1/AssetRegistry.sol
@@ -26,7 +26,6 @@ contract AssetRegistryP1 is ComponentP1, IAssetRegistry {
 
     /// Force updates in all collateral assets
     function forceUpdates() external {
-        require(_msgSender() == address(main.basketHandler()), "basket handler only");
         for (uint256 i = 0; i < _erc20s.length(); i++) {
             IAsset asset = assets[IERC20(_erc20s.at(i))];
             if (asset.isCollateral()) ICollateral(address(asset)).forceUpdates();

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -54,11 +54,12 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     /// Manage backing funds: maintain the overall backing policy
     /// Collective Action
     function manageFunds() external notPaused {
-        // Call keepers before
-        main.poke();
+        // Call keepers
+        main.assetRegistry().forceUpdates();
+        settleTrades();
 
         // Do not trade when DISABLED or IFFY
-        if (main.basketHandler().status() != CollateralStatus.SOUND) return;
+        require(main.basketHandler().status() == CollateralStatus.SOUND, "basket defaulted");
 
         (, uint256 basketTimestamp) = main.basketHandler().lastSet();
         if (block.timestamp < basketTimestamp + tradingDelay) return;

--- a/contracts/p1/Main.sol
+++ b/contracts/p1/Main.sol
@@ -22,14 +22,9 @@ contract MainP1 is Initializable, ContextUpgradeable, Pausable, UUPSUpgradeable,
     // solhint-disable-next-line no-empty-blocks
     constructor() initializer {}
 
-    function poke() external virtual notPaused {
-        // We think these are totally order-independent.
-        basketHandler.ensureBasket();
-        furnace.melt();
-        rsrTrader.settleTrades();
-        rTokenTrader.settleTrades();
-        backingManager.settleTrades();
-        stRSR.payoutRewards();
+    // solhint-disable-next-line no-empty-blocks
+    function poke() external virtual {
+        // TODO remove? only adds extra bytecode to deployment, might be okay
     }
 
     function owner() public view override(IMain, OwnableUpgradeable) returns (address) {

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -30,9 +30,13 @@ contract RevenueTradingP1 is TradingP1, IRevenueTrader {
 
     /// Close any open trades and start new ones, for all assets
     /// Collective Action
-    function manageFunds() external {
+    function manageFunds() external notPaused {
         // Call state keepers
-        main.poke();
+        main.assetRegistry().forceUpdates();
+        settleTrades();
+
+        // Do not trade when DISABLED or IFFY
+        require(main.basketHandler().status() == CollateralStatus.SOUND, "basket defaulted");
 
         IERC20[] memory erc20s = main.assetRegistry().erc20s();
         for (uint256 i = 0; i < erc20s.length; i++) {

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -128,6 +128,9 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
         require(stakeAmount > 0, "Cannot withdraw zero");
         require(stakes[era][account] >= stakeAmount, "Not enough balance");
 
+        // TODO I think we can get rid of this for gas optimization, since `withdraw` handles it
+        main.assetRegistry().forceUpdates();
+
         require(bh.fullyCapitalized(), "RToken uncapitalized");
         require(bh.status() == CollateralStatus.SOUND, "basket defaulted");
 
@@ -139,6 +142,8 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
     /// Complete delayed unstaking for an account, up to but not including `endId`
     /// @custom:completion
     function withdraw(address account, uint256 endId) external notPaused {
+        main.assetRegistry().forceUpdates();
+
         IBasketHandler bh = main.basketHandler();
         require(bh.fullyCapitalized(), "RToken uncapitalized");
         require(bh.status() == CollateralStatus.SOUND, "basket defaulted");

--- a/contracts/p1/mixins/Component.sol
+++ b/contracts/p1/mixins/Component.sol
@@ -24,7 +24,7 @@ abstract contract ComponentP1 is Initializable, ContextUpgradeable, UUPSUpgradea
     }
 
     modifier notPaused() {
-        require(!main.paused(), "Component: system is paused");
+        require(!main.paused(), "paused");
         _;
     }
 

--- a/contracts/p1/mixins/Rewardable.sol
+++ b/contracts/p1/mixins/Rewardable.sol
@@ -19,9 +19,6 @@ abstract contract RewardableP1 is ComponentP1, IRewardable {
     /// Claim all rewards and sweep to BackingManager
     /// Collective Action
     function claimAndSweepRewards() external {
-        // Call state keepers before collective actions
-        main.poke();
-
         IAssetRegistry reg = main.assetRegistry();
         IERC20[] memory erc20s = reg.erc20s();
         IERC20[] memory rewardTokens = new IERC20[](erc20s.length);

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -48,7 +48,7 @@ abstract contract TradingP1 is RewardableP1, ITrading {
 
     /// Settle any trades that can be settled
     /// @custom:refresher
-    function settleTrades() external {
+    function settleTrades() public {
         uint256 i = tradesStart;
         for (; i < trades.length && trades[i].canSettle(); i++) {
             ITrade trade = trades[i];

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -370,7 +370,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await token2.connect(addr1).approve(rToken.address, initialBal)
       await token3.connect(addr1).approve(rToken.address, initialBal)
 
-      const quotes: BigNumber[] = await rToken.connect(addr1).callStatic.issue(issueAmount)
+      const quotes: BigNumber[] = await facade.connect(addr1).callStatic.issue(issueAmount)
 
       // check balances before
       expect(await token0.balanceOf(main.address)).to.equal(0)
@@ -566,7 +566,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await token2.connect(addr1).approve(rToken.address, initialBal)
       await token3.connect(addr1).approve(rToken.address, initialBal)
 
-      const quotes: BigNumber[] = await rToken.connect(addr1).callStatic.issue(issueAmount)
+      const quotes: BigNumber[] = await facade.connect(addr1).callStatic.issue(issueAmount)
 
       // Issue rTokens
       await rToken.connect(addr1).issue(issueAmount)
@@ -606,11 +606,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       })
 
       // Nothing should process
-      expect(
-        await rToken.callStatic.vest(addr1.address, await rToken.endIdForVest(addr1.address))
-      ).to.equal(0)
       await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
-
       // Check previous minting was not processed[, , , , , sm_proc] = await rToken.issuances(addr1.address, 0)
       await expectIssuance(addr1.address, 0, {
         processed: false,
@@ -685,9 +681,6 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       })
 
       // Should not process
-      expect(
-        await rToken.callStatic.vest(addr1.address, await rToken.endIdForVest(addr1.address))
-      ).to.equal(0)
       await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
 
       // Check previous minting was not processed
@@ -802,11 +795,11 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Set automine to true again
       await hre.network.provider.send('evm_setAutomine', [true])
 
-      // Process issuances
-      expect(
-        await rToken.callStatic.vest(addr1.address, await rToken.endIdForVest(addr1.address))
-      ).to.equal(0)
-      await rToken.callStatic.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      // Process issuances again, should not change anything
+      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.mul(2))
+      expect(await rToken.balanceOf(rToken.address)).to.equal(0)
+      expect(await facade.callStatic.totalAssetValue()).to.equal(issueAmount.mul(2))
     })
 
     it('Should move issuances to next block if exceeds issuance limit', async function () {
@@ -858,7 +851,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await token2.connect(addr1).approve(rToken.address, initialBal)
       await token3.connect(addr1).approve(rToken.address, initialBal)
 
-      const quotes: BigNumber[] = await rToken.connect(addr1).callStatic.issue(issueAmount)
+      const quotes: BigNumber[] = await facade.connect(addr1).callStatic.issue(issueAmount)
       const expectedTkn0: BigNumber = quotes[0]
       const expectedTkn1: BigNumber = quotes[1]
       const expectedTkn2: BigNumber = quotes[2]
@@ -911,7 +904,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await token2.connect(addr1).approve(rToken.address, initialBal)
       await token3.connect(addr1).approve(rToken.address, initialBal)
 
-      const quotes: BigNumber[] = await rToken.connect(addr1).callStatic.issue(issueAmount)
+      const quotes: BigNumber[] = await facade.connect(addr1).callStatic.issue(issueAmount)
 
       // Issue rTokens
       await rToken.connect(addr1).issue(issueAmount)

--- a/test/Recapitalization.test.ts
+++ b/test/Recapitalization.test.ts
@@ -226,7 +226,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token1 to default - 50% price reduction
@@ -238,8 +238,6 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         // Check state - No changes
         expect(await basketHandler.status()).to.equal(CollateralStatus.IFFY)
         expect(await basketHandler.fullyCapitalized()).to.equal(true)
-        // quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
-        // expect(quotes).to.eql(initialQuotes)
         await expectCurrentBacking({
           tokens: initialTokens,
           quantities: initialQuantities,
@@ -287,7 +285,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([initialQuotes[0], initialQuotes[2], initialQuotes[3], bn('0.25e18')])
       })
 
@@ -311,7 +309,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token2 to hard default - Decrease rate
@@ -351,7 +349,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([
           initialQuotes[0],
           initialQuotes[1],
@@ -377,7 +375,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token0 to default - 50% price reduction
@@ -417,7 +415,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([initialQuotes[1], bn('0.75e18')])
       })
 
@@ -437,7 +435,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token3 to hard default - Decrease rate (cDai)
@@ -462,7 +460,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         // Incremented the weight for token0
         expect(quotes).to.eql([bn('0.5e18'), initialQuotes[1], initialQuotes[2]])
       })
@@ -475,7 +473,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token1 to default - 50% price reduction
@@ -534,7 +532,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set Token2 to hard default - Decrease rate
@@ -572,7 +570,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([initialQuotes[0], initialQuotes[1], initialQuotes[3], bn('0.25e18')])
       })
 
@@ -592,7 +590,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Basket should switch
@@ -621,7 +619,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([initialQuotes[0], initialQuotes[2], initialQuotes[3], bn('0.25e18')])
       })
     })
@@ -705,7 +703,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set new EUR Token to default - 50% price reduction
@@ -744,7 +742,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: newTokens,
           quantities: newQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql([initialQuotes[0], bn('0.5e18')])
       })
 
@@ -764,7 +762,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
           tokens: initialTokens,
           quantities: initialQuantities,
         })
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         // Set the USD Token to default - 50% price reduction
@@ -2278,7 +2276,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         //  Check no Backup tokens available
@@ -2327,7 +2325,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         // Running auctions will trigger recapitalization - All balance will be redeemed
@@ -2417,7 +2415,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -2476,7 +2474,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -2522,7 +2520,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         //  Check no Backup tokens available
@@ -2582,7 +2580,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         // Running auctions will trigger recapitalization - All balance will be redeemed
@@ -2679,7 +2677,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -2752,7 +2750,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -2814,7 +2812,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -2848,7 +2846,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         //  Check no Backup tokens available
@@ -2891,7 +2889,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         // Running auctions will trigger recapitalization - All balance will be redeemed
@@ -2979,7 +2977,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3042,7 +3040,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3122,7 +3120,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3177,7 +3175,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('0.85'))
 
         // Check quotes - reduced by 15% as well (less collateral is required to match the new price)
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         const finalQuotes = newQuotes.map((q) => {
           return q.mul(85).div(100)
         })
@@ -3216,7 +3214,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(initialQuotes)
 
         //  Check no Backup tokens available
@@ -3259,7 +3257,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         // Running auctions will trigger recapitalization - All balance will be redeemed
@@ -3345,7 +3343,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3409,7 +3407,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3492,7 +3490,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3578,7 +3576,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('1'))
 
         // Check quotes
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         expect(quotes).to.eql(newQuotes)
 
         //  Check Backup tokens available
@@ -3644,7 +3642,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         expect(await rToken.price()).to.equal(fp('0.625'))
 
         // Check quotes - reduced by 15% as well (less collateral is required to match the new price)
-        quotes = await rToken.connect(addr1).callStatic.issue(bn('1e18'))
+        quotes = await facade.connect(addr1).callStatic.issue(bn('1e18'))
         const finalQuotes = newQuotes.map((q) => {
           return q.mul(625).div(1000)
         })
@@ -3666,7 +3664,6 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
     let initialTokens: string[]
     let initialQuantities: BigNumber[]
     let initialQuotes: BigNumber[]
-    let quotes: BigNumber[]
 
     beforeEach(async function () {
       issueAmount = bn('100e18')

--- a/test/Recapitalization.test.ts
+++ b/test/Recapitalization.test.ts
@@ -23,13 +23,7 @@ import {
   USDCMock,
 } from '../typechain'
 import { advanceTime, getLatestBlockTimestamp } from './utils/time'
-import {
-  Collateral,
-  defaultFixture,
-  IConfig,
-  Implementation,
-  IMPLEMENTATION,
-} from './fixtures'
+import { Collateral, defaultFixture, IConfig, Implementation, IMPLEMENTATION } from './fixtures'
 import snapshotGasCost from './utils/snapshotGasCost'
 import { expectTrade } from './utils/trades'
 
@@ -1288,7 +1282,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
         await aaveOracleInternal.setPrice(token0.address, bn('1.25e14'))
 
         // Running auctions will not trigger recapitalization until collateral defauls
-        await expect(facade.runAuctionsForAllTraders()).to.not.emit(backingManager, 'TradeStarted')
+        await expect(facade.runAuctionsForAllTraders()).to.be.revertedWith('basket defaulted')
 
         // Mark default as probable
         await collateral0.forceUpdates()

--- a/test/StRSR.test.ts
+++ b/test/StRSR.test.ts
@@ -290,9 +290,7 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
       // Approve transfer and stake
       await rsr.connect(addr1).approve(stRSR.address, amount)
-      await expect(stRSR.connect(addr1).stake(amount)).to.be.revertedWith(
-        'Component: system is paused'
-      )
+      await expect(stRSR.connect(addr1).stake(amount)).to.be.revertedWith('paused')
 
       // Check deposit not registered
       expect(await rsr.balanceOf(stRSR.address)).to.equal(0)
@@ -502,14 +500,10 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
         await main.connect(owner).pause()
 
         // Withdraw
-        await expect(stRSR.connect(addr1).withdraw(addr1.address, 1)).to.be.revertedWith(
-          'is paused'
-        )
+        await expect(stRSR.connect(addr1).withdraw(addr1.address, 1)).to.be.revertedWith('paused')
 
         // You cannot unstake also in this situation
-        await expect(stRSR.connect(addr2).unstake(amount2)).to.be.revertedWith(
-          'Component: system is paused'
-        )
+        await expect(stRSR.connect(addr2).unstake(amount2)).to.be.revertedWith('paused')
 
         // If unpaused should withdraw OK
         await main.connect(owner).unpause()


### PR DESCRIPTION
- Break out P1 `main.poke()` to only the necessary subroutines
- Remove return values from mutator functions and create replacements in Facade