### PR TITLE
Sanitize owner input in deployer

### DIFF
--- a/contracts/p0/Deployer.sol
+++ b/contracts/p0/Deployer.sol
@@ -59,6 +59,8 @@ contract DeployerP0 is IDeployer {
         address owner,
         DeploymentParams memory params
     ) external returns (address) {
+        require(owner != address(0) && owner != address(this), "invalid owner");
+
         MainP0 main = new MainP0();
 
         // Components

--- a/contracts/p1/Deployer.sol
+++ b/contracts/p1/Deployer.sol
@@ -104,6 +104,8 @@ contract DeployerP1 is IDeployer {
         address owner,
         DeploymentParams memory params
     ) external returns (address) {
+        require(owner != address(0) && owner != address(this), "invalid owner");
+
         // Main - Proxy
         MainP1 main = MainP1(
             address(new ERC1967Proxy(address(implementations.main), new bytes(0)))

--- a/test/Deployer.test.ts
+++ b/test/Deployer.test.ts
@@ -273,6 +273,16 @@ describe(`DeployerP${IMPLEMENTATION} contract #fast`, () => {
       ).to.be.revertedWith('mandate empty')
     })
 
+    it('Should not allow invalid owner address', async () => {
+      await expect(
+        deployer.deploy('RTKN RToken', 'RTKN', 'mandate', ZERO_ADDRESS, config)
+      ).to.be.revertedWith('invalid owner')
+
+      await expect(
+        deployer.deploy('RTKN RToken', 'RTKN', 'mandate', deployer.address, config)
+      ).to.be.revertedWith('invalid owner')
+    })
+
     it('Should setup Main correctly', async () => {
       // Assets
       // RSR


### PR DESCRIPTION
* Adds checks for `owner` in DeployerP0 and DeployerP1. Includes tests.

Resolves #373  