### PR TITLE
StRSR gas optimizations

### DIFF
--- a/contracts/interfaces/IDeployer.sol
+++ b/contracts/interfaces/IDeployer.sol
@@ -24,11 +24,11 @@ struct DeploymentParams {
     RevenueShare dist; // revenue sharing splits between RToken and RSR
     //
     // === Rewards (Furnace + StRSR) ===
-    uint256 rewardPeriod; // {s} the atomic unit of rewards, determines # of exponential rounds
+    uint32 rewardPeriod; // {s} the atomic unit of rewards, determines # of exponential rounds
     int192 rewardRatio; // the fraction of available revenues that stRSR holders get each PayPeriod
     //
     // === StRSR ===
-    uint256 unstakingDelay; // {s} the "thawing time" of staked RSR before withdrawal
+    uint32 unstakingDelay; // {s} the "thawing time" of staked RSR before withdrawal
     //
     // === BackingManager ===
     uint256 tradingDelay; // {s} how long to wait until starting auctions after switching basket
@@ -81,9 +81,9 @@ interface IDeployer {
     function deploy(
         string calldata name,
         string calldata symbol,
-        string memory constitutionURI,
+        string calldata constitutionURI,
         address owner,
-        DeploymentParams memory params
+        DeploymentParams calldata params
     ) external returns (address);
 }
 

--- a/contracts/interfaces/IStRSR.sol
+++ b/contracts/interfaces/IStRSR.sol
@@ -65,8 +65,8 @@ interface IStRSR is IERC20PermitUpgradeable, IERC20MetadataUpgradeable, ICompone
     /// Emitted if all the RSR in the staking pool is seized and all balances are reset to zero.
     event AllBalancesReset(uint256 indexed newEra);
 
-    event UnstakingDelaySet(uint256 indexed oldVal, uint256 indexed newVal);
-    event RewardPeriodSet(uint256 indexed oldVal, uint256 indexed newVal);
+    event UnstakingDelaySet(uint32 indexed oldVal, uint32 indexed newVal);
+    event RewardPeriodSet(uint32 indexed oldVal, uint32 indexed newVal);
     event RewardRatioSet(int192 indexed oldVal, int192 indexed newVal);
 
     // Initialization
@@ -74,8 +74,8 @@ interface IStRSR is IERC20PermitUpgradeable, IERC20MetadataUpgradeable, ICompone
         IMain main_,
         string memory name_,
         string memory symbol_,
-        uint256 unstakingDelay_,
-        uint256 rewardPeriod_,
+        uint32 unstakingDelay_,
+        uint32 rewardPeriod_,
         int192 rewardRatio_
     ) external;
 
@@ -108,17 +108,17 @@ interface IStRSR is IERC20PermitUpgradeable, IERC20MetadataUpgradeable, ICompone
 }
 
 interface TestIStRSR is IStRSR {
-    function rewardPeriod() external view returns (uint256);
+    function rewardPeriod() external view returns (uint32);
 
-    function setRewardPeriod(uint256) external;
+    function setRewardPeriod(uint32) external;
 
     function rewardRatio() external view returns (int192);
 
     function setRewardRatio(int192) external;
 
-    function unstakingDelay() external view returns (uint256);
+    function unstakingDelay() external view returns (uint32);
 
-    function setUnstakingDelay(uint256) external;
+    function setUnstakingDelay(uint32) external;
 
     function increaseAllowance(address, uint256) external returns (bool);
 

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -84,16 +84,16 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
     int192 private constant MIN_EXCHANGE_RATE = int192(1e9); // 1e-9
 
     // ==== Gov Params ====
-    uint256 public unstakingDelay;
-    uint256 public rewardPeriod;
+    uint32 public unstakingDelay;
+    uint32 public rewardPeriod;
     int192 public rewardRatio;
 
     function init(
         IMain main_,
         string memory name_,
         string memory symbol_,
-        uint256 unstakingDelay_,
-        uint256 rewardPeriod_,
+        uint32 unstakingDelay_,
+        uint32 rewardPeriod_,
         int192 rewardRatio_
     ) public initializer {
         __Component_init(main_);
@@ -483,13 +483,13 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
 
     // ==== Gov Param Setters ====
 
-    function setUnstakingDelay(uint256 val) external onlyOwner {
+    function setUnstakingDelay(uint32 val) external onlyOwner {
         emit UnstakingDelaySet(unstakingDelay, val);
         unstakingDelay = val;
         require(rewardPeriod * 2 <= unstakingDelay, "unstakingDelay/rewardPeriod incompatible");
     }
 
-    function setRewardPeriod(uint256 val) external onlyOwner {
+    function setRewardPeriod(uint32 val) external onlyOwner {
         emit RewardPeriodSet(rewardPeriod, val);
         rewardPeriod = val;
         require(rewardPeriod * 2 <= unstakingDelay, "unstakingDelay/rewardPeriod incompatible");

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -55,6 +55,9 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
     uint256 internal totalStakes; // Total of all stakes {qStakes}
     uint256 internal stakeRSR; // Amount of RSR backing all stakes {qRSR}
 
+    // ==== Unstaking Gov Param ====
+    uint32 public unstakingDelay;
+
     // Drafts: share of the withdrawing tokens. Not transferrable.
     // Draft queues by account. Handle only through pushDrafts() and withdraw(). Indexed by era.
     mapping(uint256 => mapping(address => CumulativeDraft[])) public draftQueues;
@@ -64,9 +67,6 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
 
     // ERC20 allowances of stakes
     mapping(address => mapping(address => uint256)) private allowances;
-
-    // {seconds} The last time stRSR paid out rewards to stakers
-    uint256 internal payoutLastPaid;
 
     // {qRSR} How much reward RSR was held the last time rewards were paid out
     uint256 internal rsrRewardsAtLastPayout;
@@ -80,25 +80,26 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
     // Min exchange rate {qRSR/qStRSR}
     int192 private constant MIN_EXCHANGE_RATE = int192(1e9); // 1e-9
 
-    // ==== Gov Params ====
-    uint256 public unstakingDelay;
-    uint256 public rewardPeriod;
+    // {seconds} The last time stRSR paid out rewards to stakers
+    uint32 internal payoutLastPaid;
+
+    // ==== Reward Gov Params ====
+    uint32 public rewardPeriod;
     int192 public rewardRatio;
 
     function init(
         IMain main_,
-        string memory name_,
-        string memory symbol_,
-        uint256 unstakingDelay_,
-        uint256 rewardPeriod_,
+        string calldata name_,
+        string calldata symbol_,
+        uint32 unstakingDelay_,
+        uint32 rewardPeriod_,
         int192 rewardRatio_
-    ) public initializer {
+    ) external initializer {
         __Component_init(main_);
         __EIP712_init(name_, "1");
         _name = name_;
         _symbol = symbol_;
-        era = 0;
-        payoutLastPaid = block.timestamp;
+        payoutLastPaid = uint32(block.timestamp);
         rsrRewardsAtLastPayout = main_.rsr().balanceOf(address(this));
         unstakingDelay = unstakingDelay_;
         rewardPeriod = rewardPeriod_;
@@ -214,7 +215,7 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
         if (block.timestamp < payoutLastPaid + rewardPeriod) return;
         int192 initialExchangeRate = exchangeRate();
 
-        uint256 numPeriods = (block.timestamp - payoutLastPaid) / rewardPeriod;
+        uint32 numPeriods = (uint32(block.timestamp) - payoutLastPaid) / rewardPeriod;
 
         // Paying out the ratio r, N times, equals paying out the ratio (1 - (1-r)^N) 1 time.
         int192 payoutRatio = FIX_ONE.minus(FIX_ONE.minus(rewardRatio).powu(numPeriods));
@@ -518,13 +519,13 @@ contract StRSRP1 is IStRSR, ComponentP1, EIP712Upgradeable {
 
     // ==== Gov Param Setters ====
 
-    function setUnstakingDelay(uint256 val) external onlyOwner {
+    function setUnstakingDelay(uint32 val) external onlyOwner {
         emit UnstakingDelaySet(unstakingDelay, val);
         unstakingDelay = val;
         require(rewardPeriod * 2 <= unstakingDelay, "unstakingDelay/rewardPeriod incompatible");
     }
 
-    function setRewardPeriod(uint256 val) external onlyOwner {
+    function setRewardPeriod(uint32 val) external onlyOwner {
         emit RewardPeriodSet(rewardPeriod, val);
         rewardPeriod = val;
         require(rewardPeriod * 2 <= unstakingDelay, "unstakingDelay/rewardPeriod incompatible");

--- a/test/StRSR.test.ts
+++ b/test/StRSR.test.ts
@@ -469,7 +469,7 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
       let amount3: BigNumber
 
       beforeEach(async () => {
-        stkWithdrawalDelay = (await stRSR.unstakingDelay()).toNumber()
+        stkWithdrawalDelay = bn(await stRSR.unstakingDelay()).toNumber()
 
         // Perform stake
         amount1 = bn('1e18')
@@ -1542,13 +1542,21 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
       if (rsrAccreted.gt(0)) {
         await rsr.connect(owner).mint(stRSR.address, rsrAccreted)
         await stRSR.connect(owner).setRewardRatio(fp('1'))
-        await advanceTime((await stRSR.rewardPeriod()).add(1).toString())
+        await advanceTime(
+          bn(await stRSR.rewardPeriod())
+            .add(1)
+            .toString()
+        )
         await expect(stRSR.payoutRewards())
           .to.emit(stRSR, 'ExchangeRateSet')
           .withArgs(fp('1'), fp('1'))
         // first payout only registers the mint
 
-        await advanceTime((await stRSR.rewardPeriod()).add(1).toString())
+        await advanceTime(
+          bn(await stRSR.rewardPeriod())
+            .add(1)
+            .toString()
+        )
         await expect(stRSR.payoutRewards())
         // now the mint has been fully paid out
       }
@@ -1607,11 +1615,11 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
     const rsrRewards = [bn('1e29'), bn('0'), bn('1e18')]
 
-    // max: // 2^40 - 1
-    const unstakingDelays = [bn('1099511627775'), bn('0'), bn('604800')]
+    // max: // 2^32 - 1
+    const unstakingDelays = [bn('4294967295'), bn('0'), bn('604800')]
 
-    // max: // 2^40 - 1
-    const rewardPeriods = [bn('1099511627775'), bn('1'), bn('604800')]
+    // max: // 2^32 - 1
+    const rewardPeriods = [bn('4294967295'), bn('1'), bn('604800')]
 
     const rewardRatios = [fp('1'), fp('0'), fp('0.02284')]
 


### PR DESCRIPTION
* Adds packing of variables for gas optimization. Mainly benefits `payoutrewards()` which is used in multiple functions.
* This implies changing timestamps to `uint32`
* Included as well the changes of removing `force.updates()` from unstaking.
* Here I attach the gas analysis for these changes:

![image](https://user-images.githubusercontent.com/56316686/165086701-7c1ef008-c041-4391-bea9-f884fcece4d8.png)
