### PR TITLE
fix endIdForVest calculation

### DIFF
--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -189,7 +189,7 @@ contract FacadeRead is IFacadeRead {
             uint256 test = (left + right) / 2;
             // In this condition: D18{block} < D18{block}
             item = rToken.issueItem(account, test);
-            if (item.when < blockNumber) left = test;
+            if (item.when <= blockNumber) left = test;
             else right = test;
         }
         return right;


### PR DESCRIPTION
* Replaces `<` for `<=` in the calculations for `endIdForVest` in `FacadeRead`
* Refactors one of the tests that was used as regression testing. Confirmed the issue was occurring and added additional checks in the test to make it more robust.

Closes #375 