### PR TITLE
better .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ ETHERSCAN_API_KEY=ABC123ABC123ABC123ABC123ABC123ABC1
 SLOW=1
 
 # Run tests and scripts using Mainnet forking - required for integration tests
-FORK=1
+# FORK=1
 
 # Block to use as default for mainnet forking
 MAINNET_BLOCK=14916729
@@ -33,4 +33,4 @@ MAINNET_BLOCK=14916729
 PROTO_IMPL=0
 
 # Run gas reporter and specific gas tests, if truthy
-REPORT_GAS=1
+# REPORT_GAS=1


### PR DESCRIPTION
These env vars cause `yarn test:fast` to fail (at least on my machine).

Better to have them unset so new developers (like me) can get the unit tests running faster.