### PR TITLE
Static a token reentrancy

### DIFF
--- a/contracts/plugins/aave/ReentrancyGuard.sol
+++ b/contracts/plugins/aave/ReentrancyGuard.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @dev Contract module that helps prevent reentrant calls to a function.
+ *
+ * Inheriting from `ReentrancyGuard` will make the {nonReentrant} modifier
+ * available, which can be applied to functions to make sure there are no nested
+ * (reentrant) calls to them.
+ *
+ * Note that because there is a single `nonReentrant` guard, functions marked as
+ * `nonReentrant` may not call one another. This can be worked around by making
+ * those functions `private`, and then adding `external` `nonReentrant` entry
+ * points to them.
+ *
+ * TIP: If you would like to learn more about reentrancy and alternative ways
+ * to protect against it, check out our blog post
+ * https://blog.openzeppelin.com/reentrancy-after-istanbul/[Reentrancy After Istanbul].
+ */
+abstract contract ReentrancyGuard {
+    // Booleans are more expensive than uint256 or any type that takes up a full
+    // word because each write operation emits an extra SLOAD to first read the
+    // slot's contents, replace the bits taken up by the boolean, and then write
+    // back. This is the compiler's defense against contract upgrades and
+    // pointer aliasing, and it cannot be disabled.
+
+    // The values being non-zero value makes deployment a bit more expensive,
+    // but in exchange the refund on every call to nonReentrant will be lower in
+    // amount. Since refunds are capped to a percentage of the total
+    // transaction's gas, it is best to keep them low in cases like this one, to
+    // increase the likelihood of the full refund coming into effect.
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    uint256 private _status;
+
+    constructor() internal {
+        _status = _NOT_ENTERED;
+    }
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and make it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _status = _ENTERED;
+
+        _;
+
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _status = _NOT_ENTERED;
+    }
+}

--- a/contracts/plugins/aave/StaticATokenLM.sol
+++ b/contracts/plugins/aave/StaticATokenLM.sol
@@ -288,15 +288,15 @@ contract StaticATokenLM is ERC20("STATIC_ATOKEN_IMPL", "STATIC_ATOKEN_IMPL"), IS
         require(recipient != address(0), StaticATokenErrors.INVALID_RECIPIENT);
         _updateRewards();
 
-        uint256 amountToMint = _dynamicToStaticAmount(amount, rate());
-        _mint(recipient, amountToMint);
-
         if (fromUnderlying) {
             ASSET.safeTransferFrom(depositor, address(this), amount);
             LENDING_POOL.deposit(address(ASSET), amount, address(this), referralCode);
         } else {
             ATOKEN.safeTransferFrom(depositor, address(this), amount);
         }
+
+        uint256 amountToMint = _dynamicToStaticAmount(amount, rate());
+        _mint(recipient, amountToMint);
 
         return amountToMint;
     }

--- a/contracts/plugins/aave/StaticATokenLM.sol
+++ b/contracts/plugins/aave/StaticATokenLM.sol
@@ -13,12 +13,12 @@ import { IAaveIncentivesController } from "./IAaveIncentivesController.sol";
 import { StaticATokenErrors } from "./StaticATokenErrors.sol";
 
 import { ERC20 } from "./ERC20.sol";
+import { ReentrancyGuard } from "./ReentrancyGuard.sol";
+
 import { SafeERC20 } from "@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/SafeERC20.sol";
 import { WadRayMath } from "@aave/protocol-v2/contracts/protocol/libraries/math/WadRayMath.sol";
 import { RayMathNoRounding } from "./RayMathNoRounding.sol";
 import { SafeMath } from "@aave/protocol-v2/contracts/dependencies/openzeppelin/contracts/SafeMath.sol";
-
-import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /**
  * @title StaticATokenLM
@@ -400,7 +400,6 @@ contract StaticATokenLM is
         }
     }
 
-    ///@inheritdoc IStaticATokenLM
     function _collectAndUpdateRewards() internal {
         if (address(INCENTIVES_CONTROLLER) == address(0)) {
             return;


### PR DESCRIPTION
This PR reverts the ordering change we previously introduced in an attempt to make `StaticATokenLM` reentrancy-safe. We think it likely broke rate accounting, though we have been unable to confirm this with the Aave team in their discord. (Aside: what a shitshow. There are like 20 questions for every answer, and over half the questions could be answered by an arbitrary smart contract developer, even if you knew nothing about Aave. They're overwhelmed by noise. Noting loudly so that we can try to avoid this same fate as we grow.)

In the new approach, every non-ERC20 external function in `StaticATokenLM` is covered with `nonReentrant`. `StaticATokenLM` inherits from `ERC20`. I do not think we have to cover the external ERC20 functions because they cannot change the token supply. The underlying ERC20 layer only deals with approvals/transfers, and transfers cannot be to the zero address. It is only through external `StaticATokenLM` functions that the token supply can change. This is the relevant data in the context of the `_deposit` function, which is where our CEI-violation sits. 

You could enter the ERC20 functions during execution of `_deposit`, but this would not allow you to break `_deposit`. I believe as long as we cover the `StaticATokenLM` contract's external functions (ignoring inherited ERC20) then we should be reentrant-safe. The ERC20 functions themselves do not have any interactions, and all adhere to CEI. 

Resolves #445