### PR TITLE
Prevent `maxTradeSlippage` of 100%

### DIFF
--- a/contracts/p0/mixins/Trading.sol
+++ b/contracts/p0/mixins/Trading.sol
@@ -74,7 +74,7 @@ abstract contract TradingP0 is RewardableP0, ITrading {
 
     /// @custom:governance
     function setMaxTradeSlippage(uint192 val) public governance {
-        require(val <= MAX_TRADE_SLIPPAGE, "invalid maxTradeSlippage");
+        require(val < MAX_TRADE_SLIPPAGE, "invalid maxTradeSlippage");
         emit MaxTradeSlippageSet(maxTradeSlippage, val);
         maxTradeSlippage = val;
     }

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -111,7 +111,7 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
 
     /// @custom:governance
     function setMaxTradeSlippage(uint192 val) public governance {
-        require(val <= MAX_TRADE_SLIPPAGE, "invalid maxTradeSlippage");
+        require(val < MAX_TRADE_SLIPPAGE, "invalid maxTradeSlippage");
         emit MaxTradeSlippageSet(maxTradeSlippage, val);
         maxTradeSlippage = val;
     }

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -935,7 +935,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
 
       // Cannot update with value > max
       await expect(
-        backingManager.connect(owner).setMaxTradeSlippage(MAX_TRADE_SLIPPAGE.add(1))
+        backingManager.connect(owner).setMaxTradeSlippage(MAX_TRADE_SLIPPAGE)
       ).to.be.revertedWith('invalid maxTradeSlippage')
     })
 


### PR DESCRIPTION
* Allows only values < 100%
* Adapt tests

Resolves #377 