### PR TITLE
Use relative paths in imports

### DIFF
--- a/contracts/facade/DeployerRegistry.sol
+++ b/contracts/facade/DeployerRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "contracts/interfaces/IDeployerRegistry.sol";
+import "../interfaces/IDeployerRegistry.sol";
 
 /**
  * @title DeployerRegistry

--- a/contracts/facade/FacadeAct.sol
+++ b/contracts/facade/FacadeAct.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IFacadeAct.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/BasketHandler.sol";
-import "contracts/p1/BackingManager.sol";
-import "contracts/p1/Furnace.sol";
-import "contracts/p1/RToken.sol";
-import "contracts/p1/RevenueTrader.sol";
-import "contracts/p1/StRSRVotes.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IFacadeAct.sol";
+import "../interfaces/IRToken.sol";
+import "../interfaces/IStRSR.sol";
+import "../libraries/Fixed.sol";
+import "../p1/BasketHandler.sol";
+import "../p1/BackingManager.sol";
+import "../p1/Furnace.sol";
+import "../p1/RToken.sol";
+import "../p1/RevenueTrader.sol";
+import "../p1/StRSRVotes.sol";
 
 /**
  * @title Facade

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -2,18 +2,18 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IFacadeRead.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/BasketHandler.sol";
-import "contracts/p1/BackingManager.sol";
-import "contracts/p1/Furnace.sol";
-import "contracts/p1/RToken.sol";
-import "contracts/p1/RevenueTrader.sol";
-import "contracts/p1/StRSRVotes.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IFacadeRead.sol";
+import "../interfaces/IRToken.sol";
+import "../interfaces/IStRSR.sol";
+import "../libraries/Fixed.sol";
+import "../p1/BasketHandler.sol";
+import "../p1/BackingManager.sol";
+import "../p1/Furnace.sol";
+import "../p1/RToken.sol";
+import "../p1/RevenueTrader.sol";
+import "../p1/StRSRVotes.sol";
 
 /**
  * @title Facade

--- a/contracts/facade/FacadeTest.sol
+++ b/contracts/facade/FacadeTest.sol
@@ -2,12 +2,12 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IFacadeTest.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/libraries/Fixed.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IFacadeTest.sol";
+import "../interfaces/IRToken.sol";
+import "../interfaces/IStRSR.sol";
+import "../libraries/Fixed.sol";
 
 /**
  * @title FacadeTest

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/interfaces/IFacadeWrite.sol";
-import "contracts/facade/lib/FacadeWriteLib.sol";
+import "../interfaces/IFacadeWrite.sol";
+import "./lib/FacadeWriteLib.sol";
 
 /**
  * @title FacadeWrite

--- a/contracts/facade/lib/FacadeWriteLib.sol
+++ b/contracts/facade/lib/FacadeWriteLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/governance/Governance.sol";
+import "../../plugins/governance/Governance.sol";
 
 library FacadeWriteLib {
     /// @return The new Governance contract address

--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IMain.sol";
 import "./IRewardable.sol";
 

--- a/contracts/interfaces/IAssetRegistry.sol
+++ b/contracts/interfaces/IAssetRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
+import "./IAsset.sol";
 import "./IComponent.sol";
 
 /**

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IAsset.sol";
 import "./IComponent.sol";
 

--- a/contracts/interfaces/IFacadeAct.sol
+++ b/contracts/interfaces/IFacadeAct.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/RToken.sol";
+import "../p1/RToken.sol";
 
 /**
  * @title IFacadeAct

--- a/contracts/interfaces/IFacadeRead.sol
+++ b/contracts/interfaces/IFacadeRead.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/RToken.sol";
+import "../p1/RToken.sol";
 import "./IRToken.sol";
 import "./IStRSR.sol";
 

--- a/contracts/interfaces/IFurnace.sol
+++ b/contracts/interfaces/IFurnace.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IComponent.sol";
 
 /**

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 // solhint-disable-next-line max-line-length
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IAsset.sol";
 import "./IComponent.sol";
 import "./IMain.sol";

--- a/contracts/interfaces/IStRSR.sol
+++ b/contracts/interfaces/IStRSR.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 // solhint-disable-next-line max-line-length
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol";
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IComponent.sol";
 import "./IMain.sol";
 

--- a/contracts/interfaces/ITrading.sol
+++ b/contracts/interfaces/ITrading.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/libraries/Fixed.sol";
+import "../libraries/Fixed.sol";
 import "./IAsset.sol";
 import "./IComponent.sol";
 import "./ITrade.sol";

--- a/contracts/libraries/RedemptionBattery.sol
+++ b/contracts/libraries/RedemptionBattery.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/interfaces/IRToken.sol";
+import "../interfaces/IRToken.sol";
 import "./Fixed.sol";
 
 // NOTE: This algorithm assumes the contract is running on PoS Ethereum and 100% of the

--- a/contracts/mixins/Auth.sol
+++ b/contracts/mixins/Auth.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "contracts/interfaces/IMain.sol";
+import "../interfaces/IMain.sol";
 
 uint256 constant LONG_FREEZE_CHARGES = 6; // 6 uses
 uint48 constant MAX_UNFREEZE_AT = type(uint48).max;

--- a/contracts/mixins/ComponentRegistry.sol
+++ b/contracts/mixins/ComponentRegistry.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/mixins/Auth.sol";
+import "../interfaces/IMain.sol";
+import "./Auth.sol";
 
 /**
  * @title ComponentRegistry

--- a/contracts/mixins/Versioned.sol
+++ b/contracts/mixins/Versioned.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/interfaces/IVersioned.sol";
+import "../interfaces/IVersioned.sol";
 
 /**
  * @title Versioned

--- a/contracts/p0/AssetRegistry.sol
+++ b/contracts/p0/AssetRegistry.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../interfaces/IMain.sol";
+import "./mixins/Component.sol";
 
 /// The AssetRegistry provides the mapping from ERC20 to Asset, allowing the rest of Main
 /// to think in terms of ERC20 tokens and target/ref units.

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/p0/mixins/TradingLib.sol";
-import "contracts/p0/mixins/Trading.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Array.sol";
-import "contracts/libraries/Fixed.sol";
+import "./mixins/TradingLib.sol";
+import "./mixins/Trading.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IBroker.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Array.sol";
+import "../libraries/Fixed.sol";
 
 /**
  * @title BackingManager

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -5,12 +5,12 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/p0/mixins/Component.sol";
-import "contracts/libraries/Array.sol";
-import "contracts/libraries/Fixed.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IMain.sol";
+import "./mixins/Component.sol";
+import "../libraries/Array.sol";
+import "../libraries/Fixed.sol";
 
 // A "valid collateral array" is a an IERC20[] value without rtoken, rsr, or any duplicate values
 

--- a/contracts/p0/Broker.sol
+++ b/contracts/p0/Broker.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "contracts/plugins/trading/GnosisTrade.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../plugins/trading/GnosisTrade.sol";
+import "../interfaces/IBroker.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/ITrade.sol";
+import "../libraries/Fixed.sol";
+import "./mixins/Component.sol";
 
 // Gnosis: uint96 ~= 7e28
 uint256 constant GNOSIS_MAX_TOKENS = 7e28;

--- a/contracts/p0/Deployer.sol
+++ b/contracts/p0/Deployer.sol
@@ -2,23 +2,23 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/plugins/assets/Asset.sol";
-import "contracts/plugins/assets/RTokenAsset.sol";
-import "contracts/p0/AssetRegistry.sol";
-import "contracts/p0/BackingManager.sol";
-import "contracts/p0/BasketHandler.sol";
-import "contracts/p0/Broker.sol";
-import "contracts/p0/Distributor.sol";
-import "contracts/p0/Furnace.sol";
-import "contracts/p0/Main.sol";
-import "contracts/p0/RevenueTrader.sol";
-import "contracts/p0/RToken.sol";
-import "contracts/p0/StRSR.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IDeployer.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/String.sol";
-import "contracts/mixins/Versioned.sol";
+import "../plugins/assets/Asset.sol";
+import "../plugins/assets/RTokenAsset.sol";
+import "./AssetRegistry.sol";
+import "./BackingManager.sol";
+import "./BasketHandler.sol";
+import "./Broker.sol";
+import "./Distributor.sol";
+import "./Furnace.sol";
+import "./Main.sol";
+import "./RevenueTrader.sol";
+import "./RToken.sol";
+import "./StRSR.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IDeployer.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/String.sol";
+import "../mixins/Versioned.sol";
 
 /**
  * @title DeployerP0

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../interfaces/IMain.sol";
+import "./mixins/Component.sol";
 
 contract DistributorP0 is ComponentP0, IDistributor {
     using SafeERC20 for IERC20;

--- a/contracts/p0/Furnace.sol
+++ b/contracts/p0/Furnace.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/libraries/Fixed.sol";
-import "contracts/interfaces/IFurnace.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../libraries/Fixed.sol";
+import "../interfaces/IFurnace.sol";
+import "./mixins/Component.sol";
 
 /**
  * @title FurnaceP0

--- a/contracts/p0/Main.sol
+++ b/contracts/p0/Main.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/mixins/ComponentRegistry.sol";
-import "contracts/mixins/Auth.sol";
-import "contracts/mixins/Versioned.sol";
+import "../libraries/Fixed.sol";
+import "../interfaces/IMain.sol";
+import "../mixins/ComponentRegistry.sol";
+import "../mixins/Auth.sol";
+import "../mixins/Versioned.sol";
 
 /**
  * @title Main

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -7,14 +7,14 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/IBasketHandler.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/libraries/RedemptionBattery.sol";
-import "contracts/p0/mixins/Component.sol";
-import "contracts/p0/mixins/Rewardable.sol";
-import "contracts/vendor/ERC20PermitUpgradeable.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/IBasketHandler.sol";
+import "../interfaces/IRToken.sol";
+import "../libraries/Fixed.sol";
+import "../libraries/RedemptionBattery.sol";
+import "./mixins/Component.sol";
+import "./mixins/Rewardable.sol";
+import "../vendor/ERC20PermitUpgradeable.sol";
 
 struct SlowIssuance {
     address issuer;

--- a/contracts/p0/RevenueTrader.sol
+++ b/contracts/p0/RevenueTrader.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/p0/mixins/Trading.sol";
-import "contracts/p0/mixins/TradingLib.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "./mixins/Trading.sol";
+import "./mixins/TradingLib.sol";
 
 /// Trader Component that converts all asset balances at its address to a
 /// single target asset and sends this asset to the Distributor.

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -9,13 +9,13 @@ import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IBasketHandler.sol";
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/libraries/Permit.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IBasketHandler.sol";
+import "../interfaces/IStRSR.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Fixed.sol";
+import "../libraries/Permit.sol";
+import "./mixins/Component.sol";
 
 /*
  * @title StRSRP0

--- a/contracts/p0/mixins/Component.sol
+++ b/contracts/p0/mixins/Component.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/mixins/Versioned.sol";
+import "../../interfaces/IMain.sol";
+import "../../mixins/Versioned.sol";
 
 /**
  * Abstract superclass for system contracts registered in Main

--- a/contracts/p0/mixins/Rewardable.sol
+++ b/contracts/p0/mixins/Rewardable.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/Address.sol";
-import "contracts/p0/mixins/Component.sol";
-import "contracts/interfaces/IRewardable.sol";
+import "./Component.sol";
+import "../../interfaces/IRewardable.sol";
 
 /**
  * @title Rewardable

--- a/contracts/p0/mixins/Trading.sol
+++ b/contracts/p0/mixins/Trading.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p0/mixins/Rewardable.sol";
+import "../../interfaces/IBroker.sol";
+import "../../interfaces/IMain.sol";
+import "../../interfaces/ITrade.sol";
+import "../../libraries/Fixed.sol";
+import "./Rewardable.sol";
 
 /// Abstract trading mixin for all Traders, to be paired with TradingLib
 abstract contract TradingP0 is RewardableP0, ITrading {

--- a/contracts/p0/mixins/TradingLib.sol
+++ b/contracts/p0/mixins/TradingLib.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/ITrading.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../interfaces/IAsset.sol";
+import "../../interfaces/IAssetRegistry.sol";
+import "../../interfaces/IMain.sol";
+import "../../interfaces/ITrading.sol";
+import "../../libraries/Fixed.sol";
 
 /**
  * @title TradingLibP0

--- a/contracts/p1/AssetRegistry.sol
+++ b/contracts/p1/AssetRegistry.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/p1/mixins/Component.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IMain.sol";
+import "./mixins/Component.sol";
 
 /// The AssetRegistry provides the mapping from ERC20 to Asset, allowing the rest of Main
 /// to think in terms of ERC20 tokens and target/ref units.

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IBackingManager.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Array.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/mixins/Trading.sol";
-import "contracts/p1/mixins/RecollateralizationLib.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IBackingManager.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Array.sol";
+import "../libraries/Fixed.sol";
+import "./mixins/Trading.sol";
+import "./mixins/RecollateralizationLib.sol";
 
 /**
  * @title BackingManager

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IBasketHandler.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Array.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/mixins/Component.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IBasketHandler.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Array.sol";
+import "../libraries/Fixed.sol";
+import "./mixins/Component.sol";
 
 // A "valid collateral array" is a an IERC20[] value without rtoken, rsr, or any duplicate values
 

--- a/contracts/p1/Broker.sol
+++ b/contracts/p1/Broker.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/mixins/Component.sol";
-import "contracts/plugins/trading/GnosisTrade.sol";
+import "../interfaces/IBroker.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/ITrade.sol";
+import "../libraries/Fixed.sol";
+import "./mixins/Component.sol";
+import "../plugins/trading/GnosisTrade.sol";
 
 // Gnosis: uint96 ~= 7e28
 uint256 constant GNOSIS_MAX_TOKENS = 7e28;

--- a/contracts/p1/Deployer.sol
+++ b/contracts/p1/Deployer.sol
@@ -4,22 +4,22 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IBackingManager.sol";
-import "contracts/interfaces/IBasketHandler.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IDeployer.sol";
-import "contracts/interfaces/IDistributor.sol";
-import "contracts/interfaces/IFurnace.sol";
-import "contracts/interfaces/IRevenueTrader.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/mixins/Versioned.sol";
-import "contracts/plugins/assets/Asset.sol";
-import "contracts/plugins/assets/RTokenAsset.sol";
-import "contracts/p1/Main.sol";
-import "contracts/libraries/String.sol";
+import "../interfaces/IAsset.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "../interfaces/IBackingManager.sol";
+import "../interfaces/IBasketHandler.sol";
+import "../interfaces/IBroker.sol";
+import "../interfaces/IDeployer.sol";
+import "../interfaces/IDistributor.sol";
+import "../interfaces/IFurnace.sol";
+import "../interfaces/IRevenueTrader.sol";
+import "../interfaces/IRToken.sol";
+import "../interfaces/IStRSR.sol";
+import "../mixins/Versioned.sol";
+import "../plugins/assets/Asset.sol";
+import "../plugins/assets/RTokenAsset.sol";
+import "./Main.sol";
+import "../libraries/String.sol";
 
 /**
  * @title DeployerP1

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "contracts/interfaces/IDistributor.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/mixins/Component.sol";
+import "../interfaces/IDistributor.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Fixed.sol";
+import "./mixins/Component.sol";
 
 contract DistributorP1 is ComponentP1, IDistributor {
     using SafeERC20Upgradeable for IERC20Upgradeable;

--- a/contracts/p1/Furnace.sol
+++ b/contracts/p1/Furnace.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/libraries/Fixed.sol";
-import "contracts/interfaces/IFurnace.sol";
-import "contracts/p1/mixins/Component.sol";
+import "../libraries/Fixed.sol";
+import "../interfaces/IFurnace.sol";
+import "./mixins/Component.sol";
 
 /**
  * @title FurnaceP1

--- a/contracts/p1/Main.sol
+++ b/contracts/p1/Main.sol
@@ -5,10 +5,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/mixins/ComponentRegistry.sol";
-import "contracts/mixins/Auth.sol";
-import "contracts/mixins/Versioned.sol";
+import "../interfaces/IMain.sol";
+import "../mixins/ComponentRegistry.sol";
+import "../mixins/Auth.sol";
+import "../mixins/Versioned.sol";
 
 /**
  * @title Main

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.9;
 
 // solhint-disable-next-line max-line-length
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/libraries/RedemptionBattery.sol";
-import "contracts/p1/mixins/Component.sol";
-import "contracts/p1/mixins/RewardableLib.sol";
-import "contracts/vendor/ERC20PermitUpgradeable.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/IRToken.sol";
+import "../libraries/Fixed.sol";
+import "../libraries/RedemptionBattery.sol";
+import "./mixins/Component.sol";
+import "./mixins/RewardableLib.sol";
+import "../vendor/ERC20PermitUpgradeable.sol";
 
 // MIN_BLOCK_ISSUANCE_LIMIT: {rTok/block} 10k whole RTok
 uint192 constant MIN_BLOCK_ISSUANCE_LIMIT = 10_000 * FIX_ONE;

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/p1/mixins/Trading.sol";
-import "contracts/p1/mixins/TradeLib.sol";
+import "../interfaces/IMain.sol";
+import "../interfaces/IAssetRegistry.sol";
+import "./mixins/Trading.sol";
+import "./mixins/TradeLib.sol";
 
 /// Trader Component that converts all asset balances at its address to a
 /// single target asset and sends this asset to the Distributor.

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -8,11 +8,11 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgra
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "contracts/interfaces/IStRSR.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/libraries/Permit.sol";
-import "contracts/p1/mixins/Component.sol";
+import "../interfaces/IStRSR.sol";
+import "../interfaces/IMain.sol";
+import "../libraries/Fixed.sol";
+import "../libraries/Permit.sol";
+import "./mixins/Component.sol";
 
 /*
  * @title StRSRP1

--- a/contracts/p1/StRSRVotes.sol
+++ b/contracts/p1/StRSRVotes.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
-import "contracts/interfaces/IStRSRVotes.sol";
-import "contracts/p1/StRSR.sol";
+import "../interfaces/IStRSRVotes.sol";
+import "./StRSR.sol";
 
 /*
  * @title StRSRP1Votes

--- a/contracts/p1/mixins/Component.sol
+++ b/contracts/p1/mixins/Component.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
-import "contracts/interfaces/IComponent.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/mixins/Versioned.sol";
+import "../../interfaces/IComponent.sol";
+import "../../interfaces/IMain.sol";
+import "../../mixins/Versioned.sol";
 
 /**
  * Abstract superclass for system contracts registered in Main

--- a/contracts/p1/mixins/RecollateralizationLib.sol
+++ b/contracts/p1/mixins/RecollateralizationLib.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/ITrading.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../interfaces/IAsset.sol";
+import "../../interfaces/IAssetRegistry.sol";
+import "../../interfaces/ITrading.sol";
+import "../../libraries/Fixed.sol";
 import "./TradeLib.sol";
 
 /// Struct purposes:

--- a/contracts/p1/mixins/RewardableLib.sol
+++ b/contracts/p1/mixins/RewardableLib.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/IBackingManager.sol";
+import "../../interfaces/IAssetRegistry.sol";
+import "../../interfaces/IBackingManager.sol";
 
 /**
  * @title RewardableLibP1

--- a/contracts/p1/mixins/TradeLib.sol
+++ b/contracts/p1/mixins/TradeLib.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "contracts/interfaces/IAsset.sol";
-import "contracts/interfaces/IAssetRegistry.sol";
-import "contracts/interfaces/ITrading.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../interfaces/IAsset.sol";
+import "../../interfaces/IAssetRegistry.sol";
+import "../../interfaces/ITrading.sol";
+import "../../libraries/Fixed.sol";
 import "./RecollateralizationLib.sol";
 
 /**

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -5,11 +5,11 @@ import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Multicall.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/interfaces/ITrading.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/p1/mixins/Component.sol";
-import "contracts/p1/mixins/RewardableLib.sol";
+import "../../interfaces/ITrade.sol";
+import "../../interfaces/ITrading.sol";
+import "../../libraries/Fixed.sol";
+import "./Component.sol";
+import "./RewardableLib.sol";
 
 /// Abstract trading mixin for all Traders, to be paired with TradingLib
 /// @dev See docs/security for discussion of Multicall safety

--- a/contracts/plugins/assets/ATokenFiatCollateral.sol
+++ b/contracts/plugins/assets/ATokenFiatCollateral.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
+import "../../libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
 
 // This interface is redundant with the one from contracts/plugins/aave/IStaticAToken,
 // but it's compiled with a different solidity version.

--- a/contracts/plugins/assets/AbstractCollateral.sol
+++ b/contracts/plugins/assets/AbstractCollateral.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/interfaces/IAsset.sol";
+import "../../interfaces/IAsset.sol";
 import "./Asset.sol";
 import "./OracleLib.sol";
 

--- a/contracts/plugins/assets/Asset.sol
+++ b/contracts/plugins/assets/Asset.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/interfaces/IAsset.sol";
+import "../../interfaces/IAsset.sol";
 import "./OracleLib.sol";
 
 contract Asset is IAsset {

--- a/contracts/plugins/assets/CTokenFiatCollateral.sol
+++ b/contracts/plugins/assets/CTokenFiatCollateral.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
-import "contracts/plugins/assets/ICToken.sol";
-import "contracts/libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
+import "./ICToken.sol";
+import "../../libraries/Fixed.sol";
 
 /**
  * @title CTokenFiatCollateral

--- a/contracts/plugins/assets/CTokenNonFiatCollateral.sol
+++ b/contracts/plugins/assets/CTokenNonFiatCollateral.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
-import "contracts/plugins/assets/ICToken.sol";
-import "contracts/plugins/assets/OracleLib.sol";
-import "contracts/libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
+import "./ICToken.sol";
+import "./OracleLib.sol";
+import "../../libraries/Fixed.sol";
 
 /**
  * @title CTokenNonFiatCollateral

--- a/contracts/plugins/assets/CTokenSelfReferentialCollateral.sol
+++ b/contracts/plugins/assets/CTokenSelfReferentialCollateral.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/AbstractCollateral.sol";
-import "contracts/plugins/assets/ICToken.sol";
+import "./AbstractCollateral.sol";
+import "./ICToken.sol";
 
 /**
  * @title CTokenSelfReferentialCollateral

--- a/contracts/plugins/assets/EURFiatCollateral.sol
+++ b/contracts/plugins/assets/EURFiatCollateral.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
+import "../../libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
 
 /**
  * @title EURFiatCollateral

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
+import "../../libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
 
 /**
  * @title FiatCollateral

--- a/contracts/plugins/assets/NonFiatCollateral.sol
+++ b/contracts/plugins/assets/NonFiatCollateral.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
+import "../../libraries/Fixed.sol";
+import "./AbstractCollateral.sol";
 
 /**
  * @title NonFiatCollateral

--- a/contracts/plugins/assets/OracleLib.sol
+++ b/contracts/plugins/assets/OracleLib.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../libraries/Fixed.sol";
 
 error StalePrice();
 error PriceOutsideRange();

--- a/contracts/plugins/assets/RTokenAsset.sol
+++ b/contracts/plugins/assets/RTokenAsset.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/Asset.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/IRToken.sol";
-import "contracts/p1/mixins/RecollateralizationLib.sol";
+import "./Asset.sol";
+import "../../interfaces/IMain.sol";
+import "../../interfaces/IRToken.sol";
+import "../../p1/mixins/RecollateralizationLib.sol";
 
 /// Once an RToken gets large eonugh to get a price feed, replacing this asset with
 /// a simpler one will do wonders for gas usage

--- a/contracts/plugins/assets/SelfReferentialCollateral.sol
+++ b/contracts/plugins/assets/SelfReferentialCollateral.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/plugins/assets/AbstractCollateral.sol";
+import "./AbstractCollateral.sol";
 
 /**
  * @title SelfReferentialCollateral

--- a/contracts/plugins/governance/Governance.sol
+++ b/contracts/plugins/governance/Governance.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
-import "contracts/interfaces/IStRSRVotes.sol";
+import "../../interfaces/IStRSRVotes.sol";
 
 /*
  * @title Governance

--- a/contracts/plugins/mocks/ATokenMock.sol
+++ b/contracts/plugins/mocks/ATokenMock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/ATokenFiatCollateral.sol";
-import "contracts/libraries/Fixed.sol";
+import "../assets/ATokenFiatCollateral.sol";
+import "../../libraries/Fixed.sol";
 import "./ERC20Mock.sol";
 
 // This is the inner, rebasing ERC. It's not what we interact with.

--- a/contracts/plugins/mocks/BadCollateralPlugin.sol
+++ b/contracts/plugins/mocks/BadCollateralPlugin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/ATokenFiatCollateral.sol";
+import "../assets/ATokenFiatCollateral.sol";
 
 contract BadCollateralPlugin is ATokenFiatCollateral {
     using OracleLib for AggregatorV3Interface;

--- a/contracts/plugins/mocks/BadERC20.sol
+++ b/contracts/plugins/mocks/BadERC20.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/Address.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../libraries/Fixed.sol";
 import "./ERC20Mock.sol";
 
 contract BadERC20 is ERC20Mock {

--- a/contracts/plugins/mocks/CTokenMock.sol
+++ b/contracts/plugins/mocks/CTokenMock.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../libraries/Fixed.sol";
 import "./ERC20Mock.sol";
 
 contract CTokenMock is ERC20Mock {

--- a/contracts/plugins/mocks/ERC1271Mock.sol
+++ b/contracts/plugins/mocks/ERC1271Mock.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/utils/Address.sol";
-import "contracts/libraries/Fixed.sol";
+import "../../libraries/Fixed.sol";
 import "./ERC20Mock.sol";
 
 /// Represents a simple smart contract wallet that provides approvals via ERC1271

--- a/contracts/plugins/mocks/EasyAuction.sol
+++ b/contracts/plugins/mocks/EasyAuction.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.6.12;
 
-import "contracts/plugins/mocks/vendor/EasyAuction.sol";
+import "./vendor/EasyAuction.sol";
 
 // ==== From https://etherscan.io/address/0x0b7ffc1f4ad541a4ed16b40d8c37f0929158d101 ====
 

--- a/contracts/plugins/mocks/GnosisMock.sol
+++ b/contracts/plugins/mocks/GnosisMock.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/plugins/trading/GnosisTrade.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Fixed.sol";
+import "../trading/GnosisTrade.sol";
+import "../../interfaces/IMain.sol";
+import "../../libraries/Fixed.sol";
 
 interface IBiddable {
     /// @param auctionId An internal auction id, not the one from AssetManager

--- a/contracts/plugins/mocks/GnosisMockReentrant.sol
+++ b/contracts/plugins/mocks/GnosisMockReentrant.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/mocks/GnosisMock.sol";
+import "../../interfaces/ITrade.sol";
+import "../../libraries/Fixed.sol";
+import "./GnosisMock.sol";
 
 /// A Gnosis Mock that attemts to reenter on initiateAuction
 // Simply used for a specific test, not intended to provide valuable functionality

--- a/contracts/plugins/mocks/InvalidATokenFiatCollateralMock.sol
+++ b/contracts/plugins/mocks/InvalidATokenFiatCollateralMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/ATokenFiatCollateral.sol";
+import "../assets/ATokenFiatCollateral.sol";
 
 contract InvalidATokenFiatCollateralMock is ATokenFiatCollateral {
     /// @param maxTradeVolume_ {UoA} The max trade volume, in UoA

--- a/contracts/plugins/mocks/InvalidBrokerMock.sol
+++ b/contracts/plugins/mocks/InvalidBrokerMock.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "contracts/plugins/trading/GnosisTrade.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/interfaces/ITrade.sol";
-import "contracts/p0/mixins/Component.sol";
+import "../trading/GnosisTrade.sol";
+import "../../interfaces/IBroker.sol";
+import "../../interfaces/IMain.sol";
+import "../../interfaces/ITrade.sol";
+import "../../p0/mixins/Component.sol";
 
 /// A simple core contract that deploys disposable trading contracts for Traders
 contract InvalidBrokerMock is ComponentP0, IBroker {

--- a/contracts/plugins/mocks/NontrivialPegCollateral.sol
+++ b/contracts/plugins/mocks/NontrivialPegCollateral.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/plugins/assets/FiatCollateral.sol";
+import "../assets/FiatCollateral.sol";
 
 contract NontrivialPegCollateral is FiatCollateral {
     uint192 private peg = FIX_ONE; // {target/ref}

--- a/contracts/plugins/mocks/RTokenCollateral.sol
+++ b/contracts/plugins/mocks/RTokenCollateral.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "contracts/interfaces/IMain.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/plugins/assets/RTokenAsset.sol";
+import "../../interfaces/IMain.sol";
+import "../../libraries/Fixed.sol";
+import "../assets/RTokenAsset.sol";
 
 /**
  * @title RTokenCollateral

--- a/contracts/plugins/mocks/upgrades/AssetRegistryV2.sol
+++ b/contracts/plugins/mocks/upgrades/AssetRegistryV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/AssetRegistry.sol";
+import "../../../p1/AssetRegistry.sol";
 
 contract AssetRegistryP1V2 is AssetRegistryP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/BackingManagerV2.sol
+++ b/contracts/plugins/mocks/upgrades/BackingManagerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/BackingManager.sol";
+import "../../../p1/BackingManager.sol";
 
 /// @custom:oz-upgrades-unsafe-allow external-library-linking
 contract BackingManagerP1V2 is BackingManagerP1 {

--- a/contracts/plugins/mocks/upgrades/BasketHandlerV2.sol
+++ b/contracts/plugins/mocks/upgrades/BasketHandlerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/BasketHandler.sol";
+import "../../../p1/BasketHandler.sol";
 
 contract BasketHandlerP1V2 is BasketHandlerP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/BrokerV2.sol
+++ b/contracts/plugins/mocks/upgrades/BrokerV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/Broker.sol";
+import "../../../p1/Broker.sol";
 
 contract BrokerP1V2 is BrokerP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/DistributorV2.sol
+++ b/contracts/plugins/mocks/upgrades/DistributorV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/Distributor.sol";
+import "../../../p1/Distributor.sol";
 
 contract DistributorP1V2 is DistributorP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/FurnaceV2.sol
+++ b/contracts/plugins/mocks/upgrades/FurnaceV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/Furnace.sol";
+import "../../../p1/Furnace.sol";
 
 contract FurnaceP1V2 is FurnaceP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/MainV2.sol
+++ b/contracts/plugins/mocks/upgrades/MainV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/Main.sol";
+import "../../../p1/Main.sol";
 
 contract MainP1V2 is MainP1 {
     uint256 public newValue;

--- a/contracts/plugins/mocks/upgrades/RTokenV2.sol
+++ b/contracts/plugins/mocks/upgrades/RTokenV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/RToken.sol";
+import "../../../p1/RToken.sol";
 
 /// @custom:oz-upgrades-unsafe-allow external-library-linking
 contract RTokenP1V2 is RTokenP1 {

--- a/contracts/plugins/mocks/upgrades/RevenueTraderV2.sol
+++ b/contracts/plugins/mocks/upgrades/RevenueTraderV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/RevenueTrader.sol";
+import "../../../p1/RevenueTrader.sol";
 
 /// @custom:oz-upgrades-unsafe-allow external-library-linking
 contract RevenueTraderP1V2 is RevenueTraderP1 {

--- a/contracts/plugins/mocks/upgrades/StRSRV2.sol
+++ b/contracts/plugins/mocks/upgrades/StRSRV2.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.9;
 
-import "contracts/p1/StRSRVotes.sol";
+import "../../../p1/StRSRVotes.sol";
 
 contract StRSRP1VotesV2 is StRSRP1Votes {
     uint256 public newValue;

--- a/contracts/plugins/trading/GnosisTrade.sol
+++ b/contracts/plugins/trading/GnosisTrade.sol
@@ -4,10 +4,10 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import "contracts/libraries/Fixed.sol";
-import "contracts/interfaces/IBroker.sol";
-import "contracts/interfaces/IGnosis.sol";
-import "contracts/interfaces/ITrade.sol";
+import "../../libraries/Fixed.sol";
+import "../../interfaces/IBroker.sol";
+import "../../interfaces/IGnosis.sol";
+import "../../interfaces/ITrade.sol";
 
 enum TradeStatus {
     NOT_STARTED, // before init()

--- a/contracts/vendor/ERC20PermitUpgradeable.sol
+++ b/contracts/vendor/ERC20PermitUpgradeable.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "contracts/libraries/Permit.sol";
+import "../libraries/Permit.sol";
 
 /**
  * @dev Implementation of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in


### PR DESCRIPTION
This change is so that the Reserve Protocol repo can be used as a hardhat dependency. That way, `reserve` can be used as a dependency like I do [here](https://github.com/gjaldon/ctokenv3-collateral-plugin/blob/main/contracts/CTokenV3Collateral.sol#L9-L10). Hardhat does not support using absolute paths in libraries/dependencies and without this change, hardhat will be unable to find the files.