### PR TITLE
Reduce contract size- Backing Manager

### DIFF
--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/libraries/Fixed.sol";
 import "./IComponent.sol";
 import "./ITrading.sol";
 


### PR DESCRIPTION
* Moves two functions from `BackingManagerP1` to the external library `TradingLibP1`.
* Reduces the contract to the accepted size
* all tests pass successfully.