### PR TITLE
Fix USDT approvals - using `safeApprove`

### DIFF
--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -44,9 +44,8 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
     /// @custom:interaction
     function grantRTokenAllowance(IERC20 erc20) external notPausedOrFrozen {
         require(main.assetRegistry().isRegistered(erc20), "erc20 unregistered");
-
-        uint256 currAllowance = erc20.allowance(address(this), address(main.rToken()));
-        erc20.safeIncreaseAllowance(address(main.rToken()), type(uint256).max - currAllowance);
+        erc20.safeApprove(address(main.rToken()), 0);
+        erc20.safeApprove(address(main.rToken()), type(uint256).max);
     }
 
     /// Mointain the overall backing policy; handout assets otherwise

--- a/contracts/p0/RevenueTrader.sol
+++ b/contracts/p0/RevenueTrader.sol
@@ -37,8 +37,9 @@ contract RevenueTraderP0 is TradingP0, IRevenueTrader {
         uint256 bal = erc20.balanceOf(address(this));
         if (bal == 0) return;
 
-        if (erc20 == tokenToBuy) {
-            erc20.safeIncreaseAllowance(address(main.distributor()), bal);
+        if (erc20 == tokenToBuy) { 
+            erc20.safeApprove(address(main.distributor()), 0);
+            erc20.safeApprove(address(main.distributor()), bal);
             main.distributor().distribute(erc20, address(this), bal);
             return;
         }

--- a/contracts/p0/RevenueTrader.sol
+++ b/contracts/p0/RevenueTrader.sol
@@ -37,7 +37,7 @@ contract RevenueTraderP0 is TradingP0, IRevenueTrader {
         uint256 bal = erc20.balanceOf(address(this));
         if (bal == 0) return;
 
-        if (erc20 == tokenToBuy) { 
+        if (erc20 == tokenToBuy) {
             erc20.safeApprove(address(main.distributor()), 0);
             erc20.safeApprove(address(main.distributor()), bal);
             main.distributor().distribute(erc20, address(this), bal);

--- a/contracts/p0/mixins/Trading.sol
+++ b/contracts/p0/mixins/Trading.sol
@@ -54,7 +54,9 @@ abstract contract TradingP0 is RewardableP0, ITrading {
         assert(address(trades[req.sell.erc20()]) == address(0));
         require(!broker.disabled(), "broker disabled");
 
-        req.sell.erc20().safeIncreaseAllowance(address(broker), req.sellAmount);
+        req.sell.erc20().safeApprove(address(broker), 0);
+        req.sell.erc20().safeApprove(address(broker), req.sellAmount);
+
         ITrade trade = broker.openTrade(req);
 
         trades[req.sell.erc20()] = trade;

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -68,14 +68,12 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     /// @custom:interaction CEI
     // checks: erc20 in assetRegistry
     // action: set allowance on erc20 for rToken to UINT_MAX
+    // Using two safeApprove calls instead of safeIncreaseAllowance to support USDT
     function grantRTokenAllowance(IERC20 erc20) external notPausedOrFrozen {
         require(assetRegistry.isRegistered(erc20), "erc20 unregistered");
         // == Interaction ==
-        uint256 currAllowance = erc20.allowance(address(this), address(rToken));
-        IERC20Upgradeable(address(erc20)).safeIncreaseAllowance(
-            address(rToken),
-            type(uint256).max - currAllowance
-        );
+        IERC20Upgradeable(address(erc20)).safeApprove(address(main.rToken()), 0);
+        IERC20Upgradeable(address(erc20)).safeApprove(address(main.rToken()), type(uint256).max);
     }
 
     /// Maintain the overall backing policy; handout assets otherwise

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -43,7 +43,7 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
     //
     // If erc20 is tokenToBuy:
     //   actions:
-    //     erc20.increaseAllowance(distributor, bal)
+    //     erc20.increaseAllowance(distributor, bal) - two safeApprove calls to support USDT
     //     distributor.distribute(erc20, this, bal)
     //
     // If erc20 is any other registered asset (checked):
@@ -58,7 +58,8 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
 
         if (erc20 == tokenToBuy) {
             // == Interactions then return ==
-            IERC20Upgradeable(address(erc20)).safeIncreaseAllowance(address(distributor), bal);
+            IERC20Upgradeable(address(erc20)).safeApprove(address(distributor), 0);
+            IERC20Upgradeable(address(erc20)).safeApprove(address(distributor), bal);
             distributor.distribute(erc20, address(this), bal);
             return;
         }

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -84,7 +84,7 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     //   (not external, so we don't need auth or pause checks)
     //   trades[req.sell] == 0
     // actions:
-    //   req.sell.increaseAllowance(broker, req.sellAmount)
+    //   req.sell.increaseAllowance(broker, req.sellAmount) - two safeApprove calls to support USDT
     //   tradeID = broker.openTrade(req)
     // effects:
     //   trades' = trades.set(req.sell, tradeID)
@@ -98,7 +98,8 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
         IERC20 sell = req.sell.erc20();
         assert(address(trades[sell]) == address(0));
 
-        IERC20Upgradeable(address(sell)).safeIncreaseAllowance(address(broker), req.sellAmount);
+        IERC20Upgradeable(address(sell)).safeApprove(address(broker), 0);
+        IERC20Upgradeable(address(sell)).safeApprove(address(broker), req.sellAmount);
         ITrade trade = broker.openTrade(req);
 
         trades[sell] = trade;

--- a/contracts/plugins/trading/GnosisTrade.sol
+++ b/contracts/plugins/trading/GnosisTrade.sol
@@ -130,7 +130,9 @@ contract GnosisTrade is ITrade {
 
         // == Interactions ==
 
-        IERC20Upgradeable(address(sell)).safeIncreaseAllowance(address(gnosis), initBal);
+        // Set allowance (two safeApprove calls to support USDT)
+        IERC20Upgradeable(address(sell)).safeApprove(address(gnosis), 0);
+        IERC20Upgradeable(address(sell)).safeApprove(address(gnosis), initBal);
 
         auctionId = gnosis.initiateAuction(
             sell,

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -2135,6 +2135,9 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
           newBasketERC20s.push(await newBasket[i].erc20())
           // Grant allowance
           await backingManager.grantRTokenAllowance(await newBasket[i].erc20())
+
+          // Another call to grant allowance should not revert
+          await backingManager.grantRTokenAllowance(await newBasket[i].erc20())
         }
         // Set non-empty basket
         await basketHandler.connect(owner).setPrimeBasket(newBasketERC20s, newBasketsNeededAmts)

--- a/test/integration/Deployment.test.ts
+++ b/test/integration/Deployment.test.ts
@@ -5,23 +5,11 @@ import hre, { ethers, waffle } from 'hardhat'
 import { Collateral, IMPLEMENTATION } from '../fixtures'
 import { defaultFixture } from './fixtures'
 import { getChainId } from '../../common/blockchain-utils'
-import {
-  IConfig,
-  IRTokenConfig,
-  IRTokenSetup,
-  networkConfig,
-} from '../../common/configuration'
+import { IConfig, IRTokenConfig, IRTokenSetup, networkConfig } from '../../common/configuration'
 import { ZERO_ADDRESS } from '../../common/constants'
 import { expectInIndirectReceipt } from '../../common/events'
 import { bn, fp } from '../../common/numbers'
-import {
-  ERC20Mock,
-  FacadeWrite,
-  FiatCollateral,
-  IERC20,
-  TestIDeployer,
-  TestIMain,
-} from '../../typechain'
+import { FacadeWrite, FiatCollateral, TestIDeployer, TestIMain } from '../../typechain'
 
 const createFixtureLoader = waffle.createFixtureLoader
 
@@ -29,13 +17,11 @@ const describeFork = process.env.FORK ? describe : describe.skip
 
 describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, function () {
   let owner: SignerWithAddress
-  let addr1: SignerWithAddress
 
   // Assets
   let collateral: Collateral[]
 
   // Tokens and Assets
-  let usdt: ERC20Mock
   let usdtCollateral: FiatCollateral
 
   // Contracts to retrieve after deploy
@@ -46,8 +32,6 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
 
   let rTokenConfig: IRTokenConfig
   let rTokenSetup: IRTokenSetup
-  
-  let erc20s: IERC20[]
 
   let loadFixture: ReturnType<typeof createFixtureLoader>
   let wallet: Wallet
@@ -66,10 +50,8 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
     })
 
     beforeEach(async () => {
-      ;[owner, addr1] = await ethers.getSigners()
-      ;({ erc20s, collateral, deployer, config } = await loadFixture(
-        defaultFixture
-      ))
+      ;[owner] = await ethers.getSigners()
+      ;({ collateral, deployer, config } = await loadFixture(defaultFixture))
 
       // Deploy DFacadeWriteLib lib
       const facadeWriteLib = await (await ethers.getContractFactory('FacadeWriteLib')).deploy()
@@ -84,13 +66,12 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
       facadeWrite = <FacadeWrite>await FacadeFactory.deploy(deployer.address)
 
       // Get tokens
-      usdt = <ERC20Mock>erc20s[2] // USDT
-      usdtCollateral = <FiatCollateral>collateral[2] // USDT   
+      usdtCollateral = <FiatCollateral>collateral[2] // USDT
     })
 
     it('Should allow to deploy USDT in both prime and backup basket', async () => {
-       // Set parameters
-       rTokenConfig = {
+      // Set parameters
+      rTokenConfig = {
         name: 'RTKN RToken',
         symbol: 'RTKN',
         mandate: 'mandate',
@@ -111,7 +92,7 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
       }
       // Deploy RToken via FacadeWrite
       const receipt = await (
-        await facadeWrite.connect(addr1).deployRToken(rTokenConfig, rTokenSetup)
+        await facadeWrite.connect(owner).deployRToken(rTokenConfig, rTokenSetup)
       ).wait()
 
       const mainAddr = expectInIndirectReceipt(receipt, deployer.interface, 'RTokenCreated').args

--- a/test/integration/Deployment.test.ts
+++ b/test/integration/Deployment.test.ts
@@ -1,0 +1,125 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ContractFactory, Wallet } from 'ethers'
+import hre, { ethers, waffle } from 'hardhat'
+import { Collateral, IMPLEMENTATION } from '../fixtures'
+import { defaultFixture } from './fixtures'
+import { getChainId } from '../../common/blockchain-utils'
+import {
+  IConfig,
+  IRTokenConfig,
+  IRTokenSetup,
+  networkConfig,
+} from '../../common/configuration'
+import { ZERO_ADDRESS } from '../../common/constants'
+import { expectInIndirectReceipt } from '../../common/events'
+import { bn, fp } from '../../common/numbers'
+import {
+  ERC20Mock,
+  FacadeWrite,
+  FiatCollateral,
+  IERC20,
+  TestIDeployer,
+  TestIMain,
+} from '../../typechain'
+
+const createFixtureLoader = waffle.createFixtureLoader
+
+const describeFork = process.env.FORK ? describe : describe.skip
+
+describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, function () {
+  let owner: SignerWithAddress
+  let addr1: SignerWithAddress
+
+  // Assets
+  let collateral: Collateral[]
+
+  // Tokens and Assets
+  let usdt: ERC20Mock
+  let usdtCollateral: FiatCollateral
+
+  // Contracts to retrieve after deploy
+  let main: TestIMain
+  let deployer: TestIDeployer
+  let facadeWrite: FacadeWrite
+  let config: IConfig
+
+  let rTokenConfig: IRTokenConfig
+  let rTokenSetup: IRTokenSetup
+  
+  let erc20s: IERC20[]
+
+  let loadFixture: ReturnType<typeof createFixtureLoader>
+  let wallet: Wallet
+
+  let chainId: number
+
+  describe('Deployment', () => {
+    before(async () => {
+      ;[wallet] = (await ethers.getSigners()) as unknown as Wallet[]
+      loadFixture = createFixtureLoader([wallet])
+
+      chainId = await getChainId(hre)
+      if (!networkConfig[chainId]) {
+        throw new Error(`Missing network configuration for ${hre.network.name}`)
+      }
+    })
+
+    beforeEach(async () => {
+      ;[owner, addr1] = await ethers.getSigners()
+      ;({ erc20s, collateral, deployer, config } = await loadFixture(
+        defaultFixture
+      ))
+
+      // Deploy DFacadeWriteLib lib
+      const facadeWriteLib = await (await ethers.getContractFactory('FacadeWriteLib')).deploy()
+      const facadeWriteLibAddr = facadeWriteLib.address
+
+      // Deploy Facade
+      const FacadeFactory: ContractFactory = await ethers.getContractFactory('FacadeWrite', {
+        libraries: {
+          FacadeWriteLib: facadeWriteLibAddr,
+        },
+      })
+      facadeWrite = <FacadeWrite>await FacadeFactory.deploy(deployer.address)
+
+      // Get tokens
+      usdt = <ERC20Mock>erc20s[2] // USDT
+      usdtCollateral = <FiatCollateral>collateral[2] // USDT   
+    })
+
+    it('Should allow to deploy USDT in both prime and backup basket', async () => {
+       // Set parameters
+       rTokenConfig = {
+        name: 'RTKN RToken',
+        symbol: 'RTKN',
+        mandate: 'mandate',
+        params: config,
+      }
+
+      rTokenSetup = {
+        assets: [],
+        primaryBasket: [usdtCollateral.address],
+        weights: [fp('1')],
+        backups: [
+          {
+            backupUnit: ethers.utils.formatBytes32String('USD'),
+            diversityFactor: bn(1),
+            backupCollateral: [usdtCollateral.address],
+          },
+        ],
+      }
+      // Deploy RToken via FacadeWrite
+      const receipt = await (
+        await facadeWrite.connect(addr1).deployRToken(rTokenConfig, rTokenSetup)
+      ).wait()
+
+      const mainAddr = expectInIndirectReceipt(receipt, deployer.interface, 'RTokenCreated').args
+        .main
+
+      main = <TestIMain>await ethers.getContractAt('TestIMain', mainAddr)
+
+      expect(main.address).to.not.equal(ZERO_ADDRESS)
+    })
+  })
+})


### PR DESCRIPTION
* Uses `safeApprove` instead of `safeIncreaseAllowance` to support the USDT case.
* Adapts both P1 and P0
*Adds a new integration test for regression testing

Resolves #383 
