### PR TITLE
Poke refactor

### DIFF
--- a/contracts/Facade.sol
+++ b/contracts/Facade.sol
@@ -8,7 +8,6 @@ import "contracts/interfaces/IAssetRegistry.sol";
 import "contracts/interfaces/IFacade.sol";
 import "contracts/interfaces/IRToken.sol";
 import "contracts/interfaces/IMain.sol";
-import "contracts/p0/Main.sol";
 import "contracts/libraries/Fixed.sol";
 
 /**
@@ -22,21 +21,20 @@ import "contracts/libraries/Fixed.sol";
 contract Facade is Initializable, IFacade {
     using FixLib for int192;
 
-    MainP0 public main;
+    IMain public main;
 
-    constructor(address main_) {
+    constructor(IMain main_) {
         init(main_);
     }
 
-    function init(address main_) public initializer {
-        main = MainP0(main_);
+    function init(IMain main_) public initializer {
+        main = main_;
     }
 
     /// Prompt all traders to run auctions
     /// Relatively gas-inefficient, shouldn't be used in production. Use multicall instead
     /// @custom:action
     function runAuctionsForAllTraders() external {
-        main.poke();
         IBackingManager backingManager = main.backingManager();
         IRevenueTrader rsrTrader = main.rsrTrader();
         IRevenueTrader rTokenTrader = main.rTokenTrader();

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -16,11 +16,6 @@ abstract contract Pausable is OwnableUpgradeable, IPausable {
         paused = true;
     }
 
-    modifier notPaused() {
-        require(!paused, "paused");
-        _;
-    }
-
     function pause() external {
         require(_msgSender() == _pauser || _msgSender() == owner(), "only pauser or owner");
         emit PausedSet(paused, true);

--- a/contracts/fuzz/Utils.sol
+++ b/contracts/fuzz/Utils.sol
@@ -7,7 +7,7 @@ import "contracts/plugins/mocks/GnosisMock.sol";
 import "contracts/plugins/mocks/ComptrollerMock.sol";
 import "contracts/plugins/mocks/AaveLendingPoolMock.sol";
 import "contracts/plugins/mocks/AaveLendingAddrProviderMock.sol";
-import "contracts/p0/aux/Deployer.sol";
+import "contracts/p0/Deployer.sol";
 
 function defaultParams() pure returns (DeploymentParams memory params) {
     params = DeploymentParams({

--- a/contracts/p0/Deployer.sol
+++ b/contracts/p0/Deployer.sol
@@ -149,7 +149,7 @@ contract DeployerP0 is IDeployer {
         main.transferOwnership(owner);
 
         // Facade
-        IFacade facade = new Facade(address(main));
+        IFacade facade = new Facade(main);
         emit RTokenCreated(main, components.rToken, components.stRSR, facade, owner);
         return (address(main));
     }

--- a/contracts/p1/Deployer.sol
+++ b/contracts/p1/Deployer.sol
@@ -215,7 +215,7 @@ contract DeployerP1 is IDeployer {
 
         // Facade
         Facade facade = Facade(address(implementations.facade).clone());
-        facade.init(address(main));
+        facade.init(main);
         emit RTokenCreated(main, components.rToken, components.stRSR, facade, owner);
         return (address(main));
     }

--- a/contracts/p1/Main.sol
+++ b/contracts/p1/Main.sol
@@ -20,9 +20,11 @@ contract MainP1 is Initializable, ContextUpgradeable, Pausable, UUPSUpgradeable,
     // solhint-disable-next-line no-empty-blocks
     constructor() initializer {}
 
-    // solhint-disable-next-line no-empty-blocks
     function poke() external virtual {
-        // TODO remove? only adds extra bytecode to deployment, might be okay
+        // We think these are totally order-independent.
+        assetRegistry.forceUpdates();
+        furnace.melt();
+        if (!paused) stRSR.payoutRewards();
     }
 
     function owner() public view override(IMain, OwnableUpgradeable) returns (address) {


### PR DESCRIPTION
* Adds `poke` to P1
* Facade use of interface and not P0 contract
* Removes unused code