### PR TITLE
FacadeWrite beneficiary revShare

### DIFF
--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -284,6 +284,8 @@ export interface IRTokenSetup {
   primaryBasket: string[]
   weights: BigNumber[]
   backups: IBackupInfo[]
+  beneficiary: string
+  revShare: IRevenueShare
 }
 
 export interface IGovParams {

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -94,7 +94,10 @@ contract FacadeWrite is IFacadeWrite {
         }
 
         // Setup revshare beneficiary
-        if (setup.revShare.rTokenDist > 0 || setup.revShare.rsrDist > 0) {
+        if (
+            setup.beneficiary != address(0) &&
+            (setup.revShare.rTokenDist > 0 || setup.revShare.rsrDist > 0)
+        ) {
             main.distributor().setDistribution(setup.beneficiary, setup.revShare);
         }
 

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -33,6 +33,13 @@ contract FacadeWrite is IFacadeWrite {
             require(setup.backups[i].backupCollateral.length > 0, "no backup collateral");
         }
 
+        // Validate beneficiary was set intentionally
+        require(
+            setup.beneficiary != address(0) ||
+                (setup.revShare.rTokenDist == 0 && setup.revShare.rsrDist == 0),
+            "beneficiary revShare mismatch"
+        );
+
         // Deploy contracts
         IRToken rToken = IRToken(
             deployer.deploy(
@@ -46,11 +53,14 @@ contract FacadeWrite is IFacadeWrite {
 
         // Get Main
         IMain main = rToken.main();
+        IAssetRegistry assetRegistry = main.assetRegistry();
+        IBackingManager backingManager = main.backingManager();
+        IBasketHandler basketHandler = main.basketHandler();
 
         // Register assets
         for (uint256 i = 0; i < setup.assets.length; ++i) {
-            main.assetRegistry().register(setup.assets[i]);
-            main.backingManager().grantRTokenAllowance(setup.assets[i].erc20());
+            assetRegistry.register(setup.assets[i]);
+            backingManager.grantRTokenAllowance(setup.assets[i].erc20());
         }
 
         // Setup basket
@@ -59,15 +69,15 @@ contract FacadeWrite is IFacadeWrite {
 
             // Register collateral
             for (uint256 i = 0; i < setup.primaryBasket.length; ++i) {
-                main.assetRegistry().register(setup.primaryBasket[i]);
+                assetRegistry.register(setup.primaryBasket[i]);
                 IERC20 erc20 = setup.primaryBasket[i].erc20();
                 basketERC20s[i] = erc20;
-                main.backingManager().grantRTokenAllowance(erc20);
+                backingManager.grantRTokenAllowance(erc20);
             }
 
             // Set basket
-            main.basketHandler().setPrimeBasket(basketERC20s, setup.weights);
-            main.basketHandler().refreshBasket();
+            basketHandler.setPrimeBasket(basketERC20s, setup.weights);
+            basketHandler.refreshBasket();
         }
 
         // Setup backup config
@@ -79,13 +89,13 @@ contract FacadeWrite is IFacadeWrite {
 
                 for (uint256 j = 0; j < setup.backups[i].backupCollateral.length; ++j) {
                     ICollateral backupColl = setup.backups[i].backupCollateral[j];
-                    main.assetRegistry().register(backupColl);
+                    assetRegistry.register(backupColl);
                     IERC20 erc20 = backupColl.erc20();
                     backupERC20s[j] = erc20;
-                    main.backingManager().grantRTokenAllowance(erc20);
+                    backingManager.grantRTokenAllowance(erc20);
                 }
 
-                main.basketHandler().setBackupConfig(
+                basketHandler.setBackupConfig(
                     setup.backups[i].backupUnit,
                     setup.backups[i].diversityFactor,
                     backupERC20s
@@ -94,10 +104,7 @@ contract FacadeWrite is IFacadeWrite {
         }
 
         // Setup revshare beneficiary
-        if (
-            setup.beneficiary != address(0) &&
-            (setup.revShare.rTokenDist > 0 || setup.revShare.rsrDist > 0)
-        ) {
+        if (setup.beneficiary != address(0)) {
             main.distributor().setDistribution(setup.beneficiary, setup.revShare);
         }
 

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -49,7 +49,7 @@ contract FacadeWrite is IFacadeWrite {
 
         // Register assets
         for (uint256 i = 0; i < setup.assets.length; ++i) {
-            IAssetRegistry(address(main.assetRegistry())).register(setup.assets[i]);
+            main.assetRegistry().register(setup.assets[i]);
             main.backingManager().grantRTokenAllowance(setup.assets[i].erc20());
         }
 
@@ -59,7 +59,7 @@ contract FacadeWrite is IFacadeWrite {
 
             // Register collateral
             for (uint256 i = 0; i < setup.primaryBasket.length; ++i) {
-                IAssetRegistry(address(main.assetRegistry())).register(setup.primaryBasket[i]);
+                main.assetRegistry().register(setup.primaryBasket[i]);
                 IERC20 erc20 = setup.primaryBasket[i].erc20();
                 basketERC20s[i] = erc20;
                 main.backingManager().grantRTokenAllowance(erc20);
@@ -70,7 +70,7 @@ contract FacadeWrite is IFacadeWrite {
             main.basketHandler().refreshBasket();
         }
 
-        // Set backup config
+        // Setup backup config
         {
             for (uint256 i = 0; i < setup.backups.length; ++i) {
                 IERC20[] memory backupERC20s = new IERC20[](
@@ -79,7 +79,7 @@ contract FacadeWrite is IFacadeWrite {
 
                 for (uint256 j = 0; j < setup.backups[i].backupCollateral.length; ++j) {
                     ICollateral backupColl = setup.backups[i].backupCollateral[j];
-                    IAssetRegistry(address(main.assetRegistry())).register(backupColl);
+                    main.assetRegistry().register(backupColl);
                     IERC20 erc20 = backupColl.erc20();
                     backupERC20s[j] = erc20;
                     main.backingManager().grantRTokenAllowance(erc20);
@@ -91,6 +91,11 @@ contract FacadeWrite is IFacadeWrite {
                     backupERC20s
                 );
             }
+        }
+
+        // Setup revshare beneficiary
+        if (setup.revShare.rTokenDist > 0 || setup.revShare.rsrDist > 0) {
+            main.distributor().setDistribution(setup.beneficiary, setup.revShare);
         }
 
         // Pause until setupGovernance

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -57,4 +57,8 @@ interface TestIDistributor is IDistributor {
 
     // solhint-disable-next-line func-name-mixedcase
     function ST_RSR() external view returns (address);
+
+    /// @return rTokenDist The RToken distribution for the address
+    /// @return rsrDist The RSR distribution for the address
+    function distribution(address) external view returns (uint16 rTokenDist, uint16 rsrDist);
 }

--- a/contracts/interfaces/IFacadeWrite.sol
+++ b/contracts/interfaces/IFacadeWrite.sol
@@ -28,6 +28,9 @@ struct SetupParams {
     uint192[] weights;
     // === Basket Backup ===
     BackupInfo[] backups;
+    // === Revenue Sharing ===
+    address beneficiary;
+    RevenueShare revShare;
 }
 
 /**

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -91,6 +91,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
 
     /// Sets the distribution values - Internals
     function _setDistribution(address dest, RevenueShare memory share) internal {
+        require(dest != address(0), "dest cannot be zero");
         if (dest == FURNACE) require(share.rsrDist == 0, "Furnace must get 0% of RSR");
         if (dest == ST_RSR) require(share.rTokenDist == 0, "StRSR must get 0% of RToken");
         require(share.rsrDist <= 10000, "RSR distribution too high");

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -13,7 +13,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     EnumerableSet.AddressSet internal destinations;
-    mapping(address => RevenueShare) internal distribution;
+    mapping(address => RevenueShare) public distribution;
     // invariant: distribution values are all nonnegative, and at least one is nonzero.
     // invariant: distribution[FURNACE].rsrDist == FIX_ZERO
     // invariant: distribution[ST_RSR].rTokenDist == FIX_ZERO

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -15,7 +15,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     EnumerableSet.AddressSet internal destinations;
-    mapping(address => RevenueShare) internal distribution;
+    mapping(address => RevenueShare) public distribution;
 
     // ==== Invariants ====
     // distribution is nonzero. (That is, distribution has at least one nonzero value)

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -159,6 +159,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     //   destinations' = destinations.add(dest)
     //   distribution' = distribution.set(dest, share)
     function _setDistribution(address dest, RevenueShare memory share) internal {
+        require(dest != address(0), "dest cannot be zero");
         if (dest == FURNACE) require(share.rsrDist == 0, "Furnace must get 0% of RSR");
         if (dest == ST_RSR) require(share.rTokenDist == 0, "StRSR must get 0% of RToken");
         require(share.rsrDist <= 10000, "RSR distribution too high");

--- a/scripts/deployment/phase3-rtoken/1_deploy_rtoken.ts
+++ b/scripts/deployment/phase3-rtoken/1_deploy_rtoken.ts
@@ -65,6 +65,11 @@ async function main() {
         backupCollateral: [assetCollDeployments.collateral.USDC as string],
       },
     ],
+    beneficiary: deployerUser.address, // doesn't matter what this is since it won't get used
+    revShare: {
+      rTokenDist: bn('0'),
+      rsrDist: bn('0'),
+    },
   }
 
   // Validate assets

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -203,26 +203,23 @@ describe('FacadeWrite contract', () => {
       facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
     ).to.be.revertedWith('beneficiary revShare mismatch')
 
-    // Cannot deploy with no basket
-    rTokenSetup.primaryBasket = []
+    // Cannot deploy backup info with no collateral tokens
+    rTokenSetup.backups[0].backupCollateral = []
     await expect(
       facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
-    ).to.be.revertedWith('no collateral')
+    ).to.be.revertedWith('no backup collateral')
 
     // Cannot deploy with invalid length in weights
-    rTokenSetup.primaryBasket = [tokenAsset.address, usdcAsset.address]
     rTokenSetup.weights = [fp('1')]
     await expect(
       facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
     ).to.be.revertedWith('invalid length')
 
-    // Cannot deploy backup info with no collateral tokens
-    rTokenSetup.primaryBasket = [tokenAsset.address, usdcAsset.address]
-    rTokenSetup.weights = [fp('0.5'), fp('0.5')]
-    rTokenSetup.backups[0].backupCollateral = []
+    // Cannot deploy with no basket
+    rTokenSetup.primaryBasket = []
     await expect(
       facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
-    ).to.be.revertedWith('no backup collateral')
+    ).to.be.revertedWith('no collateral')
   })
 
   describe('Deployment Process', () => {

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -197,6 +197,12 @@ describe('FacadeWrite contract', () => {
   })
 
   it('Should perform validations', async () => {
+    // Should not accept zero addr beneficiary
+    rTokenSetup.beneficiary = ZERO_ADDRESS
+    await expect(
+      facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
+    ).to.be.revertedWith('beneficiary revShare mismatch')
+
     // Cannot deploy with no basket
     rTokenSetup.primaryBasket = []
     await expect(

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -296,12 +296,18 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       await distributor
         .connect(owner)
         .setDistribution(FURNACE_DEST, { rTokenDist: bn(0), rsrDist: bn(0) })
-
       await expect(
         distributor
           .connect(owner)
           .setDistribution(STRSR_DEST, { rTokenDist: bn(0), rsrDist: bn(0) })
       ).to.be.revertedWith('no distribution defined')
+
+      // Cannot set zero addr beneficiary
+      await expect(
+        distributor
+          .connect(owner)
+          .setDistribution(ZERO_ADDRESS, { rTokenDist: bn(5), rsrDist: bn(5) })
+      ).to.be.revertedWith('dest cannot be zero')
     })
 
     it('Should validate number of destinations', async () => {

--- a/test/integration/Deployment.test.ts
+++ b/test/integration/Deployment.test.ts
@@ -89,6 +89,8 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
             backupCollateral: [usdtCollateral.address],
           },
         ],
+        beneficiary: ZERO_ADDRESS,
+        revShare: { rTokenDist: bn(0), rsrDist: bn(0) },
       }
       // Deploy RToken via FacadeWrite
       const receipt = await (

--- a/test/integration/individual-collateral/CTokenFiatCollateral.test.ts
+++ b/test/integration/individual-collateral/CTokenFiatCollateral.test.ts
@@ -202,6 +202,8 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
       primaryBasket: [cDaiCollateral.address],
       weights: [fp('1')],
       backups: [],
+      beneficiary: ZERO_ADDRESS,
+      revShare: { rTokenDist: bn('0'), rsrDist: bn('0') },
     }
 
     // Deploy RToken via FacadeWrite


### PR DESCRIPTION
Adds a beneficiary address with customizable revShare to `FacadeWrite.deployToken`.

Also:
- Prevent zero addr destinations
- Make `Distributor.distribution` mapping public. Previously you could compute the state of it by traversing previous logs, but it was complicated. 
- Some minor gas optimization stuff

@lcamargof 