### PR TITLE
Feat coverage in P1

### DIFF
--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -217,12 +217,9 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     function price() external view returns (int192 p) {
         uint256 length = basket.erc20s.length;
         for (uint256 i = 0; i < length; ++i) {
-            try main.assetRegistry().toColl(basket.erc20s[i]) returns (ICollateral coll) {
-                if (coll.status() != CollateralStatus.DISABLED) {
-                    p = p.plus(coll.price().mul(quantity(basket.erc20s[i])));
-                }
-            } catch {
-                continue;
+            ICollateral coll = main.assetRegistry().toColl(basket.erc20s[i]);
+            if (coll.status() != CollateralStatus.DISABLED) {
+                p = p.plus(coll.price().mul(quantity(basket.erc20s[i])));
             }
         }
     }

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -383,7 +383,7 @@ contract RTokenP1 is ComponentP1, IRewardable, ERC20Upgradeable, ERC20PermitUpgr
                 IERC20Upgradeable(queue.tokens[i]).safeTransfer(account, rightItem.deposits[i]);
             }
         } else {
-            IssueItem storage leftItem = queue.items[queue.left];
+            IssueItem storage leftItem = queue.items[queue.left - 1];
             for (uint256 i = 0; i < queue.tokens.length; ++i) {
                 IERC20Upgradeable(queue.tokens[i]).safeTransfer(
                     account,

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -798,7 +798,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(totalValue)
       expect(await facade.callStatic.totalAssetValue()).to.equal(totalValue)
     })
-    
+
     it('Should allow multiple issuances in the same block', async function () {
       // Provide approvals
       await token0.connect(addr1).approve(rToken.address, initialBal)


### PR DESCRIPTION
* Increase coverage in `BasketHandler` and `RToken`.
* Removes unreachable `catch` block (Basket Handler)
* Fixes -1 type of error in RToken `refundSpan` and adds a test for this case.
* Adds a test for the binary search in `endIdForVest`
* Adds a test for the binary search in `endIfForWithraw`
