### PR TITLE
Rtoken contract size

### DIFF
--- a/contracts/facade/Facade.sol
+++ b/contracts/facade/Facade.sol
@@ -27,7 +27,7 @@ contract Facade is IFacade {
     /// Returns zero bytes to indicate no action should be made
     /// @dev This function begins reverting due to blocksize constraints at ~400 registered assets
     /// @custom:static-call
-    function getActCalldata(IRToken rToken) external returns (address, bytes memory) {
+    function getActCalldata(RTokenP1 rToken) external returns (address, bytes memory) {
         IMain main = rToken.main();
         BackingManagerP1 backingManager = BackingManagerP1(address(main.backingManager()));
         BasketHandlerP1 basketHandler = BasketHandlerP1(address(main.basketHandler()));
@@ -184,138 +184,89 @@ contract Facade is IFacade {
 
     // ==============================================================
 
-    /// Prompt all traders to run auctions
-    /// Relatively gas-inefficient, shouldn't be used in production. Use multicall instead
-    function runAuctionsForAllTraders(IRToken rToken) external {
-        IMain main = rToken.main();
-        IBackingManager backingManager = main.backingManager();
-        IRevenueTrader rsrTrader = main.rsrTrader();
-        IRevenueTrader rTokenTrader = main.rTokenTrader();
-        IERC20[] memory erc20s = main.assetRegistry().erc20s();
-
-        for (uint256 i = 0; i < erc20s.length; i++) {
-            // BackingManager
-            ITrade trade = backingManager.trades(erc20s[i]);
-            if (address(trade) != address(0) && trade.canSettle()) {
-                backingManager.settleTrade(erc20s[i]);
-            }
-
-            // RSRTrader
-            trade = rsrTrader.trades(erc20s[i]);
-            if (address(trade) != address(0) && trade.canSettle()) {
-                rsrTrader.settleTrade(erc20s[i]);
-            }
-
-            // RTokenTrader
-            trade = rTokenTrader.trades(erc20s[i]);
-            if (address(trade) != address(0) && trade.canSettle()) {
-                rTokenTrader.settleTrade(erc20s[i]);
-            }
-        }
-
-        main.backingManager().manageTokens(erc20s);
-        for (uint256 i = 0; i < erc20s.length; i++) {
-            rsrTrader.manageToken(erc20s[i]);
-            rTokenTrader.manageToken(erc20s[i]);
-        }
-    }
-
-    /// Prompt all traders and the RToken itself to claim rewards and sweep to BackingManager
-    function claimRewards(IRToken rToken) external {
-        IMain main = rToken.main();
-        main.backingManager().claimAndSweepRewards();
-        main.rsrTrader().claimAndSweepRewards();
-        main.rTokenTrader().claimAndSweepRewards();
-        rToken.claimAndSweepRewards();
-    }
-
-    /// @return {qRTok} How many RToken `account` can issue given current holdings
-    /// @custom:static-call
-    function maxIssuable(IRToken rToken, address account) external returns (uint256) {
-        IMain main = rToken.main();
-        main.poke();
-        // {BU}
-
-        uint192 held = main.basketHandler().basketsHeldBy(account);
-        uint192 needed = rToken.basketsNeeded();
-
-        int8 decimals = int8(rToken.decimals());
-
-        // return {qRTok} = {BU} * {(1 RToken) qRTok/BU)}
-        if (needed.eq(FIX_ZERO)) return held.shiftl_toUint(decimals);
-
-        uint192 totalSupply = shiftl_toFix(rToken.totalSupply(), -decimals); // {rTok}
-
-        // {qRTok} = {BU} * {rTok} / {BU} * {qRTok/rTok}
-        return held.mulDiv(totalSupply, needed).shiftl_toUint(decimals);
-    }
-
-    /// @return tokens Array of all known ERC20 asset addreses.
-    /// @return amounts {qTok} Array of balance that the protocol holds of this current asset
-    /// @custom:static-call
-    function currentAssets(IRToken rToken)
+    /// @param account The account for the query
+    /// @return issuances All the pending RToken issuances for an account
+    /// @custom:view
+    function pendingIssuances(RTokenP1 rToken, address account)
         external
-        returns (address[] memory tokens, uint256[] memory amounts)
+        view
+        returns (Pending[] memory issuances)
     {
-        IMain main = rToken.main();
-        main.poke();
-
-        IAssetRegistry reg = main.assetRegistry();
-        IERC20[] memory erc20s = reg.erc20s();
-
-        tokens = new address[](erc20s.length);
-        amounts = new uint256[](erc20s.length);
-
-        for (uint256 i = 0; i < erc20s.length; i++) {
-            tokens[i] = address(erc20s[i]);
-            amounts[i] = erc20s[i].balanceOf(address(main.backingManager()));
+        (, uint256 left, uint256 right) = rToken.issueQueues(account);
+        issuances = new Pending[](right - left);
+        for (uint256 i = 0; i < right - left; i++) {
+            RTokenP1.IssueItem memory issueItem = rToken.issueItem(account, i + left);
+            uint256 diff = i + left == 0
+                ? issueItem.amtRToken
+                : issueItem.amtRToken - rToken.issueItem(account, i + left - 1).amtRToken;
+            issuances[i] = Pending(i + left, issueItem.when, diff);
         }
     }
 
-    /// @return total {UoA} An estimate of the total value of all assets held at BackingManager
-    /// @custom:static-call
-    function totalAssetValue(IRToken rToken) external returns (uint192 total) {
-        IMain main = rToken.main();
-        main.poke();
-        IAssetRegistry reg = main.assetRegistry();
-        address backingManager = address(main.backingManager());
+    /// @param account The account for the query
+    /// @return unstakings All the pending RToken issuances for an account
+    /// @custom:view
+    function pendingUnstakings(RTokenP1 rToken, address account)
+        external
+        view
+        returns (Pending[] memory unstakings)
+    {
+        StRSRP1Votes stRSR = StRSRP1Votes(address(rToken.main().stRSR()));
+        uint256 era = stRSR.currentEra();
+        uint256 left = stRSR.firstRemainingDraft(era, account);
+        uint256 right = stRSR.draftQueueLen(era, account);
 
-        IERC20[] memory erc20s = reg.erc20s();
-        for (uint256 i = 0; i < erc20s.length; i++) {
-            IAsset asset = reg.toAsset(erc20s[i]);
-            // Exclude collateral that has defaulted
-            if (
-                asset.isCollateral() &&
-                ICollateral(address(asset)).status() != CollateralStatus.DISABLED
-            ) {
-                total = total.plus(asset.bal(backingManager).mul(asset.price()));
+        unstakings = new Pending[](right - left);
+        for (uint256 i = 0; i < right - left; i++) {
+            (uint192 drafts, uint64 availableAt) = stRSR.draftQueues(era, account, i + left);
+
+            uint192 diff = drafts;
+            if (i + left > 0) {
+                (uint192 prevDrafts, ) = stRSR.draftQueues(era, account, i + left - 1);
+                diff = drafts - prevDrafts;
             }
+
+            unstakings[i] = Pending(i + left, availableAt, diff);
         }
     }
 
-    /// @custom:static-call
-    function issue(IRToken rToken, uint256 amount)
-        public
-        returns (address[] memory tokens, uint256[] memory deposits)
-    {
-        IMain main = rToken.main();
-        main.poke();
-        IRToken rTok = rToken;
-        IBasketHandler bh = main.basketHandler();
+    /// @return A non-inclusive ending index
+    function endIdForVest(RTokenP1 rToken, address account) external view returns (uint256) {
+        (uint256 queueLeft, uint256 queueRight) = rToken.queueBounds(account);
+        uint256 blockNumber = FIX_ONE_256 * block.number; // D18{block} = D18{1} * {block}
 
-        // Compute # of baskets to create `amount` qRTok
-        uint192 baskets = (rTok.totalSupply() > 0) // {BU}
-            ? rTok.basketsNeeded().muluDivu(amount, rTok.totalSupply()) // {BU * qRTok / qRTok}
-            : shiftl_toFix(amount, -int8(rTok.decimals())); // {qRTok / qRTok}
+        RTokenP1.IssueItem memory item;
 
-        (tokens, deposits) = bh.quote(baskets, CEIL);
+        // Handle common edge cases in O(1)
+        if (queueLeft == queueRight) return queueLeft;
+
+        item = rToken.issueItem(account, queueLeft);
+        if (blockNumber < item.when) return queueLeft;
+
+        item = rToken.issueItem(account, queueRight - 1);
+        if (item.when <= blockNumber) return queueRight;
+
+        // find left and right (using binary search where always left <= right) such that:
+        //     left == right - 1
+        //     queue[left].when <= block.timestamp
+        //     right == queueRight  or  block.timestamp < queue[right].when
+        uint256 left = queueLeft;
+        uint256 right = queueRight;
+        while (left < right - 1) {
+            uint256 test = (left + right) / 2;
+            // In this condition: D18{block} < D18{block}
+            item = rToken.issueItem(account, test);
+            if (item.when < blockNumber) left = test;
+            else right = test;
+        }
+        return right;
     }
 
     /// @return erc20s The ERC20 addresses in the current basket
     /// @return uoaShares {1} The proportion of the basket associated with each ERC20
     /// @return targets The bytes32 representations of the target unit associated with each ERC20
     /// @custom:static-call
-    function basketBreakdown(IRToken rToken)
+    function basketBreakdown(RTokenP1 rToken)
         external
         returns (
             address[] memory erc20s,
@@ -349,6 +300,8 @@ contract Facade is IFacade {
         }
     }
 
+    // ============
+
     /// @return tokens The addresses of the ERC20s backing the RToken
     function basketTokens(IRToken rToken) external view returns (address[] memory tokens) {
         IMain main = rToken.main();
@@ -359,6 +312,45 @@ contract Facade is IFacade {
     function stToken(IRToken rToken) external view returns (IStRSR stTokenAddress) {
         IMain main = rToken.main();
         stTokenAddress = main.stRSR();
+    }
+
+    /// @return {qRTok} How many RToken `account` can issue given current holdings
+    /// @custom:static-call
+    function maxIssuable(IRToken rToken, address account) external returns (uint256) {
+        IMain main = rToken.main();
+        main.poke();
+        // {BU}
+
+        uint192 held = main.basketHandler().basketsHeldBy(account);
+        uint192 needed = rToken.basketsNeeded();
+
+        int8 decimals = int8(rToken.decimals());
+
+        // return {qRTok} = {BU} * {(1 RToken) qRTok/BU)}
+        if (needed.eq(FIX_ZERO)) return held.shiftl_toUint(decimals);
+
+        uint192 totalSupply = shiftl_toFix(rToken.totalSupply(), -decimals); // {rTok}
+
+        // {qRTok} = {BU} * {rTok} / {BU} * {qRTok/rTok}
+        return held.mulDiv(totalSupply, needed).shiftl_toUint(decimals);
+    }
+
+    /// @custom:static-call
+    function issue(IRToken rToken, uint256 amount)
+        public
+        returns (address[] memory tokens, uint256[] memory deposits)
+    {
+        IMain main = rToken.main();
+        main.poke();
+        IRToken rTok = rToken;
+        IBasketHandler bh = main.basketHandler();
+
+        // Compute # of baskets to create `amount` qRTok
+        uint192 baskets = (rTok.totalSupply() > 0) // {BU}
+            ? rTok.basketsNeeded().muluDivu(amount, rTok.totalSupply()) // {BU * qRTok / qRTok}
+            : shiftl_toFix(amount, -int8(rTok.decimals())); // {qRTok / qRTok}
+
+        (tokens, deposits) = bh.quote(baskets, CEIL);
     }
 
     /// @return backing The worst-case collaterazation % the protocol will have after done trading
@@ -419,61 +411,5 @@ contract Facade is IFacade {
     /// @return {UoA/tok} The price of the RToken as given by the relevant RTokenAsset
     function price(IRToken rToken) external view returns (uint192) {
         return rToken.main().assetRegistry().toAsset(IERC20(address(rToken))).price();
-    }
-}
-
-/**
- * @title Facade
- * @notice An extension of the Facade specific to P1
- */
-contract FacadeP1 is Facade, IFacadeP1 {
-    // solhint-disable-next-line no-empty-blocks
-    constructor() Facade() {}
-
-    /// @param account The account for the query
-    /// @return issuances All the pending RToken issuances for an account
-    /// @custom:view
-    function pendingIssuances(IRToken rToken, address account)
-        external
-        view
-        returns (Pending[] memory issuances)
-    {
-        RTokenP1 rTok = RTokenP1(address(rToken));
-        (, uint256 left, uint256 right) = rTok.issueQueues(account);
-        issuances = new Pending[](right - left);
-        for (uint256 i = 0; i < right - left; i++) {
-            RTokenP1.IssueItem memory issueItem = rTok.issueItem(account, i + left);
-            uint256 diff = i + left == 0
-                ? issueItem.amtRToken
-                : issueItem.amtRToken - rTok.issueItem(account, i + left - 1).amtRToken;
-            issuances[i] = Pending(i + left, issueItem.when, diff);
-        }
-    }
-
-    /// @param account The account for the query
-    /// @return unstakings All the pending RToken issuances for an account
-    /// @custom:view
-    function pendingUnstakings(IRToken rToken, address account)
-        external
-        view
-        returns (Pending[] memory unstakings)
-    {
-        StRSRP1Votes stRSR = StRSRP1Votes(address(rToken.main().stRSR()));
-        uint256 era = stRSR.currentEra();
-        uint256 left = stRSR.firstRemainingDraft(era, account);
-        uint256 right = stRSR.draftQueueLen(era, account);
-
-        unstakings = new Pending[](right - left);
-        for (uint256 i = 0; i < right - left; i++) {
-            (uint192 drafts, uint64 availableAt) = stRSR.draftQueues(era, account, i + left);
-
-            uint192 diff = drafts;
-            if (i + left > 0) {
-                (uint192 prevDrafts, ) = stRSR.draftQueues(era, account, i + left - 1);
-                diff = drafts - prevDrafts;
-            }
-
-            unstakings[i] = Pending(i + left, availableAt, diff);
-        }
     }
 }

--- a/contracts/facade/FacadeTest.sol
+++ b/contracts/facade/FacadeTest.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "contracts/interfaces/IAsset.sol";
+import "contracts/interfaces/IAssetRegistry.sol";
+import "contracts/interfaces/IFacadeTest.sol";
+import "contracts/interfaces/IRToken.sol";
+import "contracts/interfaces/IStRSR.sol";
+import "contracts/libraries/Fixed.sol";
+
+/**
+ * @title FacadeTest
+ * @notice A facade that is useful for driving/querying the system during testing.
+ *   These functions should be generic to both P0 and P1.
+ *
+ * @custom:static-call - Use ethers callStatic() in order to get result after update
+ */
+contract FacadeTest is IFacadeTest {
+    using FixLib for uint192;
+
+    /// Prompt all traders to run auctions
+    /// Relatively gas-inefficient, shouldn't be used in production. Use multicall instead
+    function runAuctionsForAllTraders(IRToken rToken) external {
+        IMain main = rToken.main();
+        IBackingManager backingManager = main.backingManager();
+        IRevenueTrader rsrTrader = main.rsrTrader();
+        IRevenueTrader rTokenTrader = main.rTokenTrader();
+        IERC20[] memory erc20s = main.assetRegistry().erc20s();
+
+        for (uint256 i = 0; i < erc20s.length; i++) {
+            // BackingManager
+            ITrade trade = backingManager.trades(erc20s[i]);
+            if (address(trade) != address(0) && trade.canSettle()) {
+                backingManager.settleTrade(erc20s[i]);
+            }
+
+            // RSRTrader
+            trade = rsrTrader.trades(erc20s[i]);
+            if (address(trade) != address(0) && trade.canSettle()) {
+                rsrTrader.settleTrade(erc20s[i]);
+            }
+
+            // RTokenTrader
+            trade = rTokenTrader.trades(erc20s[i]);
+            if (address(trade) != address(0) && trade.canSettle()) {
+                rTokenTrader.settleTrade(erc20s[i]);
+            }
+        }
+
+        main.backingManager().manageTokens(erc20s);
+        for (uint256 i = 0; i < erc20s.length; i++) {
+            rsrTrader.manageToken(erc20s[i]);
+            rTokenTrader.manageToken(erc20s[i]);
+        }
+    }
+
+    /// Prompt all traders and the RToken itself to claim rewards and sweep to BackingManager
+    function claimRewards(IRToken rToken) external {
+        IMain main = rToken.main();
+        main.backingManager().claimAndSweepRewards();
+        main.rsrTrader().claimAndSweepRewards();
+        main.rTokenTrader().claimAndSweepRewards();
+        rToken.claimAndSweepRewards();
+    }
+
+    /// @return total {UoA} An estimate of the total value of all assets held at BackingManager
+    /// @custom:static-call
+    function totalAssetValue(IRToken rToken) external returns (uint192 total) {
+        IMain main = rToken.main();
+        main.poke();
+        IAssetRegistry reg = main.assetRegistry();
+        address backingManager = address(main.backingManager());
+
+        IERC20[] memory erc20s = reg.erc20s();
+        for (uint256 i = 0; i < erc20s.length; i++) {
+            IAsset asset = reg.toAsset(erc20s[i]);
+            // Exclude collateral that has defaulted
+            if (
+                asset.isCollateral() &&
+                ICollateral(address(asset)).status() != CollateralStatus.DISABLED
+            ) {
+                total = total.plus(asset.bal(backingManager).mul(asset.price()));
+            }
+        }
+    }
+}

--- a/contracts/interfaces/IFacadeTest.sol
+++ b/contracts/interfaces/IFacadeTest.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+import "./IRToken.sol";
+import "./IStRSR.sol";
+
+/**
+ * @title IFacadeTest
+ * @notice A facade that is useful for driving/querying the system during testing
+ *
+ * - @custom:static-call - Use ethers callStatic() in order to get result after update
+ * - @custom:view - Regular view
+ */
+interface IFacadeTest {
+    /// Prompt all traders to run auctions
+    /// @custom:interaction
+    function runAuctionsForAllTraders(IRToken rToken) external;
+
+    /// Prompt all traders and the RToken itself to claim rewards and sweep to BackingManager
+    /// @custom:interaction
+    function claimRewards(IRToken rToken) external;
+
+    /// @return total {UoA} An estimate of the total value of all assets held at BackingManager
+    /// @custom:static-call
+    function totalAssetValue(IRToken rToken) external returns (uint192 total);
+}

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -119,10 +119,6 @@ interface IRToken is IRewardable, IERC20MetadataUpgradeable, IERC20PermitUpgrade
     /// @custom:interaction
     function vest(address account, uint256 endId) external;
 
-    /// Return the highest index that could be completed by a vestIssuances call.
-    /// @dev Use with `vest`
-    function endIdForVest(address account) external view returns (uint256);
-
     /// Redeem RToken for basket collateral
     /// @param amount {qRTok} The quantity {qRToken} of RToken to redeem
     /// @custom:interaction

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -252,6 +252,7 @@ contract RTokenP0 is ComponentP0, RewardableP0, ERC20Upgradeable, ERC20PermitUpg
     }
 
     /// Return the highest index that could be completed by a vestIssuances call.
+    /// In P1 this function is over in the Facade
     function endIdForVest(address account) external view returns (uint256) {
         uint256 i = leftIndex(account);
         uint192 currBlock = toFix(block.number);

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -2,14 +2,14 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { BigNumber, Wallet } from 'ethers'
 import { ethers, waffle } from 'hardhat'
-import { BN_SCALE_FACTOR, ZERO_ADDRESS } from '../common/constants'
+import { ZERO_ADDRESS } from '../common/constants'
 import { bn, fp } from '../common/numbers'
 import { IConfig } from '../common/configuration'
 import {
   CTokenMock,
   ERC20Mock,
   Facade,
-  FacadeP1,
+  FacadeTest,
   OracleLib,
   StaticATokenMock,
   StRSRP1,
@@ -38,8 +38,6 @@ describe('Facade contract', () => {
   let aToken: StaticATokenMock
   let cToken: CTokenMock
   let rsr: ERC20Mock
-  let compToken: ERC20Mock
-  let aaveToken: ERC20Mock
   let basket: Collateral[]
 
   // Assets
@@ -53,6 +51,7 @@ describe('Facade contract', () => {
 
   // Facade
   let facade: Facade
+  let facadeTest: FacadeTest
 
   // Main
   let rToken: TestIRToken
@@ -70,8 +69,9 @@ describe('Facade contract', () => {
     ;[owner, addr1, addr2, other] = await ethers.getSigners()
 
     // Deploy fixture
-    ;({ oracleLib, stRSR, rsr, compToken, aaveToken, basket, facade, rToken, config } =
-      await loadFixture(defaultFixture))
+    ;({ oracleLib, stRSR, rsr, basket, facade, facadeTest, rToken, config } = await loadFixture(
+      defaultFixture
+    ))
 
     // Get assets and tokens
     ;[tokenAsset, usdcAsset, aTokenAsset, cTokenAsset] = basket
@@ -86,12 +86,9 @@ describe('Facade contract', () => {
 
   describe('Views', () => {
     let issueAmount: BigNumber
-    let initialQuotes: BigNumber[]
 
     beforeEach(async () => {
       await rToken.connect(owner).setIssuanceRate(fp('1'))
-
-      initialQuotes = [bn('0.25e18'), bn('0.25e6'), bn('0.25e18'), bn('1.25e9')]
 
       // Mint Tokens
       initialBal = bn('10000000000e18')
@@ -131,38 +128,6 @@ describe('Facade contract', () => {
         bn('40000000000e18')
       )
       expect(await facade.callStatic.maxIssuable(rToken.address, other.address)).to.equal(0)
-    })
-
-    it('Should return currentAssets correctly', async () => {
-      const initialQuantities: BigNumber[] = initialQuotes.map((q) => {
-        return q.mul(issueAmount).div(BN_SCALE_FACTOR)
-      })
-
-      const [tokens, quantities] = await facade.callStatic.currentAssets(rToken.address)
-
-      // Get Backing ERC20s addresses
-      const backingERC20Addrs: string[] = await Promise.all(
-        basket.map(async (c): Promise<string> => {
-          return await c.erc20()
-        })
-      )
-
-      // Check token addresses
-      expect(tokens[0]).to.equal(rToken.address)
-      expect(quantities[0]).to.equal(bn(0))
-
-      expect(tokens[1]).to.equal(rsr.address)
-      expect(quantities[1]).to.equal(bn(0))
-
-      expect(tokens[2]).to.equal(aaveToken.address)
-      expect(quantities[2]).to.equal(bn(0))
-
-      expect(tokens[3]).to.equal(compToken.address)
-      expect(quantities[3]).to.equal(bn(0))
-
-      // Backing tokens
-      expect(tokens.slice(4, 8)).to.eql(backingERC20Addrs)
-      expect(quantities.slice(4, 8)).to.eql(initialQuantities)
     })
 
     it('Should return backingOverview correctly', async () => {
@@ -223,8 +188,8 @@ describe('Facade contract', () => {
       expect(targets[3]).to.equal(ethers.utils.formatBytes32String('USD'))
     })
 
-    it('Should return totalAssetValue correctly', async () => {
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+    it('Should return totalAssetValue correctly - FacadeTest', async () => {
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
     })
 
     it('Should return RToken price correctly', async () => {
@@ -233,11 +198,9 @@ describe('Facade contract', () => {
 
     // P1 only
     if (IMPLEMENTATION == Implementation.P1) {
-      let facadeP1: FacadeP1
       let stRSRP1: StRSRP1
 
       beforeEach(async () => {
-        facadeP1 = await ethers.getContractAt('FacadeP1', facade.address)
         stRSRP1 = await ethers.getContractAt('StRSRP1', stRSR.address)
       })
 
@@ -247,7 +210,7 @@ describe('Facade contract', () => {
         // Issue rTokens
         await rToken.connect(addr1).issue(largeIssueAmount)
         await rToken.connect(addr1).issue(largeIssueAmount.add(1))
-        const pendings = await facadeP1.pendingIssuances(rToken.address, addr1.address)
+        const pendings = await facade.pendingIssuances(rToken.address, addr1.address)
 
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
@@ -267,7 +230,7 @@ describe('Facade contract', () => {
         await stRSRP1.connect(addr1).unstake(unstakeAmount)
         await stRSRP1.connect(addr1).unstake(unstakeAmount.add(1))
 
-        const pendings = await facadeP1.pendingUnstakings(rToken.address, addr1.address)
+        const pendings = await facade.pendingUnstakings(rToken.address, addr1.address)
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
         expect(pendings[0][2]).to.eql(unstakeAmount) // amount

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -24,6 +24,7 @@ import {
   ERC20Mock,
   IBasketHandler,
   Facade,
+  FacadeTest,
   FacadeWrite,
   FiatCollateral,
   Governance,
@@ -86,6 +87,7 @@ describe('FacadeWrite contract', () => {
 
   // Facade
   let facade: Facade
+  let facadeTest: FacadeTest
   let facadeWriteLibAddr: string
 
   // Core contracts
@@ -118,9 +120,8 @@ describe('FacadeWrite contract', () => {
     ;[deployerUser, owner, addr1, addr2] = await ethers.getSigners()
 
     // Deploy fixture
-    ;({ rsr, compToken, compAsset, basket, config, facade, deployer } = await loadFixture(
-      defaultFixture
-    ))
+    ;({ rsr, compToken, compAsset, basket, config, facade, facadeTest, deployer } =
+      await loadFixture(defaultFixture))
 
     // Get assets and tokens
     tokenAsset = <FiatCollateral>basket[0]
@@ -470,7 +471,7 @@ describe('FacadeWrite contract', () => {
           expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
           expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
           expect(await basketHandler.price()).to.equal(fp('1'))
-          expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+          expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
           // Check BU price
           expect(await basketHandler.price()).to.equal(fp('1'))

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -30,6 +30,7 @@ import {
   CTokenMock,
   ERC20Mock,
   Facade,
+  FacadeTest,
   FiatCollateral,
   GnosisMock,
   GnosisTrade,
@@ -108,6 +109,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
   let furnace: TestIFurnace
   let main: TestIMain
   let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
@@ -151,6 +153,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       gnosis,
       broker,
       facade,
+      facadeTest,
       rsrTrader,
       rTokenTrader,
       oracleLib,
@@ -283,7 +286,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.price()).to.equal(fp('1'))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // Check BU price
       expect(await basketHandler.price()).to.equal(fp('1'))
@@ -1419,7 +1422,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect((await basketHandler.lastSet())[0]).to.be.gt(bn(1))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       await main.connect(owner).unpause()
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
     })
 
     it('Should handle full collateral deregistration and reduce to empty basket', async () => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -13,6 +13,7 @@ import {
   CTokenMock,
   ERC20Mock,
   Facade,
+  FacadeTest,
   FiatCollateral,
   IAssetRegistry,
   IBasketHandler,
@@ -72,6 +73,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
   let main: TestIMain
   let rToken: TestIRToken
   let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
@@ -144,6 +146,16 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
     }
   }
 
+  const endIdForVest = async (account: string) => {
+    if (IMPLEMENTATION == Implementation.P1) {
+      return facade.endIdForVest(rToken.address, account)
+    } else if (IMPLEMENTATION == Implementation.P0) {
+      return (rToken as RTokenP0).endIdForVest(account)
+    } else {
+      throw new Error('PROTO_IMPL must be set to either `0` or `1`')
+    }
+  }
+
   before('create fixture loader', async () => {
     ;[wallet] = (await ethers.getSigners()) as unknown as Wallet[]
     loadFixture = createFixtureLoader([wallet])
@@ -160,6 +172,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       basketHandler,
       config,
       facade,
+      facadeTest,
       main,
       rToken,
       rTokenAsset,
@@ -587,7 +600,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Process issuance
       await advanceBlocks(17)
 
-      const endID = await rToken.endIdForVest(addr1.address)
+      const endID = await endIdForVest(addr1.address)
       expect(endID).to.equal(1)
       await expectEvents(rToken.vest(addr1.address, 1), [
         {
@@ -610,7 +623,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
     })
 
     it('Should issue RTokens correctly for more complex basket multiple users', async function () {
@@ -683,7 +696,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await token2.connect(addr2).approve(rToken.address, initialBal)
       await token3.connect(addr2).approve(rToken.address, initialBal)
       await advanceBlocks(1)
-      await expectEvents(rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address)), [
+      await expectEvents(rToken.vest(addr1.address, await endIdForVest(addr1.address)), [
         {
           contract: rToken,
           name: 'IssuancesCompleted',
@@ -707,7 +720,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(main.address)).to.equal(0)
 
       // Check asset value at this point
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
       // Issue rTokens
       await rToken.connect(addr2).issue(issueAmount)
@@ -737,7 +750,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
       // Complete 2nd issuance
       await advanceBlocks(1)
-      await rToken.vest(addr2.address, await rToken.endIdForVest(addr2.address))
+      await rToken.vest(addr2.address, await endIdForVest(addr2.address))
 
       // Check issuance is confirmed
       await expectIssuance(addr2.address, 0, {
@@ -746,7 +759,9 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr2.address)).to.equal(issueAmount)
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+        issueAmount.mul(2)
+      )
     })
 
     it('Should not vest RTokens if collateral not SOUND', async function () {
@@ -771,7 +786,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Attempt to vest (pending 1 block)
       await advanceBlocks(1)
       await expect(
-        rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+        rToken.vest(addr1.address, await endIdForVest(addr1.address))
       ).to.be.revertedWith('basket unsound')
 
       // Check previous minting was not processed
@@ -847,13 +862,13 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await rToken.connect(addr1).issue(issueAmount)
 
       // Attempt to process slow issuances - nothing at this point
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Process 2 blocks
       await advanceTime(100)
 
       // Vest tokens
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check values, with issued tokens
       expect(await facade.callStatic.maxIssuable(rToken.address, addr1.address)).to.equal(
@@ -945,7 +960,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       })
 
       // Nothing should process
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
       // Check previous minting was not processed[, , , , , sm_proc] = await rToken.issuances(addr1.address, 0)
       await expectIssuance(addr1.address, 0, {
         processed: false,
@@ -954,13 +969,13 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(0)
 
       // Check asset value at this point (still nothing issued)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // Process 4 blocks
       await advanceTime(100)
       await advanceTime(100)
       await advanceTime(100)
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check previous minting was processed and funds sent to minter
       await expectIssuance(addr1.address, 0, {
@@ -970,7 +985,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
     })
 
     it('Should process issuances in multiple attempts (using issuanceRate)', async function () {
@@ -989,7 +1004,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await advanceTime(100)
       await advanceTime(100)
       await advanceTime(100)
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check issuance was confirmed
       expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -1020,7 +1035,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       })
 
       // Should not process
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check previous minting was not processed
       await expectIssuance(addr1.address, 1, {
@@ -1031,11 +1046,11 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
 
       // Check asset value at this point (still nothing issued beyond initial amount)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
       // Process slow mintings one more time
       await advanceBlocks(1)
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check previous minting was processed and funds sent to minter
       await expectIssuance(addr1.address, 1, {
@@ -1046,7 +1061,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.add(newIssuanceAmt))
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
         issueAmount.add(newIssuanceAmt)
       )
     })
@@ -1073,13 +1088,13 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
       // Check first slow minting is confirmed
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
       // Process another block to get the 2nd issuance processed
       await rToken.vest(addr1.address, 2)
 
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.add(newIssueAmount))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
         issueAmount.add(newIssueAmount)
       )
 
@@ -1087,7 +1102,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await rToken.vest(addr1.address, 3)
 
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.add(newIssueAmount.mul(2)))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
         issueAmount.add(newIssueAmount.mul(2))
       )
     })
@@ -1104,7 +1119,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await rToken.connect(addr1).issue(issueAmount)
 
       // Check vestings - Nothing available yet
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(0)
+      expect(await endIdForVest(addr1.address)).to.equal(0)
 
       // Create three additional issuances of 3 blocks each
       const newIssueAmount: BigNumber = MIN_ISSUANCE_PER_BLOCK.mul(3)
@@ -1113,37 +1128,37 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await rToken.connect(addr1).issue(newIssueAmount)
 
       // Check vestings - Nothing available yet, need two more blocks
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(0)
+      expect(await endIdForVest(addr1.address)).to.equal(0)
 
       //  Advance 2 blocks
       await advanceBlocks(2)
 
       // Check vestings - We can vest the first issuance only
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(1)
+      expect(await endIdForVest(addr1.address)).to.equal(1)
 
       // Advance 3 blocks, should be able to vest second issuance
       await advanceBlocks(3)
 
       // Check vestings - Can vest issuances #1 and #2
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(2)
+      expect(await endIdForVest(addr1.address)).to.equal(2)
 
       // Advance 1 block
       await advanceBlocks(1)
 
       // Check vestings - Nothing changed
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(2)
+      expect(await endIdForVest(addr1.address)).to.equal(2)
 
       // Advance 3 more blocks, will unlock third issuance
       await advanceBlocks(3)
 
       // Check vestings - Can vest issuances #1, #2, and #3
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(3)
+      expect(await endIdForVest(addr1.address)).to.equal(3)
 
       // Advance 10 blocks will unlock all issuances
       await advanceBlocks(10)
 
       // Check vestings - Can vest all issuances
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(4)
+      expect(await endIdForVest(addr1.address)).to.equal(4)
 
       // Vest all issuances
       await rToken.vest(addr1.address, 4)
@@ -1151,7 +1166,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Check slow mintings are all confirmed
       const totalValue: BigNumber = issueAmount.add(newIssueAmount.mul(3))
       expect(await rToken.balanceOf(addr1.address)).to.equal(totalValue)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(totalValue)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(totalValue)
     })
 
     it('Should allow multiple issuances in the same block', async function () {
@@ -1177,16 +1192,20 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Check both slow mintings are confirmed
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.mul(2))
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+        issueAmount.mul(2)
+      )
 
       // Set automine to true again
       await hre.network.provider.send('evm_setAutomine', [true])
 
       // Process issuances again, should not change anything
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.mul(2))
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+        issueAmount.mul(2)
+      )
     })
 
     it('Should allow instant issuances', async function () {
@@ -1242,15 +1261,15 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Check first slow mintings is confirmed
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
       // Process issuance #2
-      await rToken.vest(addr1.address, (await rToken.endIdForVest(addr1.address)).add(1))
+      await rToken.vest(addr1.address, (await endIdForVest(addr1.address)).add(1))
 
       // Check second mintings is confirmed
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount.add(newIssueAmount))
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
         issueAmount.add(newIssueAmount)
       )
     })
@@ -1305,7 +1324,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect((await token3.balanceOf(addr1.address)).sub(before3).div(expectedTkn3)).to.equal(28)
 
       // Check total asset value did not change
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
     })
 
     it('Should allow the issuer to rollback minting', async function () {
@@ -1351,7 +1370,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await token3.balanceOf(addr1.address)).to.equal(initialBal)
 
       // Check total asset value did not change
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // We've cleared the queue so calls to cancel should revert
       await expectNoIssuance(addr1.address, 0)
@@ -1388,7 +1407,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
       // Vest minting
       await advanceBlocks(1)
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
 
       // Check previous minting was processed and funds sent to minter
       await expectIssuance(addr1.address, 0, {
@@ -1425,7 +1444,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await token3.balanceOf(addr1.address)).to.equal(initialBal.sub(expectedTkn3))
 
       // Check total asset value did not change
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
       // Another call will not do anything
       await rToken.connect(addr1).cancel(0, true)
@@ -1495,11 +1514,11 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(rToken.address)).to.equal(0)
 
       await expectNoIssuance(addr1.address, 0)
-      expect(await rToken.endIdForVest(addr1.address)).to.equal(0)
+      expect(await endIdForVest(addr1.address)).to.equal(0)
       expect(await rToken.balanceOf(addr1.address)).to.equal(0)
 
       // Check total asset value did not change
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
     })
 
     it('Should not allow solidified cancel exploit', async () => {
@@ -1585,7 +1604,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         // Check balances
         expect(await rToken.balanceOf(addr1.address)).to.equal(redeemAmount)
         expect(await rToken.totalSupply()).to.equal(redeemAmount)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
         // Redeem rTokens
         await rToken.connect(addr1).redeem(redeemAmount)
@@ -1600,7 +1619,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         expect(await token3.balanceOf(addr1.address)).to.equal(initialBal)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.sub(redeemAmount)
         )
       })
@@ -1614,19 +1633,21 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         await token1.connect(addr2).approve(rToken.address, initialBal)
         await token2.connect(addr2).approve(rToken.address, initialBal)
         await token3.connect(addr2).approve(rToken.address, initialBal)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
 
         // Issue rTokens
         await rToken.connect(addr2).issue(issueAmount)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+          issueAmount.mul(2)
+        )
 
         // Redeem rTokens
         await rToken.connect(addr1).redeem(redeemAmount)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.mul(2).sub(redeemAmount)
         )
 
@@ -1650,7 +1671,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         expect(await token3.balanceOf(addr2.address)).to.equal(initialBal)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.mul(2).sub(redeemAmount.mul(2))
         )
       })
@@ -1975,13 +1996,13 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // ==== Issue the "initial" rtoken supply to owner
 
       expect(await rToken.balanceOf(owner.address)).to.equal(bn(0))
-      await issueMany(rToken, toIssue0, owner)
+      await issueMany(facade, rToken, toIssue0, owner)
       expect(await rToken.balanceOf(owner.address)).to.equal(toIssue0)
 
       // ==== Issue the toIssue supply to addr1
 
       expect(await rToken.balanceOf(addr1.address)).to.equal(0)
-      await issueMany(rToken, toIssue, addr1)
+      await issueMany(facade, rToken, toIssue, addr1)
       expect(await rToken.balanceOf(addr1.address)).to.equal(toIssue)
 
       // ==== Send enough rTokens to addr2 that it can redeem the amount `toRedeem`
@@ -2073,7 +2094,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       // Vest
       await advanceTime(100)
       await advanceTime(100)
-      await rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address))
+      await rToken.vest(addr1.address, await endIdForVest(addr1.address))
       expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
 
       // Transfer
@@ -2105,11 +2126,11 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
       // Vest
       await advanceTime(100)
-      await snapshotGasCost(rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address)))
+      await snapshotGasCost(rToken.vest(addr1.address, await endIdForVest(addr1.address)))
 
       // Vest
       await advanceTime(100)
-      await snapshotGasCost(rToken.vest(addr1.address, await rToken.endIdForVest(addr1.address)))
+      await snapshotGasCost(rToken.vest(addr1.address, await endIdForVest(addr1.address)))
     })
 
     it('Redemption', async () => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -148,9 +148,10 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
   const endIdForVest = async (account: string) => {
     if (IMPLEMENTATION == Implementation.P1) {
-      return facade.endIdForVest(rToken.address, account)
+      return await facade.endIdForVest(rToken.address, account)
     } else if (IMPLEMENTATION == Implementation.P0) {
-      return (rToken as RTokenP0).endIdForVest(account)
+      const rTok = await ethers.getContractAt('RTokenP0', rToken.address)
+      return await rTok.endIdForVest(account)
     } else {
       throw new Error('PROTO_IMPL must be set to either `0` or `1`')
     }

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -20,7 +20,7 @@ import {
   CTokenFiatCollateral,
   CTokenMock,
   ERC20Mock,
-  Facade,
+  FacadeTest,
   GnosisMock,
   IAssetRegistry,
   IBasketHandler,
@@ -101,7 +101,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
   let rToken: TestIRToken
   let stRSR: TestIStRSR
   let furnace: TestIFurnace
-  let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
@@ -142,7 +142,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       stRSR,
       broker,
       gnosis,
-      facade,
+      facadeTest,
       rsrTrader,
       rTokenTrader,
       oracleLib,
@@ -453,7 +453,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rsr.balanceOf(stRSR.address)).to.equal(0)
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -521,7 +521,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -616,7 +616,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rsr.balanceOf(stRSR.address)).to.equal(0)
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -654,7 +654,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const minBuyAmtRToken: BigNumber = sellAmtRToken.sub(sellAmtRToken.div(100)) // due to trade slippage 1%
 
         // Can also claim through Facade
-        await expectEvents(facade.claimRewards(rToken.address), [
+        await expectEvents(facadeTest.claimRewards(rToken.address), [
           {
             contract: backingManager,
             name: 'RewardsClaimed',
@@ -674,7 +674,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -727,7 +727,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -827,7 +827,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -857,7 +857,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await compToken.balanceOf(rsrTrader.address)).to.equal(sellAmt)
 
         // Another call will not create a new auction (we only allow only one at a time per pair)
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -882,7 +882,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -927,7 +927,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -1017,7 +1017,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rTokenTrader,
             name: 'TradeStarted',
@@ -1062,7 +1062,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         // Another call will create a new auction and close existing
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rTokenTrader,
             name: 'TradeSettled',
@@ -1110,7 +1110,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         // Close auction
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rTokenTrader,
             name: 'TradeSettled',
@@ -1215,7 +1215,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -1277,7 +1277,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await compToken.balanceOf(rTokenTrader.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -1321,7 +1321,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
           buyAmount: minBuyAmtRemainder,
         })
 
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -1456,7 +1456,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions - should not start any auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -1494,7 +1494,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Claim rewards
 
-        await expectEvents(facade.claimRewards(rToken.address), [
+        await expectEvents(facadeTest.claimRewards(rToken.address), [
           {
             contract: backingManager,
             name: 'RewardsClaimed',
@@ -1514,7 +1514,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -1568,7 +1568,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions - Will end trades and also report violation
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: broker,
             name: 'DisabledSet',
@@ -1617,7 +1617,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await token2.setRewards(backingManager.address, rewardAmountAAVE)
 
         // Claim rewards
-        await expectEvents(facade.claimRewards(rToken.address), [
+        await expectEvents(facadeTest.claimRewards(rToken.address), [
           {
             contract: backingManager,
             name: 'RewardsClaimed',
@@ -1749,7 +1749,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         expect(await rToken.balanceOf(other.address)).to.equal(0)
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -1804,7 +1804,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -1987,7 +1987,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       it('Should sell collateral as it appreciates and handle revenue auction correctly', async () => {
         // Check Price and Assets value
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Increase redemption rate for AToken to double
@@ -1997,7 +1997,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const excessValue: BigNumber = issueAmount.div(2)
         const excessQuantity: BigNumber = excessValue.div(2) // Because each unit is now worth $2
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.add(excessValue)
         )
         expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -2017,7 +2017,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const minBuyAmtRToken: BigNumber = sellAmtRToken.mul(2).sub(sellAmtRToken.mul(2).div(100)) // due to trade slippage 1% and because RSR/RToken are worth half
 
         // Run auctions - Will detect excess
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -2034,7 +2034,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Check Price (unchanged) and Assets value (restored) - Supply remains constant
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(currentTotalSupply)
 
         // Check destinations at this stage
@@ -2085,7 +2085,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -2112,7 +2112,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Check Price (unchanged) and Assets value (unchanged)
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(currentTotalSupply)
 
         // Check destinations at this stage - RSR and RTokens already in StRSR and Furnace
@@ -2128,7 +2128,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       it('Should handle slight increase in collateral correctly - full cycle', async () => {
         // Check Price and Assets value
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Increase redemption rate for AToken by 2%
@@ -2139,7 +2139,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const excessValue: BigNumber = issueAmount.mul(1).div(100)
         const excessQuantity: BigNumber = divCeil(excessValue.mul(BN_SCALE_FACTOR), rate) // Because each unit is now worth $1.02
         expect(near(await rTokenAsset.price(), fp('1'), 1)).to.equal(true)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.add(excessValue)
         )
         expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -2163,7 +2163,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const minBuyAmtRToken: BigNumber = buyAmtRToken.sub(divFloor(buyAmtRToken, bn(100))) // due to trade slippage 1%
 
         // Run auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeStarted',
@@ -2181,11 +2181,11 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         // Check Price (unchanged) and Assets value (restored) - Supply remains constant
         expect(near(await rTokenAsset.price(), fp('1'), 1)).to.equal(true)
         expect(
-          near(await facade.callStatic.totalAssetValue(rToken.address), issueAmount, 100)
+          near(await facadeTest.callStatic.totalAssetValue(rToken.address), issueAmount, 100)
         ).to.equal(true)
-        expect((await facade.callStatic.totalAssetValue(rToken.address)).gt(issueAmount)).to.equal(
-          true
-        )
+        expect(
+          (await facadeTest.callStatic.totalAssetValue(rToken.address)).gt(issueAmount)
+        ).to.equal(true)
         expect(await rToken.totalSupply()).to.equal(currentTotalSupply)
 
         // Check destinations at this stage
@@ -2239,7 +2239,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         })
 
         // Close auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -2267,11 +2267,11 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         //  Check Price (unchanged) and Assets value (unchanged)
         expect(near(await rTokenAsset.price(), fp('1'), 1)).to.equal(true)
         expect(
-          near(await facade.callStatic.totalAssetValue(rToken.address), issueAmount, 100)
+          near(await facadeTest.callStatic.totalAssetValue(rToken.address), issueAmount, 100)
         ).to.equal(true)
-        expect((await facade.callStatic.totalAssetValue(rToken.address)).gt(issueAmount)).to.equal(
-          true
-        )
+        expect(
+          (await facadeTest.callStatic.totalAssetValue(rToken.address)).gt(issueAmount)
+        ).to.equal(true)
         expect(await rToken.totalSupply()).to.equal(currentTotalSupply)
 
         // Check balances sent to corresponding destinations
@@ -2382,7 +2382,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       it('Should mint RTokens when collateral appreciates and handle revenue auction correctly - Even quantity', async () => {
         // Check Price and Assets value
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Change redemption rate for AToken and CToken to double
@@ -2391,7 +2391,9 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Check Price (unchanged) and Assets value (now doubled)
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+          issueAmount.mul(2)
+        )
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Check status of destinations at this point
@@ -2410,7 +2412,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         const minBuyAmt: BigNumber = sellAmt.sub(sellAmt.div(100)) // due to trade slippage 1%
 
         // Collect revenue and mint new tokens - Will also launch auction
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rToken,
             name: 'Transfer',
@@ -2427,7 +2429,9 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Check Price (unchanged) and Assets value - Supply has doubled
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+          issueAmount.mul(2)
+        )
         expect(await rToken.totalSupply()).to.equal(newTotalSupply)
 
         // Check destinations after newly minted tokens
@@ -2461,7 +2465,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         //  End current auction - will not start new one
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -2480,7 +2484,9 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
           .mul(BN_SCALE_FACTOR)
           .div(await rToken.totalSupply())
         expect(await rTokenAsset.price()).to.equal(updatedRTokenPrice)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount.mul(2))
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
+          issueAmount.mul(2)
+        )
 
         // Check no funds in Market
         expect(await rToken.balanceOf(gnosis.address)).to.equal(0)
@@ -2493,7 +2499,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       it('Should mint RTokens and handle remainder when collateral appreciates - Uneven quantity', async () => {
         // Check Price and Assets value
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Change redemption rates for AToken and CToken - Higher for the AToken
@@ -2503,7 +2509,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         // Check Price (unchanged) and Assets value (now 80% higher)
         const excessTotalValue: BigNumber = issueAmount.mul(80).div(100)
         expect(near(await rTokenAsset.price(), fp('1'), 1)).to.equal(true)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.add(excessTotalValue)
         )
         expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -2541,7 +2547,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
           .sub(sellAmtRTokenFromCollateral.mul(2).div(100)) // due to trade slippage 1% and because RSR/RToken is worth half
 
         //  Collect revenue and mint new tokens - Will also launch auctions
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rToken,
             name: 'Transfer',
@@ -2582,7 +2588,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
 
         // Check Price (unchanged) and Assets value (excess collateral not counted anymore) - Supply has increased
         expect(await rTokenAsset.price()).to.equal(fp('1'))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.add(excessRToken)
         )
         expect(await rToken.totalSupply()).to.equal(newTotalSupply)
@@ -2660,7 +2666,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await advanceTime(config.auctionLength.add(100).toString())
 
         // End current auction, should start a new one with same amount
-        await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+        await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
           {
             contract: rsrTrader,
             name: 'TradeSettled',
@@ -2712,7 +2718,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
           .mul(BN_SCALE_FACTOR)
           .div(await rToken.totalSupply())
         expect(await rTokenAsset.price()).to.equal(updatedRTokenPrice)
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
           issueAmount.add(excessRToken)
         )
 

--- a/test/ZTradingExtremes.test.ts
+++ b/test/ZTradingExtremes.test.ts
@@ -13,6 +13,7 @@ import {
   CTokenMock,
   ERC20Mock,
   Facade,
+  FacadeTest,
   FiatCollateral,
   GnosisMock,
   GnosisTrade,
@@ -62,6 +63,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
   let stRSR: TestIStRSR
   let rToken: TestIRToken
   let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
@@ -104,6 +106,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
       distributor,
       rToken,
       facade,
+      facadeTest,
       rsrTrader,
       rTokenTrader,
       rsrAsset,
@@ -254,7 +257,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
     for (let i = 0; didStuff && i < 10; i++) {
       didStuff = false
       // Close any auctions and start new ones
-      await facade.runAuctionsForAllTraders(rToken.address)
+      await facadeTest.runAuctionsForAllTraders(rToken.address)
 
       expect(await backingManager.tradesOpen()).to.equal(0)
       const traders = [rsrTrader, rTokenTrader]
@@ -348,7 +351,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
       await basketHandler.connect(owner).refreshBasket()
 
       // Issue rTokens
-      await issueMany(rToken, rTokenSupply, addr1)
+      await issueMany(facade, rToken, rTokenSupply, addr1)
       expect(await rToken.balanceOf(addr1.address)).to.equal(rTokenSupply)
 
       // === Execution ===
@@ -476,7 +479,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
       await expect(basketHandler.connect(owner).refreshBasket()).to.emit(basketHandler, 'BasketSet')
 
       // Issue rTokens
-      await issueMany(rToken, rTokenSupply, addr1)
+      await issueMany(facade, rToken, rTokenSupply, addr1)
       expect(await rToken.balanceOf(addr1.address)).to.equal(rTokenSupply)
 
       // === Execution ===
@@ -556,7 +559,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
 
       for (let i = 0; i < basketSize + 1 && uncapitalized; i++) {
         // Close any open auctions and launch new ones
-        await facade.runAuctionsForAllTraders(rToken.address)
+        await facadeTest.runAuctionsForAllTraders(rToken.address)
 
         for (const erc20 of erc20s) {
           const tradeAddr = await backingManager.trades(erc20)
@@ -653,7 +656,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
       await stRSR.connect(addr1).stake(fp('1e29'))
 
       // Issue rTokens
-      await issueMany(rToken, rTokenSupply, addr1)
+      await issueMany(facade, rToken, rTokenSupply, addr1)
       expect(await rToken.balanceOf(addr1.address)).to.equal(rTokenSupply)
 
       // === Execution ===

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -20,6 +20,7 @@ import {
   DeployerP0,
   DeployerP1,
   Facade,
+  FacadeTest,
   DistributorP1,
   FurnaceP1,
   EasyAuction,
@@ -360,6 +361,7 @@ export interface DefaultFixture extends RSRAndCompAaveAndCollateralAndModuleFixt
   furnace: TestIFurnace
   stRSR: TestIStRSR
   facade: Facade
+  facadeTest: FacadeTest
   broker: TestIBroker
   rsrTrader: TestIRevenueTrader
   rTokenTrader: TestIRevenueTrader
@@ -370,7 +372,6 @@ export interface DefaultFixture extends RSRAndCompAaveAndCollateralAndModuleFixt
 export const defaultFixture: Fixture<DefaultFixture> = async function ([
   owner,
 ]): Promise<DefaultFixture> {
-  let facade: Facade
   const { rsr } = await rsrFixture()
   const { weth, compToken, compoundMock, aaveToken } = await compAaveFixture()
   const { gnosis, easyAuction } = await gnosisFixture()
@@ -419,7 +420,11 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
 
   // Deploy Facade
   const FacadeFactory: ContractFactory = await ethers.getContractFactory('Facade')
-  facade = <Facade>await FacadeFactory.deploy()
+  const facade = <Facade>await FacadeFactory.deploy()
+
+  // Deploy FacadeTest
+  const FacadeTestFactory: ContractFactory = await ethers.getContractFactory('FacadeTest')
+  const facadeTest = <FacadeTest>await FacadeTestFactory.deploy()
 
   // Deploy RSR chainlink feed
   const MockV3AggregatorFactory: ContractFactory = await ethers.getContractFactory(
@@ -521,10 +526,6 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
       },
       trade: tradeImpl.address,
     }
-
-    // Deploy FacadeP1
-    const FacadeFactory: ContractFactory = await ethers.getContractFactory('FacadeP1')
-    facade = <Facade>await FacadeFactory.deploy()
 
     const DeployerFactory: ContractFactory = await ethers.getContractFactory('DeployerP1', {
       libraries: { RTokenPricingLib: rTokenPricing.address },
@@ -669,6 +670,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
     gnosis,
     easyAuction,
     facade,
+    facadeTest,
     rsrTrader,
     rTokenTrader,
     oracleLib,

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -24,6 +24,7 @@ import {
   ERC20Mock,
   EURFiatCollateral,
   Facade,
+  FacadeTest,
   FiatCollateral,
   IAToken,
   IERC20,
@@ -139,6 +140,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
   let rTokenAsset: RTokenAsset
   let main: TestIMain
   let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
@@ -190,6 +192,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         rToken,
         rTokenAsset,
         facade,
+        facadeTest,
         config,
         oracleLib,
       } = await loadFixture(defaultFixture))
@@ -1595,7 +1598,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.price()).to.be.closeTo(fp('1'), fp('0.015'))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // Check RToken price
       const issueAmount: BigNumber = bn('10000e18')
@@ -1661,7 +1664,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(await rToken.totalSupply()).to.equal(issueAmount)
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
         issueAmount,
         fp('150')
       ) // approx 10K in value
@@ -1687,7 +1690,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       )
 
       // Check asset value left
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
         bn(0),
         fp('0.001')
       ) // Near zero
@@ -1725,7 +1728,9 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(cDaiRefPerTok1).to.be.closeTo(fp('0.022'), fp('0.001'))
 
       // Check total asset value
-      const totalAssetValue1: BigNumber = await facade.callStatic.totalAssetValue(rToken.address)
+      const totalAssetValue1: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
       expect(totalAssetValue1).to.be.closeTo(issueAmount, fp('150')) // approx 10K in value
 
       // Advance time and blocks slightly
@@ -1754,7 +1759,9 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(cDaiRefPerTok2).to.be.closeTo(fp('0.022'), fp('0.001'))
 
       // Check total asset value increased
-      const totalAssetValue2: BigNumber = await facade.callStatic.totalAssetValue(rToken.address)
+      const totalAssetValue2: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
       expect(totalAssetValue2).to.be.gt(totalAssetValue1)
 
       // Advance time and blocks significantly
@@ -1783,7 +1790,9 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(cDaiRefPerTok3).to.be.closeTo(fp('0.032'), fp('0.001'))
 
       // Check total asset value increased
-      const totalAssetValue3: BigNumber = await facade.callStatic.totalAssetValue(rToken.address)
+      const totalAssetValue3: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
       expect(totalAssetValue3).to.be.gt(totalAssetValue2)
 
       // Redeem Rtokens with the udpated rates
@@ -1812,7 +1821,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(await cDai.balanceOf(backingManager.address)).to.be.closeTo(bn(75331e8), bn('5e7')) // ~= 2481 usd in value
 
       //  Check total asset value (remainder)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
         fp('2742'), // ~=  260usd + 2481 usd (from above)
         fp('1')
       )
@@ -1856,7 +1865,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(await rToken.totalSupply()).to.equal(issueAmount)
 
       // Check asset value
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
         issueAmount,
         fp('150')
       ) // approx 10K in value
@@ -1941,7 +1950,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.price()).to.be.closeTo(totalPriceUSD, point1Pct(totalPriceUSD))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
         await expect(rTokenAsset.price()).to.be.revertedWith('no supply')
 
         // Check rToken balance
@@ -2012,7 +2021,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
           totalPriceUSD,
           point1Pct(totalPriceUSD)
         )
@@ -2047,7 +2056,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         )
 
         //  Check asset value left
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
           bn(0),
           fp('0.001')
         ) // Near zero
@@ -2150,7 +2159,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.price()).to.be.closeTo(totalPriceUSD, point1Pct(totalPriceUSD))
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
         await expect(rTokenAsset.price()).to.be.revertedWith('no supply')
 
         // Check rToken balance
@@ -2180,7 +2189,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect(await rToken.totalSupply()).to.equal(issueAmount)
 
         // Check asset value
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
           totalPriceUSD,
           point1Pct(totalPriceUSD)
         )
@@ -2199,7 +2208,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect(await usdt.balanceOf(addr1.address)).to.equal(toBNDecimals(initialBal, 6))
 
         //  Check asset value left
-        expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+        expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
           bn(0),
           fp('0.001')
         ) // Near zero

--- a/test/integration/EasyAuction.test.ts
+++ b/test/integration/EasyAuction.test.ts
@@ -16,7 +16,7 @@ import { whileImpersonating } from '../utils/impersonation'
 import {
   EasyAuction,
   ERC20Mock,
-  Facade,
+  FacadeTest,
   FiatCollateral,
   IAssetRegistry,
   IBasketHandler,
@@ -44,7 +44,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
   let broker: TestIBroker
   let backingManager: TestIBackingManager
   let basketHandler: IBasketHandler
-  let facade: Facade
+  let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
 
   let easyAuction: EasyAuction
@@ -79,7 +79,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       rsr,
       collateral,
       easyAuction,
-      facade,
+      facadeTest,
       backingManager,
       basketHandler,
       rTokenAsset,
@@ -119,7 +119,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check initial state
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
       expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
       expect(await rTokenAsset.price()).to.equal(fp('1'))
@@ -152,7 +152,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check state
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
       expect(await token0.balanceOf(backingManager.address)).to.equal(0)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
 
@@ -191,7 +191,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       await advanceTime(config.auctionLength.add(100).toString())
 
       // End current auction, should restart
-      await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+      await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
         {
           contract: backingManager,
           name: 'TradeSettled',
@@ -236,7 +236,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check state - Order restablished
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt.sub(1))
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt.sub(1))
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt.sub(1))
       expect(await token0.balanceOf(easyAuction.address)).to.equal(1) // remainder
       expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -301,7 +301,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check state - Order restablished
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(easyAuction.address)).to.equal(0)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -405,7 +405,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check state - Order restablished
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(easyAuction.address)).to.equal(0)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -493,7 +493,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check state - Order restablished
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt)
       expect(await token0.balanceOf(easyAuction.address)).to.equal(0)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
@@ -532,7 +532,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       // Check initial state
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
       expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
       expect(await rToken.totalSupply()).to.equal(issueAmount)
       expect(await rTokenAsset.price()).to.equal(fp('1'))

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -25,6 +25,7 @@ import {
   ERC20Mock,
   EURFiatCollateral,
   Facade,
+  FacadeTest,
   FurnaceP1,
   GnosisTrade,
   IAssetRegistry,
@@ -616,6 +617,7 @@ interface DefaultFixture extends RSRAndCompAaveAndCollateralAndModuleFixture {
   furnace: TestIFurnace
   stRSR: TestIStRSR
   facade: Facade
+  facadeTest: FacadeTest
   broker: TestIBroker
   rsrTrader: TestIRevenueTrader
   rTokenTrader: TestIRevenueTrader
@@ -674,6 +676,10 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
   // Deploy Facade
   const FacadeFactory: ContractFactory = await ethers.getContractFactory('Facade')
   facade = <Facade>await FacadeFactory.deploy()
+
+  // Deploy FacadeTest
+  const FacadeTestFactory: ContractFactory = await ethers.getContractFactory('FacadeTest')
+  const facadeTest = <FacadeTest>await FacadeTestFactory.deploy()
 
   // Deploy RSR Asset
   const AssetFactory: ContractFactory = await ethers.getContractFactory('Asset', {
@@ -913,6 +919,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function ([
     broker,
     gnosis,
     facade,
+    facadeTest,
     rsrTrader,
     rTokenTrader,
     oracleLib,

--- a/test/plugins/Collateral.test.ts
+++ b/test/plugins/Collateral.test.ts
@@ -20,7 +20,7 @@ import {
   CTokenSelfReferentialCollateral,
   ERC20Mock,
   EURFiatCollateral,
-  Facade,
+  FacadeTest,
   FiatCollateral,
   MockV3Aggregator,
   NonFiatCollateral,
@@ -78,7 +78,7 @@ describe('Collateral contracts', () => {
   let oracleLib: OracleLib
 
   // Facade
-  let facade: Facade
+  let facadeTest: FacadeTest
 
   // Factories
   let FiatCollateralFactory: ContractFactory
@@ -109,7 +109,7 @@ describe('Collateral contracts', () => {
       config,
       backingManager,
       rToken,
-      facade,
+      facadeTest,
       oracleLib,
       rTokenAsset,
     } = await loadFixture(defaultFixture))
@@ -898,7 +898,7 @@ describe('Collateral contracts', () => {
       expect(await aaveToken.balanceOf(backingManager.address)).to.equal(0)
 
       // Claim and Sweep rewards - From Main
-      await facade.claimRewards(rToken.address)
+      await facadeTest.claimRewards(rToken.address)
 
       // Check rewards were transfered to BackingManager
       expect(await compToken.balanceOf(backingManager.address)).to.equal(rewardAmountCOMP)
@@ -915,7 +915,9 @@ describe('Collateral contracts', () => {
 
       // Force call to fail, set an invalid COMP token in Comptroller
       await compoundMock.connect(owner).setCompToken(cTokenCollateral.address)
-      await expect(facade.claimRewards(rToken.address)).to.be.revertedWith('rewards claim failed')
+      await expect(facadeTest.claimRewards(rToken.address)).to.be.revertedWith(
+        'rewards claim failed'
+      )
 
       // Check funds not yet swept
       expect(await compToken.balanceOf(backingManager.address)).to.equal(0)

--- a/test/scenario/ComplexBasket.test.ts
+++ b/test/scenario/ComplexBasket.test.ts
@@ -11,6 +11,7 @@ import {
   CTokenMock,
   ERC20Mock,
   Facade,
+  FacadeTest,
   GnosisMock,
   IAssetRegistry,
   IBasketHandler,
@@ -99,6 +100,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
   let assetRegistry: IAssetRegistry
   let basketHandler: IBasketHandler
   let facade: Facade
+  let facadeTest: FacadeTest
   let backingManager: TestIBackingManager
   let oracleLib: OracleLib
 
@@ -137,6 +139,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
       backingManager,
       basketHandler,
       facade,
+      facadeTest,
       rsr,
       rsrAsset,
       furnace,
@@ -432,7 +435,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
     expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
     expect(await basketHandler.price()).to.equal(totalPriceUSD)
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
     const issueAmt = bn('10e18')
 
@@ -444,7 +447,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmt)
     expect(await rToken.totalSupply()).to.equal(issueAmt)
     expect(await basketHandler.price()).to.equal(totalPriceUSD)
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(
       issueAmt.mul(totalPriceUSD.div(BN_SCALE_FACTOR))
     )
 
@@ -591,7 +594,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect(await rToken.balanceOf(furnace.address)).to.equal(0)
 
     // Run auctions
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeStarted',
@@ -631,7 +634,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeSettled',
@@ -683,7 +686,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     const origAssetValue = issueAmount.mul(totalPriceUSD).div(BN_SCALE_FACTOR)
     expect(await rTokenAsset.price()).to.equal(totalPriceUSD)
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(origAssetValue)
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(origAssetValue)
     expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
     expect(await rToken.totalSupply()).to.equal(issueAmount)
 
@@ -751,7 +754,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     expect(await rTokenAsset.price()).to.be.closeTo(totalPriceUSD, fp('0.1'))
     const excessTotal = excessValue2.add(excessValue5).add(excessValue7)
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
       origAssetValue.add(excessTotal),
       point5Pct(origAssetValue.add(excessTotal))
     )
@@ -799,7 +802,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect(minBuyAmtRToken2).to.be.closeTo(fp('0.00000133'), fp('0.00000001'))
 
     // Run auctions - Will detect excess
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeStarted',
@@ -846,7 +849,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     // Check Price (unchanged) and Assets value
     expect(await rTokenAsset.price()).to.be.closeTo(totalPriceUSD, point5Pct(totalPriceUSD))
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
       origAssetValue,
       point5Pct(origAssetValue)
     )
@@ -903,7 +906,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect(minBuyAmtRToken5).to.be.closeTo(fp('0.053225'), fp('0.0001'))
 
     // Close auctions - Will open for next token
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeSettled',
@@ -936,7 +939,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     // Check Price (unchanged) and Assets value (unchanged)
     expect(await rTokenAsset.price()).to.be.closeTo(totalPriceUSD, point5Pct(totalPriceUSD))
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
       origAssetValue,
       point5Pct(origAssetValue)
     )
@@ -1034,7 +1037,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     expect(minBuyAmtRToken7).to.be.closeTo(fp('0.002554'), point5Pct(fp('0.002554')))
 
     // Close auctions - Will open for next token
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeSettled',
@@ -1067,7 +1070,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     // Check Price (unchanged) and Assets value (unchanged)
     expect(await rTokenAsset.price()).to.be.closeTo(totalPriceUSD, point5Pct(totalPriceUSD))
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
       origAssetValue,
       point5Pct(origAssetValue)
     )
@@ -1147,7 +1150,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions - Will not open new ones
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: rsrTrader,
         name: 'TradeSettled',
@@ -1174,7 +1177,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     // Check Price (unchanged) and Assets value (unchanged)
     expect(await rTokenAsset.price()).to.be.closeTo(totalPriceUSD, point5Pct(totalPriceUSD))
-    expect(await facade.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+    expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
       origAssetValue,
       point5Pct(origAssetValue)
     )
@@ -1261,7 +1264,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     // Running auctions will trigger recapitalization - All balance of invalid tokens will be redeemed
     const sellAmt: BigNumber = await cWBTC.balanceOf(backingManager.address)
 
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeStarted',
@@ -1312,7 +1315,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
       .div(await rsrAsset.price()) // 7 wBTC @ 20K = 140K USD of value, in RSR ~= 560K RSR (@0.25)
 
     // Close auctions - Will sell RSR for the remaining 7 WBTC
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1369,7 +1372,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions - Will sell RSR for the remaining 7 WBTC
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1466,7 +1469,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     const sellAmt = toBNDecimals(maxAmt, 8)
     const sellAmtRemainder = (await cETH.balanceOf(backingManager.address)).sub(sellAmt)
 
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeStarted',
@@ -1509,7 +1512,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Run auctions again for remainder
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1581,7 +1584,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     const lastAuctionBuyAmtRSR = buyAmtBidRSR.sub(partialBuyAmtRSR.mul(2))
 
     // Close auctions - Will sell RSR for partial Buy #1
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1647,7 +1650,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions - Will sell RSR for partial Buy #2
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1711,7 +1714,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions - Will sell RSR for final auction
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',
@@ -1766,7 +1769,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     })
 
     // Close auctions - No more auctions should be triggered
-    await expectEvents(facade.runAuctionsForAllTraders(rToken.address), [
+    await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
       {
         contract: backingManager,
         name: 'TradeSettled',

--- a/test/scenario/MaxBasketSize.test.ts
+++ b/test/scenario/MaxBasketSize.test.ts
@@ -12,6 +12,7 @@ import {
   CTokenMock,
   ERC20Mock,
   Facade,
+  FacadeTest,
   FiatCollateral,
   IAssetRegistry,
   IBasketHandler,
@@ -58,6 +59,7 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
   let assetRegistry: IAssetRegistry
   let basketHandler: IBasketHandler
   let facade: Facade
+  let facadeTest: FacadeTest
   let backingManager: TestIBackingManager
   let oracleLib: OracleLib
 
@@ -257,6 +259,7 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
       backingManager,
       basketHandler,
       facade,
+      facadeTest,
       oracleLib,
     } = await loadFixture(defaultFixture))
 
@@ -285,7 +288,7 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
       expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.price()).to.equal(fp('1'))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // Mint and approve initial balances
       await prepareBacking(backing)
@@ -375,9 +378,9 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
       const sellAmt: BigNumber = await firstDefaultedToken.balanceOf(backingManager.address)
 
       if (process.env.REPORT_GAS) {
-        await snapshotGasCost(facade.runAuctionsForAllTraders(rToken.address))
+        await snapshotGasCost(facadeTest.runAuctionsForAllTraders(rToken.address))
       } else {
-        await expect(facade.runAuctionsForAllTraders(rToken.address))
+        await expect(facadeTest.runAuctionsForAllTraders(rToken.address))
           .to.emit(backingManager, 'TradeStarted')
           .withArgs(anyValue, firstDefaultedToken.address, backing[0], sellAmt, bn('0'))
       }
@@ -413,7 +416,7 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
       expect((await basketHandler.lastSet())[0]).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.price()).to.equal(fp('1'))
-      expect(await facade.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
 
       // Mint and approve initial balances
       await prepareBacking(backing)
@@ -492,9 +495,9 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
       const sellAmt: BigNumber = await firstDefaultedToken.balanceOf(backingManager.address)
 
       if (process.env.REPORT_GAS) {
-        await snapshotGasCost(facade.runAuctionsForAllTraders(rToken.address))
+        await snapshotGasCost(facadeTest.runAuctionsForAllTraders(rToken.address))
       } else {
-        await expect(facade.runAuctionsForAllTraders(rToken.address))
+        await expect(facadeTest.runAuctionsForAllTraders(rToken.address))
           .to.emit(backingManager, 'TradeStarted')
           .withArgs(anyValue, firstDefaultedToken.address, backing[0], sellAmt, bn('0'))
       }

--- a/test/scenario/NestedRTokens.test.ts
+++ b/test/scenario/NestedRTokens.test.ts
@@ -230,7 +230,7 @@ describe(`Nested RTokens - P${IMPLEMENTATION}`, () => {
       // Inner revenue auctions
       let rTokSellAmt = issueAmt.mul(2).div(5)
       let rsrSellAmt = issueAmt.mul(3).div(5)
-      await expectEvents(one.facade.runAuctionsForAllTraders(one.rToken.address), [
+      await expectEvents(one.facadeTest.runAuctionsForAllTraders(one.rToken.address), [
         {
           contract: one.rTokenTrader,
           name: 'TradeStarted',
@@ -298,7 +298,7 @@ describe(`Nested RTokens - P${IMPLEMENTATION}`, () => {
       rsrSellAmt = issueAmt.div(2).mul(3).div(5)
 
       // Note that here the outer RToken actually mints itself as the first step
-      await expectEvents(two.facade.runAuctionsForAllTraders(two.rToken.address), [
+      await expectEvents(two.facadeTest.runAuctionsForAllTraders(two.rToken.address), [
         {
           contract: two.rToken,
           name: 'Transfer', // Mint
@@ -350,7 +350,7 @@ describe(`Nested RTokens - P${IMPLEMENTATION}`, () => {
       expect(await staticATokenERC20.balanceOf(one.backingManager.address)).to.equal(issueAmt)
 
       // Note the inner RToken mints internally since it has excess backing
-      await expectEvents(one.facade.runAuctionsForAllTraders(one.rToken.address), [
+      await expectEvents(one.facadeTest.runAuctionsForAllTraders(one.rToken.address), [
         {
           contract: one.rToken,
           name: 'Transfer',

--- a/test/utils/issue.ts
+++ b/test/utils/issue.ts
@@ -1,5 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
+import { ethers } from 'hardhat'
 import { BigNumber } from 'ethers'
 import { bn, fp } from '../../common/numbers'
 import { Facade, RTokenP0, TestIRToken } from '../../typechain'
@@ -40,7 +41,10 @@ export async function issueMany(
     if (IMPLEMENTATION == Implementation.P1) {
       await rToken.vest(user.address, await facade.endIdForVest(rToken.address, user.address))
     } else if (IMPLEMENTATION == Implementation.P0) {
-      await rToken.vest(user.address, await (rToken as RTokenP0).endIdForVest(user.address))
+      const rTok = await ethers.getContractAt('RTokenP0', rToken.address)
+      await rToken.vest(user.address, await rTok.endIdForVest(user.address))
+    } else {
+      throw new Error('Invalid impl type')
     }
 
     issued = issued.add(currIssue)


### PR DESCRIPTION
RToken was over the contract size limit after our latest round of checks / improvements. By pulling out `endIdForVest` from RTokenP1 into the Facade I was able to get it back under the limit. This put the Facade above the limit (facepalm) so I then split the Facade into the Facade and a FacadeTest. We won't deploy the FacadeTest to mainnet; it is only for local testing. 

The large number of files changed are because of the testfiles. 