### PR TITLE
Final coverage tests

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,0 +1,32 @@
+# Test Coverage
+
+We aim to reach in this project 100% test coverage of `P1` (Production version) through our  *unit*, *scenario*, and *integration* tests. Because we designed our tests to run and be compatible with both versions (P0 and P1) we mainly use the `public` interface of each contract in our test cases, and we rely on mocks only when strictly required. 
+
+While working on these tests, we were able to identify some checks and validations in our contracts that would produce always the same outcome and thus, could be removed if desired. However, we decided to leave them (though may be show as uncovered) to provide additional security and alert developers during future upgrades/modifications to the code.
+
+Below we provide a detailed list of these checks to serve as a reference when running `coverage` for this project.
+
+## Uncovered sections
+
+### contracts/p1/StRSR.sol:StRSRP1
+
+- `_burn()`:  Both require statements that check for `account != address(0)` and `accountBalance >= amount` will never be false. Within the `unstake()` function, right before calling `_burn()` we are validating the user has enough balance which covers these two validations, as the zero address will never have a positive balance. No other calls to `_burn` are included in the contract.
+
+### contracts/p1/RToken.sol:RTokenP1
+- `refundSpan()`: The revert stamement `revert("Bad refundSpan")` will never occur with the current version of the code, as this is an `internal` function and the parameters for `left` and `right` are always stored in the contract and maintained with valid values doing the entire lifecycle.
+
+### contracts/p1/mixins/TradingLib.sol:TradingLibP1
+
+- `nextTradePair()`: 
+    * The check for `bal.lt(surplusAmt)` when calculating the *surplus* component, will never be *true*, because `surplusAmt` can be at most equal to `bal` in the current version. But for additional security the check is maintained to make sure we never revert if for some reason these occurs after implementing changes to how `surplusAmt` is calculated.
+    
+    * The check at the end for `rsrAvailable.gt(rsrAsset.minTradeSize())` will never be *false*, because if the RSR balances is below the `minTradeSize` will be discarded previously as part of the `basket.top` and `basket.bottom` calculations. But we will leave this as an extra safety check. Could be tested if the values of the `BasketRange` are manipulated in a way to force this situation but would not occur when using the contracts through its `public` interface.
+            
+### P0 contracts
+
+There might be a slighly lower coverage for `P0` due to differences in the implementation which are not worth tackling with specific test cases, but we make sure it is also very close to full coverage, and that all relevant paths and logic statements are covered as well.
+
+- `RTokenP0.vest()`: The final check `if (totalVested > 0)` will always be *true* because if there are no issuances to process it will return at the top of the function with the initial `endIf` validation. And if the issuances are not ready to vest they would revert with `Issuance not ready`. So at that point in the code there is always something that was processed and vested successfully.
+
+
+      

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -429,6 +429,37 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await expect(rToken.connect(addr1).cancel(1, true)).to.not.emit(rToken, 'IssuancesCanceled')
     })
 
+    it('Should be able to refund multiple issuances when calling vest if basket changed', async function () {
+      const issueAmount: BigNumber = bn('20000e18')
+
+      // Start issuances
+      await token0.connect(addr1).approve(rToken.address, issueAmount)
+      await token1.connect(addr1).approve(rToken.address, issueAmount)
+      await token2.connect(addr1).approve(rToken.address, issueAmount)
+      await token3.connect(addr1).approve(rToken.address, issueAmount)
+      await rToken.connect(addr1).issue(issueAmount)
+
+      await token0.connect(addr1).approve(rToken.address, issueAmount)
+      await token1.connect(addr1).approve(rToken.address, issueAmount)
+      await token2.connect(addr1).approve(rToken.address, issueAmount)
+      await token3.connect(addr1).approve(rToken.address, issueAmount)
+      await rToken.connect(addr1).issue(issueAmount)
+
+      await token0.connect(addr1).approve(rToken.address, issueAmount)
+      await token1.connect(addr1).approve(rToken.address, issueAmount)
+      await token2.connect(addr1).approve(rToken.address, issueAmount)
+      await token3.connect(addr1).approve(rToken.address, issueAmount)
+      await rToken.connect(addr1).issue(issueAmount)
+
+      // Refresh from owner should succeed
+      await basketHandler.connect(owner).refreshBasket()
+
+      // Vest should return tokens
+      await expect(rToken.connect(addr1).vest(addr1.address, 3))
+        .to.emit(rToken, 'IssuancesCanceled')
+        .withArgs(addr1.address, 0, 3, issueAmount.mul(3))
+    })
+
     it('Should be able to cancel vesting if paused', async function () {
       const issueAmount: BigNumber = bn('100000e18')
 

--- a/test/Recapitalization.test.ts
+++ b/test/Recapitalization.test.ts
@@ -8,6 +8,7 @@ import { BN_SCALE_FACTOR, CollateralStatus, ZERO_ADDRESS } from '../common/const
 import { expectEvents } from '../common/events'
 import { bn, fp, pow10, toBNDecimals } from '../common/numbers'
 import {
+  Asset,
   ATokenFiatCollateral,
   CTokenMock,
   ERC20Mock,
@@ -37,6 +38,7 @@ import {
 import snapshotGasCost from './utils/snapshotGasCost'
 import { expectTrade } from './utils/trades'
 import { setOraclePrice } from './utils/oracles'
+import { connect } from 'http2'
 
 const createFixtureLoader = waffle.createFixtureLoader
 
@@ -53,6 +55,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
 
   // Non-backing assets
   let rsr: ERC20Mock
+  let rsrAsset: Asset
   let aaveToken: ERC20Mock
 
   // Trading
@@ -124,6 +127,7 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
       // Deploy fixture
     ;({
       rsr,
+      rsrAsset,
       aaveToken,
       erc20s,
       collateral,
@@ -1595,6 +1599,150 @@ describe(`Recapitalization - P${IMPLEMENTATION}`, () => {
 
         // Check price in USD of the current RToken - Remains the same
         expect(await rTokenAsset.price()).to.equal(fp('1'))
+      })
+
+      it('Should recapitalize correctly in case of default - MinTradeSize too large', async () => {
+        // Register Collateral
+        await assetRegistry.connect(owner).register(backupCollateral1.address)
+
+        // Set backup configuration - USDT as backup
+        await basketHandler
+          .connect(owner)
+          .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(1), [backupToken1.address])
+
+        // Check initial state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(true)
+        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
+        expect(await backupToken1.balanceOf(backingManager.address)).to.equal(0)
+        expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+        // Check price in USD of the current RToken
+        expect(await rTokenAsset.price()).to.equal(fp('1'))
+
+        // Check stakes
+        //expect(await rsr.balanceOf(stRSR.address)).to.equal(await rsrAsset.minTradeSize())
+        //expect(await stRSR.balanceOf(addr1.address)).to.equal(await rsrAsset.minTradeSize())
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(stakeAmount)
+        expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmount)
+
+        // Set Token0 to default - 50% price reduction
+        await setOraclePrice(collateral0.address, bn('0.5e8'))
+
+        // Mark default as probable
+        await assetRegistry.refresh()
+        expect(await basketHandler.status()).to.equal(CollateralStatus.IFFY)
+
+        // Advance time post collateral's default delay
+        await advanceTime((await collateral0.delayUntilDefault()).toString())
+
+        // Confirm default and trigger basket switch
+        await assetRegistry.refresh()
+        await basketHandler.refreshBasket()
+
+        // Check new state after basket switch
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(false)
+        // Asset value is zero, the only collateral held is defaulted
+        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+        expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
+        expect(await backupToken1.balanceOf(backingManager.address)).to.equal(0)
+        expect(await rToken.totalSupply()).to.equal(issueAmount)
+        expect(await rTokenAsset.price()).to.equal(fp('0'))
+
+        // Running auctions will trigger recapitalization - only half of the balance is available
+        const sellAmt: BigNumber = await token0.balanceOf(backingManager.address)
+
+        await expect(facade.runAuctionsForAllTraders(rToken.address))
+          .to.emit(backingManager, 'TradeStarted')
+          .withArgs(anyValue, token0.address, backupToken1.address, sellAmt, bn('0'))
+
+        let auctionTimestamp = await getLatestBlockTimestamp()
+
+        // Token0 -> Backup Token Auction
+        await expectTrade(backingManager, {
+          sell: token0.address,
+          buy: backupToken1.address,
+          endTime: auctionTimestamp + Number(config.auctionLength),
+          externalId: bn('0'),
+        })
+
+        // Check state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(false)
+        // Asset value is zero, the only collateral held is defaulted
+        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+        expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount.sub(sellAmt))
+        expect(await backupToken1.balanceOf(backingManager.address)).to.equal(0)
+        expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+        // Check price in USD of the current RToken - no backing held yet
+        expect(await rTokenAsset.price()).to.equal(fp('0'))
+
+        // Perform Mock Bids (addr1 has balance)
+        // Assume fair price, get half of the tokens (because price reduction was 50%)
+        const minBuyAmt: BigNumber = sellAmt.div(2)
+        await backupToken1.connect(addr1).approve(gnosis.address, minBuyAmt)
+        await gnosis.placeBid(0, {
+          bidder: addr1.address,
+          sellAmount: sellAmt,
+          buyAmount: minBuyAmt,
+        })
+
+        // Advance time till auction ended
+        await advanceTime(config.auctionLength.add(100).toString())
+
+        // Deploy new RSR Asset with larger min trade size
+        const AssetFactory: ContractFactory = await ethers.getContractFactory('Asset', {
+          libraries: { OracleLib: oracleLib.address },
+        })
+        const newTradingRange = JSON.parse(JSON.stringify(config.rTokenTradingRange))
+        newTradingRange.minAmt = stakeAmount.div(2).sub(1)
+        newTradingRange.minVal = stakeAmount.div(2).sub(1)
+        const newRSRAsset: Asset = <Asset>(
+          await AssetFactory.deploy(
+            await rsrAsset.chainlinkFeed(),
+            rsr.address,
+            ZERO_ADDRESS,
+            newTradingRange,
+            await rsrAsset.oracleTimeout()
+          )
+        )
+
+        // Swap RSR Asset
+        await assetRegistry.connect(owner).swapRegistered(newRSRAsset.address)
+
+        // Ru auctions - NO RSR Auction launched
+        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+          {
+            contract: backingManager,
+            name: 'TradeSettled',
+            args: [anyValue, token0.address, backupToken1.address, sellAmt, minBuyAmt],
+            emitted: true,
+          },
+          {
+            contract: backingManager,
+            name: 'TradeStarted',
+            emitted: false,
+          },
+        ])
+
+        //  Should not have seized RSR
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(stakeAmount)
+
+        // Check state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(true)
+        expect(await token0.balanceOf(backingManager.address)).to.equal(0) // no dust
+
+        // Should have half of the value
+        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.div(2))
+        expect(await backupToken1.balanceOf(backingManager.address)).to.equal(minBuyAmt)
+        expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+        // Check price in USD of the current RToken - Haircut of 50%
+        expect(await rTokenAsset.price()).to.equal(fp('0.5'))
       })
 
       it('Should recapitalize correctly in case of default - Using RSR for remainder - Multiple tokens and auctions - No overshoot', async () => {

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -69,6 +69,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
   // Non-backing assets
   let rsr: ERC20Mock
   let compToken: ERC20Mock
+  let compAsset: Asset
   let compoundMock: ComptrollerMock
   let aaveToken: ERC20Mock
 
@@ -125,6 +126,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
     ;({
       rsr,
       compToken,
+      compAsset,
       aaveToken,
       compoundMock,
       erc20s,
@@ -549,6 +551,92 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rsr.balanceOf(stRSR.address)).to.equal(minBuyAmt)
         // Furnace
         expect(await rToken.balanceOf(furnace.address)).to.equal(minBuyAmtRToken)
+      })
+
+      it('Should not auction 1qTok - Amount too small', async () => {
+        // Set min tradesizefor COMP to 1 qtok
+        const newTradingRange = JSON.parse(JSON.stringify(config.rTokenTradingRange))
+        newTradingRange.minAmt = 1
+        newTradingRange.minVal = 1
+
+        const newCOMPAsset = await AssetFactory.deploy(
+          await compAsset.chainlinkFeed(),
+          compToken.address,
+          ZERO_ADDRESS,
+          newTradingRange,
+          await compAsset.oracleTimeout()
+        )
+
+        // Swap COMP Asset
+        await assetRegistry.connect(owner).swapRegistered(newCOMPAsset.address)
+
+        // Set f = 1
+        await expect(
+          distributor
+            .connect(owner)
+            .setDistribution(FURNACE_DEST, { rTokenDist: bn(0), rsrDist: bn(0) })
+        )
+          .to.emit(distributor, 'DistributionSet')
+          .withArgs(FURNACE_DEST, bn(0), bn(0))
+
+        // Avoid dropping 20 qCOMP by making there be exactly 1 distribution share.
+        await expect(
+          distributor
+            .connect(owner)
+            .setDistribution(STRSR_DEST, { rTokenDist: bn(0), rsrDist: bn(1) })
+        )
+          .to.emit(distributor, 'DistributionSet')
+          .withArgs(STRSR_DEST, bn(0), bn(1))
+
+        // Set COMP tokens as reward -1 qtok
+        rewardAmountCOMP = bn(1)
+
+        // COMP Rewards - 1 qTok
+        await compoundMock.setRewards(backingManager.address, rewardAmountCOMP)
+
+        // Collect revenue
+        await expectEvents(backingManager.claimAndSweepRewards(), [
+          {
+            contract: backingManager,
+            name: 'RewardsClaimed',
+            args: [compToken.address, rewardAmountCOMP],
+            emitted: true,
+          },
+          {
+            contract: backingManager,
+            name: 'RewardsClaimed',
+            args: [aaveToken.address, bn(0)],
+            emitted: true,
+          },
+        ])
+
+        expect(await compToken.balanceOf(backingManager.address)).to.equal(rewardAmountCOMP)
+
+        // Check status of destinations at this point
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(0)
+        expect(await rToken.balanceOf(furnace.address)).to.equal(0)
+
+        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+          {
+            contract: rsrTrader,
+            name: 'TradeStarted',
+            emitted: false,
+          },
+          {
+            contract: rTokenTrader,
+            name: 'TradeStarted',
+            emitted: false,
+          },
+        ])
+
+        // Check no funds in Market, now in trader
+        expect(await compToken.balanceOf(gnosis.address)).to.equal(bn(0))
+        expect(await compToken.balanceOf(backingManager.address)).to.equal(bn(0))
+        expect(await compToken.balanceOf(rsrTrader.address)).to.equal(rewardAmountCOMP)
+
+        // Check destinations, nothing changed
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(0)
+        expect(await rToken.balanceOf(furnace.address)).to.equal(0)
       })
 
       it('Should claim AAVE and handle revenue auction correctly - small amount processed in single auction', async () => {

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -134,6 +134,14 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
     }
   }
 
+  // Only used for P1, checks the length of the draft queue
+  const expectDraftQueue = async (era: number, account: string, expectedValue: number) => {
+    if (IMPLEMENTATION == Implementation.P1) {
+      const stRSRP1 = <StRSRP1Votes>await ethers.getContractAt('StRSRP1Votes', stRSR.address)
+      expect(await stRSRP1.draftQueueLen(era, account)).to.equal(expectedValue)
+    } else return
+  }
+
   before('create fixture loader', async () => {
     ;[wallet] = (await ethers.getSigners()) as unknown as Wallet[]
     loadFixture = createFixtureLoader([wallet])
@@ -503,6 +511,9 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
       await expectWithdrawal(addr1.address, 0, { rsrAmount: amount1 })
 
+      // Check draftQueueLen
+      await expectDraftQueue(1, addr1.address, 1)
+
       // All staked funds withdrawn upfront
       expect(await stRSR.balanceOf(addr1.address)).to.equal(amount2)
 
@@ -518,6 +529,8 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
       await expectWithdrawal(addr1.address, 1, { rsrAmount: amount2 })
 
+      await expectDraftQueue(1, addr1.address, 2)
+
       // All staked funds withdrawn upfront
       expect(await stRSR.balanceOf(addr1.address)).to.equal(0)
 
@@ -532,6 +545,9 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
         .withArgs(0, 1, addr2.address, amount3, amount3, availableAt)
 
       await expectWithdrawal(addr2.address, 0, { rsrAmount: amount3 })
+
+      await expectDraftQueue(1, addr1.address, 2)
+      await expectDraftQueue(1, addr2.address, 1)
 
       // All staked funds withdrawn upfront
       expect(await stRSR.balanceOf(addr2.address)).to.equal(0)


### PR DESCRIPTION
* Adds all final tests required for full coverage (RToken, StRSR, TradingLib, etc)
* Adds a document explaining the uncovered lines and the reasoning behind it. If these 3/4 lines are commented in P1 we have full 100% coverage of all contracts.
* Coverage for P0 is also ~100%, except one minor non-relevant check in RToken (also documented)