### PR TITLE
Basket handler coverage

### DIFF
--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -323,7 +323,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
                 // but return FIX_MAX instead of throwing overflow errors.
                 unchecked {
                     // price_, mul, and p *are* Fix values, so have 18 decimals (D18)
-                    uint256 rawDelta = price_ * qty; // {D36} = {D18} * {D18}
+                    uint256 rawDelta = uint256(price_) * qty; // {D36} = {D18} * {D18}
                     // if we overflowed *, then return FIX_MAX
                     if (rawDelta / price_ != qty) return (true, FIX_MAX);
                     uint256 delta = rawDelta / FIX_ONE; // {D18} = {D36} / {D18}

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1758,7 +1758,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect(price).to.equal(MAX_UINT192)
     })
 
-    it.only('Should return FIX_MAX as basket price in case of 2nd overflow (for individual collateral)', async () => {
+    it('Should return FIX_MAX as basket price in case of 2nd overflow (for individual collateral)', async () => {
       expect(await basketHandler.quantity(token2.address)).to.equal(basketsNeededAmts[2])
 
       // Swap out collateral plugin for one that can return a 0 price without raising FIX_MAX

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1742,8 +1742,42 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect(await basketHandler.basketsHeldBy(addr1.address)).to.equal(0)
     })
 
-    it('Should return FIX_MAX as basket price in case of overflow (for individual collateral)', async () => {
+    it('Should return FIX_MAX as basket price in case of 1st overflow (for individual collateral)', async () => {
       expect(await basketHandler.quantity(token2.address)).to.equal(basketsNeededAmts[2])
+
+      // Set RefperTok = 0
+      await token2.setExchangeRate(fp('0'))
+      expect(await basketHandler.quantity(token2.address)).to.equal(MAX_UINT192)
+
+      // Also set price of underlying to 0 so Fallback price is used
+      await setOraclePrice(collateral2.address, bn(0))
+
+      // Check BU price
+      const [isFallback, price] = await basketHandler.price(true)
+      expect(isFallback).to.equal(true)
+      expect(price).to.equal(MAX_UINT192)
+    })
+
+    it.only('Should return FIX_MAX as basket price in case of 2nd overflow (for individual collateral)', async () => {
+      expect(await basketHandler.quantity(token2.address)).to.equal(basketsNeededAmts[2])
+
+      // Swap out collateral plugin for one that can return a 0 price without raising FIX_MAX
+      const ATokenCollateralFactory = await ethers.getContractFactory('ATokenFiatCollateral', {
+        libraries: { OracleLib: oracleLib.address },
+      })
+      const coll = <ATokenFiatCollateral>await ATokenCollateralFactory.deploy(
+        fp('1.01'), // fallback price just above 1
+        await collateral2.chainlinkFeed(),
+        await collateral2.erc20(),
+        aaveToken.address,
+        config.rTokenMaxTradeVolume,
+        await collateral2.oracleTimeout(),
+        ethers.utils.formatBytes32String('USD'),
+        await collateral2.defaultThreshold(),
+        await collateral2.delayUntilDefault()
+      )
+      await assetRegistry.connect(owner).swapRegistered(coll.address)
+      await basketHandler.refreshBasket()
 
       // Set RefperTok = 0
       await token2.setExchangeRate(fp('0'))


### PR DESCRIPTION
Found a real bug while doing this coverage. We need to upcast the `rawDelta` calculation in order to avoid calculating `rawDelta` as the result mod FIX_MAX, which is not the intent. 

Resolves #431 
