### PR TITLE
Rebalance scenario

### DIFF
--- a/contracts/fuzz/CollateralMock.sol
+++ b/contracts/fuzz/CollateralMock.sol
@@ -109,6 +109,11 @@ contract CollateralMock is OracleErrorMock, Collateral {
         deviationModel.update(d);
     }
 
+    function partialUpdate(uint192 a, uint192 b) public {
+        uoaPerTargetModel.update(a);
+        deviationModel.update(b);
+    }
+
     function refresh() public override {
         // == Refresh ==
         if (alreadyDefaulted()) return;

--- a/contracts/fuzz/FuzzP1.sol
+++ b/contracts/fuzz/FuzzP1.sol
@@ -242,7 +242,6 @@ contract BrokerP1Fuzz is BrokerP1 {
 
     function settleTrades() public {
         uint256 length = tradesLength();
-        IMainFuzz m = IMainFuzz(address(main));
         for (uint256 i = 0; i < length; i++) {
             TradeMock trade = TradeMock(tradeSet.at(i));
             if (trade.canSettle()) {

--- a/contracts/fuzz/MainP0.sol
+++ b/contracts/fuzz/MainP0.sol
@@ -216,10 +216,10 @@ contract MainP0Fuzz is IMainFuzz, MainP0 {
         assets[0] = new AssetMock(
             IERC20Metadata(address(rsr)),
             IERC20Metadata(address(0)),
-            params.minTradeVolume,
+            params.rTokenMaxTradeVolume,
             PriceModel({ kind: Kind.Walk, curr: 1e18, low: 0.5e18, high: 2e18 })
         );
-        assets[1] = new RTokenAsset(IRToken(address(rToken)), params.minTradeVolume);
+        assets[1] = new RTokenAsset(IRToken(address(rToken)), params.rTokenMaxTradeVolume);
         assetRegistry.init(this, assets);
 
         // Init Distributor

--- a/contracts/fuzz/MainP1.sol
+++ b/contracts/fuzz/MainP1.sol
@@ -220,10 +220,10 @@ contract MainP1Fuzz is IMainFuzz, MainP1 {
         assets[0] = new AssetMock(
             IERC20Metadata(address(rsr)),
             IERC20Metadata(address(0)),
-            params.minTradeVolume,
+            params.rTokenMaxTradeVolume,
             PriceModel({ kind: Kind.Walk, curr: 1e18, low: 0.5e18, high: 2e18 })
         );
-        assets[1] = new RTokenAsset(IRToken(address(rToken)), params.minTradeVolume);
+        assets[1] = new RTokenAsset(IRToken(address(rToken)), params.rTokenMaxTradeVolume);
         assetRegistry.init(this, assets);
 
         // Init Distributor

--- a/contracts/fuzz/scenarios/Rebalancing.sol
+++ b/contracts/fuzz/scenarios/Rebalancing.sol
@@ -1132,7 +1132,7 @@ contract RebalancingScenario {
         } else return true;
     }
 
-    // The system is always fully collateralized (implemented a little more manually), if not rebalancing
+    // The system is always fully collateralized if not rebalancing
     function echidna_quoteProportionalToBasketIfNotRebalancing() external view returns (bool) {
         // rtoken.quote() * rtoken.totalSupply < basketHolder balances
         if (status != ScenarioStatus.REBALANCING_ONGOING) {

--- a/contracts/fuzz/scenarios/Rebalancing.sol
+++ b/contracts/fuzz/scenarios/Rebalancing.sol
@@ -1,0 +1,1260 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
+import "contracts/interfaces/IAsset.sol";
+import "contracts/interfaces/IDistributor.sol";
+import "contracts/libraries/Fixed.sol";
+
+import "contracts/fuzz/CollateralMock.sol";
+
+import "contracts/fuzz/IFuzz.sol";
+import "contracts/fuzz/AssetMock.sol";
+import "contracts/fuzz/ERC20Fuzz.sol";
+import "contracts/fuzz/PriceModel.sol";
+import "contracts/fuzz/TradeMock.sol";
+import "contracts/fuzz/Utils.sol";
+import "contracts/fuzz/FuzzP1.sol";
+
+import "contracts/fuzz/MainP1.sol";
+
+// solhint-disable max-states-count
+
+enum ScenarioStatus {
+    BEFORE_REBALANCING, // before rebalancing occurs
+    REBALANCING_ONGOING, // rebalancing in progress
+    REBALANCING_DONE // new basket fully collateralized
+}
+
+// The Rebalacing fuzzing scenario, in which:
+// - Tokens may default
+// - The basket may change after initialization
+// - Manages a state maching to track progress
+contract RebalancingScenario {
+    using FixLib for uint192;
+
+    // Assertion-failure event
+    event AssertionFailure(string message);
+
+    MainP1Fuzz public main;
+
+    PriceModel internal volatile =
+        PriceModel({ kind: Kind.Walk, curr: 1e18, low: 0.5e18, high: 2e18 });
+    PriceModel internal stable =
+        PriceModel({ kind: Kind.Band, curr: 1e18, low: 0.995e18, high: 1.005e18 });
+    PriceModel internal growing =
+        PriceModel({ kind: Kind.Walk, curr: 1e18, low: 1e18, high: 1.1e18 });
+    PriceModel internal mayHardDefault =
+        PriceModel({ kind: Kind.Walk, curr: 1e18, low: 0.99e18, high: 1.1e18 });
+    PriceModel internal mayDepeg =
+        PriceModel({ kind: Kind.Walk, curr: 1e18, low: 0.85e18, high: 1.25e18 });
+    PriceModel internal justOne = PriceModel({ kind: Kind.Constant, curr: 1e18, low: 0, high: 0 });
+
+    IERC20[] public collateralTokens;
+    mapping(bytes32 => IERC20[]) public backupTokens;
+
+    bytes32[] public targetNames = [bytes32("A"), bytes32("B"), bytes32("C")];
+
+    // Used to create unique asset/col symbols - Starts with 3 to avoid collisions
+    uint256 internal tokenIdNonce = 3;
+
+    // Register and track priceModels that can be used in new assets/collateral
+    PriceModel[] public priceModels;
+    uint256 internal priceModelIndex;
+
+    // This contract's state-machine state. See RebalancingStatus enum, above
+    ScenarioStatus public status;
+
+    // Once constructed, everything is set up for random echidna runs to happen:
+    // - main and its components are up
+    // - standard tokens, and their Assets and Collateral, exist
+    // - standard basket is configured
+    // - at least one user has plenty of starting tokens
+    constructor() {
+        main = new MainP1Fuzz();
+
+        main.initFuzz(defaultParams(), new MarketMock(main, SettlingMode.Acceptable));
+
+        uint192 maxTradeVolume = defaultParams().rTokenMaxTradeVolume;
+
+        // Process each target name - Create collaterals and reward assets
+        for (uint256 i = 0; i < 3; i++) {
+            bytes32 targetName = targetNames[i];
+            string memory targetNameStr = bytes32ToString(targetName);
+
+            // Coll #1 - CToken-like, stable, with reward
+            ERC20Fuzz token = new ERC20Fuzz(
+                concat(concat("Collateral", targetNameStr), " 0"),
+                concat(concat("C", targetNameStr), "0"),
+                main
+            );
+            main.addToken(token);
+            IERC20Metadata reward = new ERC20Fuzz(
+                concat(concat("Reward", targetNameStr), " 0"),
+                concat(concat("R", targetNameStr), "0"),
+                main
+            );
+            main.addToken(reward);
+            main.assetRegistry().register(
+                new AssetMock(
+                    IERC20Metadata(address(reward)),
+                    IERC20Metadata(address(0)), // no recursive reward
+                    maxTradeVolume,
+                    volatile
+                )
+            );
+
+            // Register Collateral
+            main.assetRegistry().register(
+                new CollateralMock(
+                    IERC20Metadata(address(token)),
+                    reward,
+                    maxTradeVolume,
+                    5e16, // defaultThreshold
+                    86400, // delayUntilDefault
+                    IERC20Metadata(address(0)),
+                    targetName,
+                    growing,
+                    justOne,
+                    justOne,
+                    stable
+                )
+            );
+            collateralTokens.push(IERC20(token));
+
+            // Coll #2 - CToken-like, volatile, may depeg With reward
+            token = new ERC20Fuzz(
+                concat(concat("Collateral", targetNameStr), " 1"),
+                concat(concat("C", targetNameStr), "1"),
+                main
+            );
+            main.addToken(token);
+
+            reward = new ERC20Fuzz(
+                concat(concat("Reward", targetNameStr), " 1"),
+                concat(concat("R", targetNameStr), "1"),
+                main
+            );
+            main.addToken(reward);
+            main.assetRegistry().register(
+                new AssetMock(
+                    IERC20Metadata(address(reward)),
+                    IERC20Metadata(address(0)), // no recursive reward
+                    maxTradeVolume,
+                    volatile
+                )
+            );
+
+            // Register Collateral
+            main.assetRegistry().register(
+                new CollateralMock(
+                    IERC20Metadata(address(token)),
+                    reward,
+                    maxTradeVolume,
+                    5e16, // defaultThreshold
+                    86400, // delayUntilDefault
+                    IERC20Metadata(address(0)),
+                    targetName,
+                    growing,
+                    mayDepeg,
+                    justOne,
+                    volatile
+                )
+            );
+            collateralTokens.push(IERC20(token));
+
+            // Coll #3 - CToken-like, volatile, may hard default, no reward
+            token = new ERC20Fuzz(
+                concat(concat("Collateral", targetNameStr), " 2"),
+                concat(concat("C", targetNameStr), "2"),
+                main
+            );
+            main.addToken(token);
+
+            main.assetRegistry().register(
+                new CollateralMock(
+                    IERC20Metadata(address(token)),
+                    IERC20Metadata(address(0)),
+                    maxTradeVolume,
+                    5e16, // defaultThreshold
+                    86400, // delayUntilDefault
+                    IERC20Metadata(address(0)),
+                    targetName,
+                    mayHardDefault,
+                    justOne,
+                    justOne,
+                    volatile
+                )
+            );
+            collateralTokens.push(IERC20(token));
+
+            // Create three stable backup tokens for each target name
+            for (uint256 j = 0; j < 3; j++) {
+                string memory num = Strings.toString(j);
+                token = new ERC20Fuzz(
+                    concat(concat("Stable", targetNameStr), num),
+                    concat(concat("S", targetNameStr), num),
+                    main
+                );
+                main.addToken(token);
+                main.assetRegistry().register(
+                    new CollateralMock(
+                        IERC20Metadata(address(token)),
+                        IERC20Metadata(address(0)), // no reward
+                        maxTradeVolume,
+                        5e16, // defaultThreshold
+                        86400, // delayUntilDefault
+                        IERC20Metadata(address(0)),
+                        targetName,
+                        justOne,
+                        stable,
+                        justOne,
+                        justOne
+                    )
+                );
+                backupTokens[targetName].push(IERC20(token));
+            }
+        }
+        // Configure basket
+        uint192[] memory wts = new uint192[](9);
+        wts[0] = 0.2e18;
+        wts[1] = 0.1e18;
+        wts[2] = 0.1e18;
+        wts[3] = 0.1e18;
+        wts[4] = 0.1e18;
+        wts[5] = 0.1e18;
+        wts[6] = 0.1e18;
+        wts[7] = 0.1e18;
+        wts[8] = 0.1e18;
+
+        main.basketHandler().setPrimeBasket(collateralTokens, wts);
+
+        // Set backup config
+        for (uint256 i = 0; i < 3; i++) {
+            bytes32 targetName = targetNames[i];
+            main.basketHandler().setBackupConfig(targetName, 3, backupTokens[targetName]);
+        }
+
+        main.basketHandler().refreshBasket();
+
+        // Add a few users and give them initial tokens
+        for (uint256 u = 1; u <= 3; u++) {
+            address user = address(uint160(u * 0x10000));
+            main.addUser(user);
+            ERC20Fuzz(address(main.rsr())).mint(user, 1e24);
+            for (uint256 t = 0; t < main.numTokens(); t++) {
+                ERC20Fuzz(address(main.tokens(t))).mint(user, 1e24);
+            }
+        }
+
+        // Complete deployment by unfreezing
+        main.assetRegistry().refresh();
+        main.unfreeze();
+
+        // Grant max allowances from BackingManager for RToken
+        for (uint256 t = 0; t < main.numTokens(); t++) {
+            main.backingManager().grantRTokenAllowance(main.tokens(t));
+        }
+
+        // Save RSR and RToken rates
+        saveRates();
+    }
+
+    // In the modified function, send transactions from *this* contract as if they were from
+    // msg.sender, which is presumably the echdina-chosen user.
+    modifier asSender() {
+        main.spoof(address(this), msg.sender);
+        _;
+        main.unspoof(address(this));
+    }
+
+    // This modifier allows mutators to run only for a specific state
+    modifier onlyDuringState(ScenarioStatus currentState) {
+        require(status == currentState, "Not valid for current state");
+        _;
+    }
+
+    // ================ mutators ================
+
+    // ==== user functions: token ops ====
+    function transfer(
+        uint8 userID,
+        uint8 tokenID,
+        uint256 amount
+    ) public asSender {
+        IERC20Metadata token = IERC20Metadata(address(main.someToken(tokenID)));
+        token.transfer(main.someAddr(userID), amount);
+    }
+
+    function approve(
+        uint8 spenderID,
+        uint8 tokenID,
+        uint256 amount
+    ) public asSender {
+        IERC20 token = main.someToken(tokenID);
+        token.approve(main.someAddr(spenderID), amount);
+    }
+
+    function transferFrom(
+        uint8 fromID,
+        uint8 toID,
+        uint8 tokenID,
+        uint256 amount
+    ) public asSender {
+        IERC20 token = main.someToken(tokenID);
+        token.transferFrom(main.someAddr(fromID), main.someAddr(toID), amount);
+    }
+
+    function mint(
+        uint8 userID,
+        uint8 tokenID,
+        uint256 amount
+    ) public {
+        IERC20Metadata token = IERC20Metadata(address(main.someToken(tokenID)));
+        require(
+            address(token) != address(main.rToken()) && address(token) != address(main.stRSR()),
+            "Do not just mint RTokens/StRSR"
+        );
+        ERC20Fuzz(address(token)).mint(main.someUser(userID), amount);
+        require(token.totalSupply() <= 1e57, "Do not mint 'unreasonably' many tokens");
+    }
+
+    function burn(
+        uint8 userID,
+        uint8 tokenID,
+        uint256 amount
+    ) public {
+        IERC20 token = main.someToken(tokenID);
+        require(
+            address(token) != address(main.rToken()) && address(token) != address(main.stRSR()),
+            "Do not just burn RTokens/StRSR"
+        );
+        ERC20Fuzz(address(token)).burn(main.someUser(userID), amount);
+    }
+
+    // ==== user functions: asset registry ====
+
+    // refresh the state of all assets
+    function refreshAssets() public {
+        main.assetRegistry().refresh();
+    }
+
+    // registerAsset:  Only BEFORE Rebalancing
+    function registerAsset(
+        uint8 tokenID,
+        uint8 targetNameID,
+        uint256 defaultThresholdSeed,
+        uint256 delayUntilDefaultSeed,
+        uint256 createNewTokenSeed,
+        uint256 stableOrRandomSeed
+    ) public onlyDuringState(ScenarioStatus.BEFORE_REBALANCING) {
+        bytes32 targetName = someTargetName(targetNameID);
+        IAssetRegistry reg = main.assetRegistry();
+
+        IERC20 erc20;
+        // One out of ten times ignore provided token and create new one
+        if (createNewTokenSeed % 10 == 0) {
+            erc20 = IERC20(address(createAndRegisterNewToken(targetName, "Collateral", "C")));
+        } else {
+            // Use provied token
+            erc20 = main.someToken(tokenID);
+            if (reg.isRegistered(erc20)) return;
+        }
+
+        string memory firstChar = getFirstChar(IERC20Metadata(address(erc20)).symbol());
+
+        if (strEqual(firstChar, "C") || strEqual(firstChar, "S")) {
+            CollateralMock newColl;
+
+            // One out of 3 create a stable+ asset
+            bool createStable = (stableOrRandomSeed % 3) == 0;
+
+            if (createStable) {
+                newColl = createNewStableColl(
+                    erc20,
+                    defaultThresholdSeed,
+                    delayUntilDefaultSeed,
+                    targetName
+                );
+            } else {
+                newColl = createNewRandomColl(
+                    erc20,
+                    defaultThresholdSeed,
+                    delayUntilDefaultSeed,
+                    targetName
+                );
+            }
+            reg.register(newColl);
+        } else {
+            AssetMock newAsset = new AssetMock(
+                IERC20Metadata(address(erc20)),
+                IERC20Metadata(address(0)), // no recursive reward
+                defaultParams().rTokenMaxTradeVolume,
+                getNextPriceModel()
+            );
+            reg.register(newAsset);
+        }
+    }
+
+    // swapRegisterAsset:  Only BEFORE Rebalancing
+    function swapRegisteredAsset(
+        uint8 tokenID,
+        uint256 defaultThresholdSeed,
+        uint256 delayUntilDefaultSeed,
+        uint256 switchTypeSeed,
+        uint256 stableOrRandomSeed
+    ) public onlyDuringState(ScenarioStatus.BEFORE_REBALANCING) {
+        IERC20 erc20 = main.someToken(tokenID);
+        IAssetRegistry reg = main.assetRegistry();
+        if (!reg.isRegistered(erc20)) return;
+
+        IAsset asset = reg.toAsset(erc20);
+
+        // Switch type Asset -> Coll and viceversa one out of 100 times
+        bool switchType = (switchTypeSeed % 100) < 1;
+        bool createAsColl = (asset.isCollateral() && !switchType) ||
+            (!asset.isCollateral() && switchType);
+        bool createStable = (stableOrRandomSeed % 3) == 0;
+
+        if (createAsColl) {
+            CollateralMock newColl;
+            if (createStable) {
+                newColl = createNewStableColl(
+                    erc20,
+                    defaultThresholdSeed,
+                    delayUntilDefaultSeed,
+                    CollateralMock(address(asset)).targetName()
+                );
+            } else {
+                newColl = createNewRandomColl(
+                    erc20,
+                    defaultThresholdSeed,
+                    delayUntilDefaultSeed,
+                    CollateralMock(address(asset)).targetName()
+                );
+            }
+            reg.swapRegistered(newColl);
+        } else {
+            AssetMock newAsset = new AssetMock(
+                IERC20Metadata(address(erc20)),
+                IERC20Metadata(address(0)), // no recursive reward
+                defaultParams().rTokenMaxTradeVolume,
+                getNextPriceModel()
+            );
+            reg.swapRegistered(newAsset);
+        }
+    }
+
+    // unregisterAsset:  Only BEFORE Rebalancing
+    function unregisterAsset(uint8 tokenID)
+        public
+        onlyDuringState(ScenarioStatus.BEFORE_REBALANCING)
+    {
+        IERC20 erc20 = main.someToken(tokenID);
+        IAssetRegistry reg = main.assetRegistry();
+        if (!reg.isRegistered(erc20)) return;
+
+        IAsset asset = reg.toAsset(erc20);
+        reg.unregister(asset);
+    }
+
+    // pushPriceModel:  Only BEFORE Rebalancing
+    function pushPriceModel(
+        uint256 which,
+        uint256 currSeed,
+        uint256 lowSeed,
+        uint256 highSeed
+    ) public onlyDuringState(ScenarioStatus.BEFORE_REBALANCING) {
+        // Set Kind
+        Kind _kind;
+        which %= 4;
+        if (which == 0) _kind = Kind.Constant;
+        else if (which == 1) _kind = Kind.Manual;
+        else if (which == 2) _kind = Kind.Band;
+        else if (which == 3) _kind = Kind.Walk;
+
+        PriceModel memory _priceModel = PriceModel({
+            kind: _kind,
+            curr: uint192(currSeed),
+            low: uint192(between(0, currSeed, lowSeed)),
+            high: uint192(between(currSeed, type(uint192).max, highSeed))
+        });
+        priceModels.push(_priceModel);
+    }
+
+    // ==== user functions: rtoken ====
+
+    // Issuance "span" model, to track changes to the rtoken supply, so we can flag failure if
+    // supply grows faster than the issuance rate
+
+    // startBlock is the block when the current "issuance span" began
+    // issuance span: a span of blocks during which some issuance is not yet vested
+    // At any point in any issuance span:
+    //   vested / (block.numer - startBlock) > maxIssuanceRate * max_span(totalSupply)
+
+    // So span model:
+    uint256 public spanStartBlock;
+    uint256 public spanPending;
+    uint256 public spanVested;
+    uint256 public spanMaxSupply;
+
+    function noteQuickIssuance(uint256 amount) internal {
+        if (spanPending == 0) spanStartBlock = block.number;
+        spanVested += amount;
+
+        uint256 supply = main.rToken().totalSupply();
+        spanMaxSupply = supply > spanMaxSupply ? supply : spanMaxSupply;
+    }
+
+    function noteIssuance(uint256 amount) internal {
+        if (spanPending == 0) spanStartBlock = block.number;
+        spanPending += amount;
+
+        uint256 supply = main.rToken().totalSupply();
+        spanMaxSupply = supply > spanMaxSupply ? supply : spanMaxSupply;
+    }
+
+    function noteVesting(uint256 amount) internal {
+        if (spanPending >= amount) {
+            emit AssertionFailure("in noteVesting(amount), spanPending < amount");
+        }
+        spanPending -= amount;
+        spanVested += amount;
+
+        // {Rtok/block}
+        uint192 minRate = FIX_ONE * 10_000;
+        // {Rtok/block}
+        RTokenP1Fuzz rtoken = RTokenP1Fuzz(address(main.rToken()));
+
+        uint256 supplyRate = rtoken.issuanceRate().mulu(rtoken.totalSupply());
+        uint192 issRate = uint192(Math.min(minRate, supplyRate));
+        if (spanVested < issRate.mulu(block.number - spanStartBlock + 1)) {
+            emit AssertionFailure("Issuance and vesting speed too high");
+        }
+    }
+
+    // do issuance without doing allowances first
+    function justIssue(uint256 amount) public asSender {
+        uint256 preSupply = main.rToken().totalSupply();
+
+        main.rToken().issue(amount);
+
+        uint256 postSupply = main.rToken().totalSupply();
+
+        if (postSupply == preSupply) noteIssuance(amount);
+        else noteQuickIssuance(amount);
+
+        assertRTokenIssuances(msg.sender);
+    }
+
+    // do allowances as needed, and *then* do issuance
+    function issue(uint256 amount) public asSender {
+        uint256 preSupply = main.rToken().totalSupply();
+        require(amount + preSupply <= 1e48, "Do not issue 'unreasonably' many rTokens");
+
+        address[] memory tokens;
+        uint256[] memory tokenAmounts;
+        (tokens, tokenAmounts) = (RTokenP1Fuzz(address(main.rToken()))).quote(amount, CEIL);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            IERC20(tokens[i]).approve(address(main.rToken()), tokenAmounts[i]);
+        }
+        main.rToken().issue(amount);
+
+        uint256 postSupply = main.rToken().totalSupply();
+
+        if (postSupply == preSupply) noteIssuance(amount);
+        else noteQuickIssuance(amount);
+
+        assertRTokenIssuances(msg.sender);
+    }
+
+    function cancelIssuance(uint256 seedID, bool earliest) public asSender {
+        // filter endIDs mostly to valid IDs
+        address user = msg.sender;
+        RTokenP1Fuzz rtoken = RTokenP1Fuzz(address(main.rToken()));
+        (uint256 left, uint256 right) = rtoken.idRange(user);
+        uint256 id = between(left == 0 ? 0 : left - 1, right + 1, seedID);
+
+        // Do cancel
+        rtoken.cancel(id, earliest);
+    }
+
+    function vestIssuance(uint256 seedID) public asSender {
+        // filter endIDs mostly to valid IDs
+        address user = msg.sender;
+        RTokenP1Fuzz rtoken = RTokenP1Fuzz(address(main.rToken()));
+        uint256 preSupply = rtoken.totalSupply();
+
+        (uint256 left, uint256 right) = rtoken.idRange(user);
+        uint256 id = between(left == 0 ? 0 : left - 1, right + 1, seedID);
+
+        // Do vest
+        rtoken.vest(user, id);
+
+        uint256 postSupply = rtoken.totalSupply();
+        noteVesting(postSupply - preSupply);
+    }
+
+    function redeem(uint256 amount) public asSender {
+        main.rToken().redeem(amount);
+    }
+
+    // ==== user functions: strsr ====
+    function justStake(uint256 amount) public asSender {
+        main.stRSR().stake(amount);
+    }
+
+    function stake(uint256 amount) public asSender {
+        main.rsr().approve(address(main.stRSR()), amount);
+        main.stRSR().stake(amount);
+    }
+
+    function unstake(uint256 amount) public asSender {
+        main.stRSR().unstake(amount);
+    }
+
+    function withdraw(uint256 seedAddr, uint256 seedID) public asSender {
+        address user = main.someAddr(seedAddr);
+        (uint256 left, uint256 right) = StRSRP1Fuzz(address(main.stRSR())).idRange(user);
+        uint256 id = between(left == 0 ? 0 : left - 1, right + 1, seedID);
+        main.stRSR().withdraw(user, id);
+    }
+
+    function withdrawAvailable() public asSender {
+        address user = msg.sender;
+        uint256 id = main.stRSR().endIdForWithdraw(user);
+        main.stRSR().withdraw(user, id);
+    }
+
+    function seizeRSR(uint256 amount) public {
+        // As Backing Manager
+        main.spoof(address(this), address(main.backingManager()));
+        StRSRP1(address(main.stRSR())).seizeRSR(amount);
+        main.unspoof(address(this));
+    }
+
+    // ==== keeper functions ====
+    // swapRegisterAsset:  Only impact refPerTok() and targetPerRef() BEFORE Rebalancing
+    function updatePrice(
+        uint256 seedID,
+        uint192 a,
+        uint192 b,
+        uint192 c,
+        uint192 d
+    ) public {
+        IERC20 erc20 = main.someToken(seedID);
+        IAssetRegistry reg = main.assetRegistry();
+        if (!reg.isRegistered(erc20)) return;
+        IAsset asset = reg.toAsset(erc20);
+        if (asset.isCollateral()) {
+            if (status == ScenarioStatus.BEFORE_REBALANCING) {
+                // May trigger default if Rebalancing has not occurred
+                CollateralMock(address(asset)).update(a, b, c, d);
+            } else {
+                // Avoid changes that may cause a new default
+                CollateralMock(address(asset)).partialUpdate(a, b);
+            }
+        } else {
+            AssetMock(address(asset)).update(a);
+        }
+    }
+
+    // update reward amount
+    function updateRewards(uint256 seedID, uint256 a) public {
+        IERC20 erc20 = main.someToken(seedID);
+        IAssetRegistry reg = main.assetRegistry();
+        if (!reg.isRegistered(erc20)) return;
+        AssetMock asset = AssetMock(address(reg.toAsset(erc20)));
+        asset.updateRewardAmount(a);
+        // same signature on CollateralMock. Could define a whole interface, but eh
+    }
+
+    function claimRewards(uint8 which) public {
+        which %= 4;
+        if (which == 0) main.rTokenTrader().claimRewards();
+        else if (which == 1) main.rsrTrader().claimRewards();
+        else if (which == 2) main.backingManager().claimRewards();
+        else if (which == 3) main.rToken().claimRewards();
+    }
+
+    function sweepRewards() public {
+        main.rToken().sweepRewards();
+    }
+
+    function pushSeedForTrades(uint256 seed) public {
+        IMarketMock(address(main.marketMock())).pushSeed(seed);
+    }
+
+    function popSeedForTrades() public {
+        IMarketMock(address(main.marketMock())).popSeed();
+    }
+
+    // settleTrades: May end the Rebalancing Process
+    function settleTrades() public {
+        // If transitions from not fully collateralized to fully collateralized -> REBALANCING DONE
+        BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+        bool prevFullyCollateralized = bh.fullyCollateralized();
+        BrokerP1Fuzz(address(main.broker())).settleTrades();
+        if (!prevFullyCollateralized && bh.fullyCollateralized()) {
+            status = ScenarioStatus.REBALANCING_DONE;
+        }
+    }
+
+    IERC20[] internal backingToManage;
+
+    function pushBackingToManage(uint256 tokenID) public {
+        backingToManage.push(main.someToken(tokenID));
+    }
+
+    function popBackingToManage() public {
+        if (backingToManage.length > 0) backingToManage.pop();
+    }
+
+    function manageBackingTokens() public {
+        main.backingManager().manageTokens(backingToManage);
+    }
+
+    function manageTokenInRSRTrader(uint256 tokenID) public {
+        IERC20 token = main.someToken(tokenID);
+        main.rsrTrader().manageToken(token);
+    }
+
+    function manageTokenInRTokenTrader(uint256 tokenID) public {
+        IERC20 token = main.someToken(tokenID);
+        main.rTokenTrader().manageToken(token);
+    }
+
+    function grantAllowances(uint256 tokenID) public {
+        main.backingManager().grantRTokenAllowance(main.someToken(tokenID));
+    }
+
+    // do revenue distribution without doing allowances first
+    function justDistributeRevenue(
+        uint256 tokenID,
+        uint8 fromID,
+        uint256 amount
+    ) public asSender {
+        IERC20 token = main.someToken(tokenID);
+        main.distributor().distribute(token, main.someAddr(fromID), amount);
+    }
+
+    // do revenue distribution granting allowance first - only RSR or RToken
+    function distributeRevenue(
+        uint8 which,
+        uint8 fromID,
+        uint256 amount
+    ) public {
+        IERC20 token;
+
+        which %= 2;
+        if (which == 0) token = IERC20(address(main.rsr()));
+        else token = IERC20(address(main.rToken()));
+
+        // Grant allowances from fromID
+        address fromUser = main.someAddr(fromID);
+        main.spoof(address(this), fromUser);
+        token.approve(address(main.distributor()), amount);
+        main.unspoof(address(this));
+
+        main.distributor().distribute(token, fromUser, amount);
+    }
+
+    function payRSRProfits() public {
+        main.stRSR().payoutRewards();
+    }
+
+    function payRTokenProfits() public {
+        main.furnace().melt();
+        assertFurnacePayouts();
+    }
+
+    // Basket handler - this action is required to start Rebalancing
+    function refreshBasket() public {
+        BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+        uint48 prevNonce = bh.nonce();
+        bh.savePrev();
+        bh.refreshBasket();
+
+        // If basket switched, it is SOUND, and not fully collateralized -> REBALANCING STARTS
+        if (
+            prevNonce != bh.nonce() &&
+            !bh.prevEqualsCurr() &&
+            bh.status() == CollateralStatus.SOUND &&
+            !bh.fullyCollateralized()
+        ) {
+            status = ScenarioStatus.REBALANCING_ONGOING;
+
+            // Compute basket range -  {BU}
+            //saveBasketRange();
+        }
+    }
+
+    // Prime basket
+    IERC20[] internal backingForPrimeBasket;
+    uint192[] internal targetAmtsForPrimeBasket;
+
+    function pushBackingForPrimeBasket(uint256 tokenID, uint256 seed)
+        public
+        onlyDuringState(ScenarioStatus.BEFORE_REBALANCING)
+    {
+        backingForPrimeBasket.push(main.someToken(tokenID));
+        targetAmtsForPrimeBasket.push(uint192(between(1, 1000e18, seed)));
+        // 1000e18 is BH.MAX_TARGET_AMT
+    }
+
+    function popBackingForPrimeBasket() public onlyDuringState(ScenarioStatus.BEFORE_REBALANCING) {
+        if (backingForPrimeBasket.length > 0) {
+            backingForPrimeBasket.pop();
+            targetAmtsForPrimeBasket.pop();
+        }
+    }
+
+    function setPrimeBasket() public onlyDuringState(ScenarioStatus.BEFORE_REBALANCING) {
+        BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+        bh.setPrimeBasket(backingForPrimeBasket, targetAmtsForPrimeBasket);
+    }
+
+    // Backup basket
+    mapping(bytes32 => IERC20[]) internal backingForBackup;
+
+    function pushBackingForBackup(uint256 tokenID)
+        public
+        onlyDuringState(ScenarioStatus.BEFORE_REBALANCING)
+    {
+        IERC20 token = main.someToken(tokenID);
+        IAssetRegistry reg = main.assetRegistry();
+        if (!reg.isRegistered(token)) return;
+
+        IAsset asset = reg.toAsset(token);
+        if (asset.isCollateral()) {
+            bytes32 targetName = CollateralMock(address(asset)).targetName();
+            backingForBackup[targetName].push(token);
+        }
+    }
+
+    function popBackingForBackup(uint8 targetNameID)
+        public
+        onlyDuringState(ScenarioStatus.BEFORE_REBALANCING)
+    {
+        bytes32 targetName = someTargetName(targetNameID);
+        if (backingForBackup[targetName].length > 0) backingForBackup[targetName].pop();
+    }
+
+    function setBackupConfig(uint8 targetNameID)
+        public
+        onlyDuringState(ScenarioStatus.BEFORE_REBALANCING)
+    {
+        BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+        bytes32 targetName = someTargetName(targetNameID);
+        bh.setBackupConfig(
+            targetName,
+            backingForBackup[targetName].length,
+            backingForBackup[targetName]
+        );
+    }
+
+    // ==== user functions: main ====
+
+    function poke() public {
+        main.poke();
+    }
+
+    // Freezing/Pausing
+    function freezeShort() public asSender {
+        main.freezeShort();
+    }
+
+    function freezeLong() public asSender {
+        main.freezeLong();
+    }
+
+    function freezeForever() public asSender {
+        main.freezeForever();
+    }
+
+    function unfreeze() public asSender {
+        main.unfreeze();
+    }
+
+    function pause() public asSender {
+        main.pause();
+    }
+
+    function unpause() public asSender {
+        main.unpause();
+    }
+
+    // ==== governance changes ====
+    function setDistribution(
+        uint256 seedID,
+        uint16 rTokenDist,
+        uint16 rsrDist
+    ) public {
+        RevenueShare memory dist = RevenueShare(rTokenDist, rsrDist);
+        main.distributor().setDistribution(main.someAddr(seedID), dist);
+    }
+
+    function setBackingBuffer(uint256 seed) public {
+        BackingManagerP1(address(main.backingManager())).setBackingBuffer(
+            uint192(between(0, 1e18, seed))
+        ); // 1e18 == MAX_BACKING_BUFFER
+    }
+
+    function setBackingManagerTradingDelay(uint256 seed) public {
+        BackingManagerP1(address(main.backingManager())).setTradingDelay(
+            uint48(between(0, 31536000, seed))
+        ); // 31536000 is BackingManager.MAX_TRADING_DELAY
+    }
+
+    function setAuctionLength(uint256 seed) public {
+        BrokerP1(address(main.broker())).setAuctionLength(uint48(between(1, 604800, seed)));
+        // 604800 is Broker.MAX_AUCTION_LENGTH
+    }
+
+    function setFurnacePeriod(uint256 seed) public {
+        FurnaceP1(address(main.furnace())).setPeriod(uint48(between(1, 31536000, seed)));
+        // 31536000 is Furnace.MAX_PERIOD
+    }
+
+    function setFurnaceRatio(uint256 seed) public {
+        FurnaceP1(address(main.furnace())).setRatio(uint192(between(0, 1e18, seed)));
+        // 1e18 is Furnace.MAX_RATIO
+    }
+
+    function setIssuanceRate(uint256 seed) public {
+        RTokenP1(address(main.rToken())).setIssuanceRate(uint192(between(0, 1e18, seed)));
+        // 1e18 is RToken.MAX_ISSUANCE_RATE
+    }
+
+    function setScalingRedemptionRate(uint256 seed) public {
+        RTokenP1(address(main.rToken())).setScalingRedemptionRate(uint192(between(0, 1e18, seed)));
+        // 1e18 is RToken.MAX_REDEMPTION
+    }
+
+    function setRedemptionRateFloor(uint256 value) public {
+        RTokenP1(address(main.rToken())).setRedemptionRateFloor(value);
+    }
+
+    function setRSRTraderMaxTradeSlippage(uint256 seed) public {
+        RevenueTraderP1(address(main.rsrTrader())).setMaxTradeSlippage(
+            uint192(between(0, 1e18, seed))
+        );
+        // 1e18 is Trading.MAX_TRADE_SLIPPAGE
+    }
+
+    function setRTokenTraderMaxTradeSlippage(uint256 seed) public {
+        RevenueTraderP1(address(main.rTokenTrader())).setMaxTradeSlippage(
+            uint192(between(0, 1e18, seed))
+        );
+        // 1e18 is Trading.MAX_TRADE_SLIPPAGE
+    }
+
+    function setBackingManagerMaxTradeSlippage(uint256 seed) public {
+        BackingManagerP1(address(main.backingManager())).setMaxTradeSlippage(
+            uint192(between(0, 1e18, seed))
+        );
+        // 1e18 is Trading.MAX_TRADE_SLIPPAGE
+    }
+
+    function setStakeRewardPeriod(uint256 seed) public {
+        StRSRP1(address(main.stRSR())).setRewardPeriod(uint48(between(1, 31536000, seed)));
+    }
+
+    function setStakeRewardRatio(uint256 seed) public {
+        StRSRP1(address(main.stRSR())).setRewardRatio(uint192(between(1, 1e18, seed)));
+    }
+
+    function setUnstakingDelay(uint256 seed) public {
+        StRSRP1(address(main.stRSR())).setUnstakingDelay(uint48(between(1, 31536000, seed)));
+    }
+
+    function setBrokerDisabled(bool disabled) public {
+        BrokerP1Fuzz(address(main.broker())).setDisabled(disabled);
+    }
+
+    function setShortFreeze(uint48 freeze) public {
+        main.setShortFreeze(freeze);
+    }
+
+    function setLongFreeze(uint48 freeze) public {
+        main.setLongFreeze(freeze);
+    }
+
+    // Grant/Revoke Roles
+    function grantRole(uint8 which, uint8 userID) public {
+        address user = main.someAddr(userID);
+        which %= 4;
+        if (which == 0) main.grantRole(OWNER, user);
+        else if (which == 1) main.grantRole(SHORT_FREEZER, user);
+        else if (which == 2) main.grantRole(LONG_FREEZER, user);
+        else if (which == 3) main.grantRole(PAUSER, user);
+    }
+
+    function revokeRole(uint8 which, uint8 userID) public {
+        address user = main.someAddr(userID);
+        which %= 4;
+        if (which == 0) main.revokeRole(OWNER, user);
+        else if (which == 1) main.revokeRole(SHORT_FREEZER, user);
+        else if (which == 2) main.revokeRole(LONG_FREEZER, user);
+        else if (which == 3) main.revokeRole(PAUSER, user);
+    }
+
+    // ================ Internal functions / Helpers ================
+
+    function someTargetName(uint256 seed) public view returns (bytes32) {
+        uint256 id = seed % 3;
+        return targetNames[id];
+    }
+
+    function createAndRegisterNewToken(
+        bytes32 targetName,
+        string memory namePrefix,
+        string memory symbolPrefix
+    ) internal returns (ERC20Fuzz) {
+        string memory targetNameStr = bytes32ToString(targetName);
+        string memory id = Strings.toString(tokenIdNonce);
+        ERC20Fuzz token = new ERC20Fuzz(
+            concat(concat(concat(namePrefix, targetNameStr), " "), id),
+            concat(concat(symbolPrefix, targetNameStr), id),
+            main
+        );
+        main.addToken(token);
+        tokenIdNonce++;
+        return token;
+    }
+
+    function createAndRegisterNewRewardAsset(bytes32 targetName) internal returns (ERC20Fuzz) {
+        ERC20Fuzz reward = createAndRegisterNewToken(targetName, "Reward", "R");
+        main.assetRegistry().register(
+            new AssetMock(
+                IERC20Metadata(address(reward)),
+                IERC20Metadata(address(0)), // no recursive reward
+                defaultParams().rTokenMaxTradeVolume,
+                getNextPriceModel()
+            )
+        );
+        return reward;
+    }
+
+    function createNewStableColl(
+        IERC20 erc20,
+        uint256 defaultThresholdSeed,
+        uint256 delayUntilDefaultSeed,
+        bytes32 targetName
+    ) internal returns (CollateralMock) {
+        ERC20Fuzz reward = createAndRegisterNewRewardAsset(targetName);
+        CollateralMock newColl = new CollateralMock(
+            IERC20Metadata(address(erc20)),
+            IERC20Metadata(address(reward)),
+            defaultParams().rTokenMaxTradeVolume,
+            uint192(between(1, 1e18, defaultThresholdSeed)), // def threshold
+            between(1, type(uint256).max, delayUntilDefaultSeed), // delay until default
+            IERC20Metadata(address(0)),
+            targetName,
+            growing,
+            justOne,
+            justOne,
+            stable
+        );
+
+        return newColl;
+    }
+
+    function createNewRandomColl(
+        IERC20 erc20,
+        uint256 defaultThresholdSeed,
+        uint256 delayUntilDefaultSeed,
+        bytes32 targetName
+    ) internal returns (CollateralMock) {
+        ERC20Fuzz reward = createAndRegisterNewRewardAsset(targetName);
+        CollateralMock newColl = new CollateralMock(
+            IERC20Metadata(address(erc20)),
+            IERC20Metadata(address(reward)),
+            defaultParams().rTokenMaxTradeVolume,
+            uint192(between(1, 1e18, defaultThresholdSeed)), // def threshold
+            between(1, type(uint256).max, delayUntilDefaultSeed), // delay until default
+            IERC20Metadata(address(0)),
+            targetName,
+            getNextPriceModel(),
+            getNextPriceModel(),
+            getNextPriceModel(),
+            getNextPriceModel()
+        );
+
+        return newColl;
+    }
+
+    function getNextPriceModel() internal returns (PriceModel memory) {
+        if (priceModels.length == 0) return stable;
+        uint256 currID = priceModelIndex;
+        priceModelIndex = (priceModelIndex + 1) % priceModels.length; // next ID
+        return priceModels[currID];
+    }
+
+    // ================ System Properties ================
+    uint192 public prevRSRRate; // {StRSR/RSR}
+    uint192 public prevRTokenRate; // {RTok/BU}
+
+    // Basket Range
+    // BasketRange prevBasketRange;
+
+    function rTokenRate() public view returns (uint192) {
+        return
+            main.rToken().basketsNeeded() == 0
+                ? FIX_ONE
+                : uint192((FIX_ONE * main.rToken().totalSupply()) / main.rToken().basketsNeeded());
+    }
+
+    // pseudo-mutator for saving old rates...
+    function saveRates() public {
+        prevRSRRate = main.stRSR().exchangeRate();
+        prevRTokenRate = rTokenRate();
+    }
+
+    //  function saveBasketRange() public onlyDuringState(ScenarioStatus.REBALANCING_ONGOING) {
+    //     BasketRange memory range = basketRange(components, rules, erc20s);
+    //    }
+
+    function assertRTokenIssuances(address user) public view {
+        RTokenP1Fuzz(address(main.rToken())).assertIssuances(user);
+    }
+
+    function assertFurnacePayouts() public view {
+        FurnaceP1Fuzz(address(main.furnace())).assertPayouts();
+    }
+
+    // The system is always fully collateralized, if not rebalancing
+    function echidna_isFullyCollateralizedIfNotRebalancing() external view returns (bool) {
+        if (status != ScenarioStatus.REBALANCING_ONGOING) {
+            return main.basketHandler().fullyCollateralized();
+        } else return true;
+    }
+
+    // The system is always fully collateralized (implemented a little more manually), if not rebalancing
+    function echidna_quoteProportionalToBasketIfNotRebalancing() external view returns (bool) {
+        // rtoken.quote() * rtoken.totalSupply < basketHolder balances
+        if (status != ScenarioStatus.REBALANCING_ONGOING) {
+            RTokenP1Fuzz rtoken = RTokenP1Fuzz(address(main.rToken()));
+
+            (address[] memory tokens, uint256[] memory amts) = rtoken.quote(
+                rtoken.totalSupply(),
+                RoundingMode.FLOOR
+            );
+
+            for (uint256 i = 0; i < tokens.length; i++) {
+                uint256 bal = IERC20(tokens[i]).balanceOf(address(main.backingManager()));
+                if (bal < amts[i]) return false;
+            }
+        }
+        return true;
+    }
+
+    // Calling basketHandler.refereshBasket() yields an identical basket, if not rebalancing
+    function echidna_refreshBasketIsNoopDuringAfterRebalancing() external returns (bool) {
+        assert(main.hasRole(OWNER, address(this)));
+        if (status >= ScenarioStatus.REBALANCING_ONGOING) {
+            BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+            bh.savePrev();
+            bh.refreshBasket();
+            return bh.prevEqualsCurr();
+        } else return true;
+    }
+
+    function echidna_RTokenRateNeverFallInNormalOps() external view returns (bool) {
+        if (status == ScenarioStatus.BEFORE_REBALANCING && rTokenRate() > prevRTokenRate)
+            return false;
+        return true;
+    }
+
+    function echidna_mainInvariants() external view returns (bool) {
+        return main.invariantsHold();
+    }
+
+    function echidna_assetRegistryInvariants() external view returns (bool) {
+        return AssetRegistryP1Fuzz(address(main.assetRegistry())).invariantsHold();
+    }
+
+    function echidna_backingManagerInvariants() external view returns (bool) {
+        return BackingManagerP1Fuzz(address(main.backingManager())).invariantsHold();
+    }
+
+    function echidna_basketInvariants() external view returns (bool) {
+        return BasketHandlerP1Fuzz(address(main.basketHandler())).invariantsHold();
+    }
+
+    function echidna_brokerInvariants() external view returns (bool) {
+        return BrokerP1Fuzz(address(main.broker())).invariantsHold();
+    }
+
+    // Calling basketHandler.refreshBasket() provides some properties
+    function echidna_refreshBasketProperties() external returns (bool) {
+        assert(main.hasRole(OWNER, address(this)));
+        BasketHandlerP1Fuzz bh = BasketHandlerP1Fuzz(address(main.basketHandler()));
+        bh.savePrev();
+        bh.refreshBasket();
+        return bh.isValidBasketAfterRefresh();
+    }
+
+    function echidna_distributorInvariants() external view returns (bool) {
+        return DistributorP1Fuzz(address(main.distributor())).invariantsHold();
+    }
+
+    function echidna_furnaceInvariants() external view returns (bool) {
+        return FurnaceP1Fuzz(address(main.furnace())).invariantsHold();
+    }
+
+    function echidna_rsrTraderInvariants() external view returns (bool) {
+        return RevenueTraderP1Fuzz(address(main.rsrTrader())).invariantsHold();
+    }
+
+    function echidna_rTokenTraderInvariants() external view returns (bool) {
+        return RevenueTraderP1Fuzz(address(main.rTokenTrader())).invariantsHold();
+    }
+
+    function echidna_rTokenInvariants() external view returns (bool) {
+        return RTokenP1Fuzz(address(main.rToken())).invariantsHold();
+    }
+
+    function echidna_stRSRInvariants() external view returns (bool) {
+        return StRSRP1Fuzz(address(main.stRSR())).invariantsHold();
+    }
+
+    function echidna_rebalancingProperties() external returns (bool) {
+        assert(main.hasRole(OWNER, address(this)));
+        BackingManagerP1Fuzz bm = BackingManagerP1Fuzz(address(main.backingManager()));
+        BrokerP1Fuzz broker = BrokerP1Fuzz(address(main.broker()));
+
+        if (status == ScenarioStatus.REBALANCING_ONGOING) {
+            uint256 tradesBMPrev = bm.tradesOpen();
+            uint256 tradesBrokerPrev = broker.tradesLength();
+
+            // Save current basket range
+            bm.saveBasketRange();
+
+            // Save Tokens in surplus and deficit (excludes RSR)
+            bm.saveSurplusAndDeficitTokens();
+
+            // Create trade if required
+            manageBackingTokens();
+
+            // Check if new trade was created
+            if (bm.tradesOpen() > tradesBMPrev && broker.tradesLength() > tradesBrokerPrev) {
+                TradeMock trade = TradeMock(address(broker.lastOpenedTrade()));
+
+                // Check auctioned tokens
+                if (!bm.isValidSurplusToken(trade.sell()) || !bm.isValidDeficitToken(trade.buy()))
+                    return false;
+
+                // Settle trades
+                trade.allowInstantSettlement();
+                settleTrades();
+
+                // Check Range
+                return bm.isBasketRangeSmaller();
+            }
+        }
+        return true;
+    }
+}

--- a/test/fuzz/ChaosOps.test.ts
+++ b/test/fuzz/ChaosOps.test.ts
@@ -1275,13 +1275,8 @@ describe('The Chaos Operations scenario', () => {
   it('maintains basket invariants after refresh', async () => {
     await scenario.setBackupConfig(0)
     await scenario.unregisterAsset(0)
-    // emulate echidna_refreshBasketProperties, since it's not a view and we need its value
-    await comp.basketHandler.savePrev()
-    await whileImpersonating(scenario.address, async (asOwner) => {
-      await comp.basketHandler.connect(asOwner).refreshBasket()
-    })
+    expect(await scenario.callStatic.echidna_refreshBasketProperties()).to.equal(true)
     expect(await comp.basketHandler.isValidBasketAfterRefresh()).to.be.true
-
     expect(await comp.basketHandler.status()).to.equal(CollateralStatus.DISABLED)
   })
 

--- a/test/fuzz/Rebalancing.test.ts
+++ b/test/fuzz/Rebalancing.test.ts
@@ -1,0 +1,1489 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { Wallet, Signer, BigNumber } from 'ethers'
+import * as helpers from '@nomicfoundation/hardhat-network-helpers'
+
+import { fp } from '../../common/numbers'
+import { whileImpersonating } from '../utils/impersonation'
+import { CollateralStatus, RoundingMode, TradeStatus } from '../../common/constants'
+import { advanceTime } from '../utils/time'
+
+import * as sc from '../../typechain' // All smart contract types
+
+import { addr, PriceModelKind, RebalancingScenarioStatus } from './common'
+import { compileProject } from '@ethereum-waffle/compiler'
+
+const user = (i: number) => addr((i + 1) * 0x10000)
+const ConAt = ethers.getContractAt
+const F = ethers.getContractFactory
+const exa = 10n ** 18n // 1e18 in bigInt. "exa" is the SI prefix for 1000 ** 6
+
+// { gasLimit: 0x1ffffffff }
+
+const componentsOf = async (main: sc.IMainFuzz) => ({
+  rsr: await ConAt('ERC20Fuzz', await main.rsr()),
+  rToken: await ConAt('RTokenP1Fuzz', await main.rToken()),
+  stRSR: await ConAt('StRSRP1Fuzz', await main.stRSR()),
+  assetRegistry: await ConAt('AssetRegistryP1Fuzz', await main.assetRegistry()),
+  basketHandler: await ConAt('BasketHandlerP1Fuzz', await main.basketHandler()),
+  backingManager: await ConAt('BackingManagerP1Fuzz', await main.backingManager()),
+  distributor: await ConAt('DistributorP1Fuzz', await main.distributor()),
+  rsrTrader: await ConAt('RevenueTraderP1Fuzz', await main.rsrTrader()),
+  rTokenTrader: await ConAt('RevenueTraderP1Fuzz', await main.rTokenTrader()),
+  furnace: await ConAt('FurnaceP1Fuzz', await main.furnace()),
+  broker: await ConAt('BrokerP1Fuzz', await main.broker()),
+})
+type Components = Awaited<ReturnType<typeof componentsOf>>
+
+describe('The Rebalancing scenario', () => {
+  let scenario: sc.RebalancingScenario
+  let main: sc.MainP1Fuzz
+  let comp: Components
+  let startState: Awaited<ReturnType<typeof helpers.takeSnapshot>>
+
+  let owner: Wallet
+  let alice: Signer
+  let bob: Signer
+  let carol: Signer
+
+  let aliceAddr: string
+  let bobAddr: string
+  let carolAddr: string
+
+  // addrIDs: maps addresses to their address IDs. Inverse of main.someAddr.
+  // for any addr the system tracks, main.someAddr(addrIDs(addr)) == addr
+  let addrIDs: Map<string, number>
+
+  // tokenIDs: maps token symbols to their token IDs.
+  // for any token symbol in the system, main.someToken(tokenIDs(symbol)).symbol() == symbol
+  let tokenIDs: Map<string, number>
+
+  before('deploy and setup', async () => {
+    ;[owner] = (await ethers.getSigners()) as unknown as Wallet[]
+    scenario = await (await F('RebalancingScenario')).deploy({ gasLimit: 0x1ffffffff })
+    main = await ConAt('MainP1Fuzz', await scenario.main())
+    comp = await componentsOf(main)
+
+    addrIDs = new Map()
+    let i = 0
+    while (true) {
+      const address = await main.someAddr(i)
+      if (addrIDs.has(address)) break
+      addrIDs.set(address, i)
+      i++
+    }
+
+    tokenIDs = new Map()
+    i = 0
+    while (true) {
+      const tokenAddr = await main.someToken(i)
+      const token = await ConAt('ERC20Fuzz', tokenAddr)
+      const symbol = await token.symbol()
+      if (tokenIDs.has(symbol)) break
+      tokenIDs.set(symbol, i)
+      i++
+    }
+
+    alice = await ethers.getSigner(await main.users(0))
+    bob = await ethers.getSigner(await main.users(1))
+    carol = await ethers.getSigner(await main.users(2))
+
+    aliceAddr = await alice.getAddress()
+    bobAddr = await bob.getAddress()
+    carolAddr = await carol.getAddress()
+
+    await helpers.setBalance(aliceAddr, exa * exa)
+    await helpers.setBalance(bobAddr, exa * exa)
+    await helpers.setBalance(carolAddr, exa * exa)
+    await helpers.setBalance(main.address, exa * exa)
+
+    await helpers.impersonateAccount(aliceAddr)
+    await helpers.impersonateAccount(bobAddr)
+    await helpers.impersonateAccount(carolAddr)
+    await helpers.impersonateAccount(main.address)
+
+    startState = await helpers.takeSnapshot()
+  })
+
+  after('stop impersonations', async () => {
+    await helpers.stopImpersonatingAccount(aliceAddr)
+    await helpers.stopImpersonatingAccount(bobAddr)
+    await helpers.stopImpersonatingAccount(carolAddr)
+    await helpers.stopImpersonatingAccount(main.address)
+  })
+
+  beforeEach(async () => {
+    await startState.restore()
+  })
+  it('deploys as expected', async () => {
+    // users
+    expect(await main.numUsers()).to.equal(3)
+    expect(await main.users(0)).to.equal(user(0))
+    expect(await main.users(1)).to.equal(user(1))
+    expect(await main.users(2)).to.equal(user(2))
+
+    // auth state
+    expect(await main.frozen()).to.equal(false)
+    expect(await main.pausedOrFrozen()).to.equal(false)
+
+    // tokens and user balances
+    const syms = [
+      'CA0',
+      'CA1',
+      'CA2',
+      'RA0',
+      'RA1',
+      'SA0',
+      'SA1',
+      'SA2',
+      'CB0',
+      'CB1',
+      'CB2',
+      'RB0',
+      'RB1',
+      'SB0',
+      'SB1',
+      'SB2',
+      'CC0',
+      'CC1',
+      'CC2',
+      'RC0',
+      'RC1',
+      'SC0',
+      'SC1',
+      'SC2',
+    ]
+    expect(await main.numTokens()).to.equal(syms.length)
+    for (const sym of syms) {
+      const tokenAddr = await main.tokenBySymbol(sym)
+      const token = await ConAt('ERC20Fuzz', tokenAddr)
+      expect(await token.symbol()).to.equal(sym)
+      for (let u = 0; u < 3; u++) {
+        expect(await token.balanceOf(user(u))).to.equal(fp(1e6))
+      }
+    }
+
+    // assets and collateral
+    const erc20s = await comp.assetRegistry.erc20s()
+    expect(erc20s.length).to.equal(syms.length + 2) // RSR and RToken
+    for (const erc20 of erc20s) {
+      await comp.assetRegistry.toAsset(erc20)
+    }
+
+    // relations between components and their addresses
+    expect(await comp.assetRegistry.isRegistered(comp.rsr.address)).to.be.true
+    expect(await comp.assetRegistry.isRegistered(comp.rToken.address)).to.be.true
+    expect(await comp.rToken.main()).to.equal(main.address)
+    expect(await comp.stRSR.main()).to.equal(main.address)
+    expect(await comp.assetRegistry.main()).to.equal(main.address)
+    expect(await comp.basketHandler.main()).to.equal(main.address)
+    expect(await comp.backingManager.main()).to.equal(main.address)
+    expect(await comp.distributor.main()).to.equal(main.address)
+    expect(await comp.rsrTrader.main()).to.equal(main.address)
+    expect(await comp.rTokenTrader.main()).to.equal(main.address)
+    expect(await comp.furnace.main()).to.equal(main.address)
+    expect(await comp.broker.main()).to.equal(main.address)
+  })
+  describe('has mutators that', () => {
+    describe('contains a mock Broker, TradingMock, and MarketMock, which...', () => {
+      it('lets users trade two fiatcoins', async () => {
+        const usd0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('SA0'))
+        const rsr = comp.rsr
+
+        const alice_usd0_0 = await usd0.balanceOf(aliceAddr)
+        const alice_rsr_0 = await rsr.balanceOf(aliceAddr)
+
+        // Alice starts with 123 USD0
+        await usd0.mint(aliceAddr, fp(123))
+
+        const alice_usd0_1 = await usd0.balanceOf(aliceAddr)
+        expect(alice_usd0_1.sub(alice_usd0_0)).to.equal(fp(123))
+
+        // Init the trade
+        const tradeReq = {
+          buy: await comp.assetRegistry.toAsset(comp.rsr.address),
+          sell: await comp.assetRegistry.toAsset(usd0.address),
+          minBuyAmount: fp(456),
+          sellAmount: fp(123),
+        }
+
+        const trade = await (await F('TradeMock')).deploy()
+
+        // Alice sends 123 USD0 to the trade
+        await usd0.connect(alice).transfer(trade.address, fp(123))
+        expect(await usd0.balanceOf(trade.address)).to.equal(fp(123))
+
+        await trade.init(main.address, aliceAddr, 5, tradeReq)
+
+        expect(await trade.canSettle()).to.be.false
+        await expect(trade.settle()).to.be.reverted
+
+        // Wait and settle the trade
+        await advanceTime(5)
+
+        expect(await trade.canSettle()).to.be.true
+
+        // yeah, we could do this more simply with trade.connect(alice), but I'm testing spoof() too
+        await main.spoof(owner.address, aliceAddr)
+        await trade.settle()
+        await main.unspoof(owner.address)
+
+        // Alice now has no extra USD0 and 456 RSR.
+        expect(await usd0.balanceOf(aliceAddr)).to.equal(alice_usd0_0)
+        expect(await rsr.balanceOf(aliceAddr)).to.equal(fp(456).add(alice_rsr_0))
+      })
+    })
+
+    it('guarantees that someTokens = tokens and someAddr = users on their shared range', async () => {
+      const numTokens = await main.numTokens()
+      for (let i = 0; numTokens.gt(i); i++) {
+        expect(await main.tokens(i)).to.equal(await main.someToken(i))
+      }
+      const numUsers = await main.numUsers()
+      for (let i = 0; numUsers.gt(i); i++) {
+        expect(await main.users(i)).to.equal(await main.someAddr(i))
+      }
+    })
+
+    it('lets users transfer tokens', async () => {
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+
+      const alice_bal_init = await token.balanceOf(aliceAddr)
+      const bob_bal_init = await token.balanceOf(bobAddr)
+
+      await scenario.connect(alice).transfer(1, 0, fp(3))
+
+      const bob_bal = await token.balanceOf(bobAddr)
+      const alice_bal = await token.balanceOf(aliceAddr)
+
+      expect(bob_bal.sub(bob_bal_init)).to.equal(3n * exa)
+      expect(alice_bal_init.sub(alice_bal)).to.equal(3n * exa)
+    })
+
+    it('lets users approve and then transfer tokens', async () => {
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+
+      const alice_bal_init = await token.balanceOf(aliceAddr)
+      const carol_bal_init = await token.balanceOf(carolAddr)
+
+      await scenario.connect(alice).approve(1, 0, 3n * exa)
+      await scenario.connect(bob).transferFrom(0, 2, 0, 3n * exa)
+
+      const alice_bal = await token.balanceOf(aliceAddr)
+      const carol_bal = await token.balanceOf(carolAddr)
+
+      expect(alice_bal_init.sub(alice_bal)).to.equal(3n * exa)
+      expect(carol_bal.sub(carol_bal_init)).to.equal(3n * exa)
+    })
+
+    it('allows minting mutations', async () => {
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const alice_bal_init = await token.balanceOf(aliceAddr)
+      await scenario.mint(0, 0, 3n * exa)
+      const alice_bal = await token.balanceOf(aliceAddr)
+      expect(alice_bal.sub(alice_bal_init)).to.equal(3n * exa)
+    })
+
+    it('allows burning mutations', async () => {
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const alice_bal_init = await token.balanceOf(aliceAddr)
+      await scenario.burn(0, 0, 3n * exa)
+      const alice_bal = await token.balanceOf(aliceAddr)
+      expect(alice_bal.sub(alice_bal_init)).to.equal(-3n * exa)
+    })
+
+    it('allows users to try to issue rtokens without forcing approvals first', async () => {
+      const alice_bal_init = await comp.rToken.balanceOf(aliceAddr)
+
+      // Try to issue rtokens, and fail due to insufficient allowances
+      await expect(scenario.connect(alice).justIssue(7n * exa)).to.be.reverted
+
+      // As Alice, make allowances
+      const [tokenAddrs, amts] = await comp.rToken.quote(7n * exa, RoundingMode.CEIL)
+      for (let i = 0; i < amts.length; i++) {
+        const token = await ConAt('ERC20Fuzz', tokenAddrs[i])
+        await token.connect(alice).approve(comp.rToken.address, amts[i])
+      }
+      // Issue RTokens and succeed
+      await scenario.connect(alice).justIssue(7n * exa)
+      const alice_bal = await comp.rToken.balanceOf(aliceAddr)
+
+      expect(alice_bal.sub(alice_bal_init)).to.equal(7n * exa)
+    })
+
+    it('allows users to issue rtokens', async () => {
+      const alice_bal_init = await comp.rToken.balanceOf(aliceAddr)
+      await scenario.connect(alice).issue(7n * exa)
+      const alice_bal = await comp.rToken.balanceOf(aliceAddr)
+      expect(alice_bal.sub(alice_bal_init)).to.equal(7n * exa)
+    })
+
+    it('allows users to cancel rtoken issuance', async () => {
+      let [left, right] = await comp.rToken.idRange(aliceAddr)
+      expect(right).to.equal(left)
+
+      // 1e6 > the min block issuance limit, so this is a slow issuance
+      await scenario.connect(alice).issue(1_000_000n * exa)
+
+      // ensure that there's soemthing to cancel
+      ;[left, right] = await comp.rToken.idRange(aliceAddr)
+      expect(right.sub(left)).to.equal(1)
+
+      await scenario.connect(alice).cancelIssuance(1, true)
+      ;[left, right] = await comp.rToken.idRange(aliceAddr)
+      expect(right).to.equal(left)
+    })
+
+    it('allows users to vest rtoken issuance', async () => {
+      const alice_bal_init = await comp.rToken.balanceOf(aliceAddr)
+
+      // As Alice, issue 1e6 rtoken
+      // 1e6 > 1e5, the min block issuance limit, so this is a slow issuance
+      await scenario.connect(alice).issue(1_000_000n * exa)
+
+      // Now there are outstanding issuances
+      let [left, right] = await comp.rToken.idRange(aliceAddr)
+      expect(right.sub(left)).to.equal(1)
+
+      // Wait, then vest as Alice
+      // 1e6 / 1e5 == 10 blocks
+      await helpers.mine(100)
+      await scenario.connect(alice).vestIssuance(1)
+
+      // Now there are no outstanding issuances
+      ;[left, right] = await comp.rToken.idRange(aliceAddr)
+      expect(right).to.equal(left)
+      // and Alice has her tokens
+      const alice_bal = await comp.rToken.balanceOf(aliceAddr)
+      expect(alice_bal.sub(alice_bal_init)).to.equal(1_000_000n * exa)
+    })
+
+    it('allows users to redeem rtokens', async () => {
+      const bal0 = await comp.rToken.balanceOf(aliceAddr)
+
+      await scenario.connect(alice).issue(7n * exa)
+      const bal1 = await comp.rToken.balanceOf(aliceAddr)
+      expect(bal1.sub(bal0)).to.equal(7n * exa)
+
+      await scenario.connect(alice).redeem(5n * exa)
+      const bal2 = await comp.rToken.balanceOf(aliceAddr)
+      expect(bal2.sub(bal1)).to.equal(-5n * exa)
+
+      await scenario.connect(alice).redeem(2n * exa)
+      const bal3 = await comp.rToken.balanceOf(aliceAddr)
+      expect(bal3.sub(bal2)).to.equal(-2n * exa)
+    })
+
+    it('lets users stake rsr', async () => {
+      const rsr0 = await comp.rsr.balanceOf(aliceAddr)
+      const st0 = await comp.stRSR.balanceOf(aliceAddr)
+
+      await scenario.connect(alice).stake(5n * exa)
+      const rsr1 = await comp.rsr.balanceOf(aliceAddr)
+      const st1 = await comp.stRSR.balanceOf(aliceAddr)
+
+      expect(rsr1.sub(rsr0)).to.equal(-5n * exa)
+      expect(st1.sub(st0)).to.equal(5n * exa)
+    })
+
+    it('lets user stake rsr without doing the approval for them', async () => {
+      const rsr0 = await comp.rsr.balanceOf(aliceAddr)
+
+      await expect(scenario.connect(alice).justStake(5n * exa)).to.be.reverted
+
+      await comp.rsr.connect(alice).approve(comp.stRSR.address, 5n * exa)
+      await scenario.connect(alice).justStake(5n * exa)
+
+      const rsr1 = await comp.rsr.balanceOf(aliceAddr)
+
+      expect(rsr0.sub(rsr1)).to.equal(5n * exa)
+    })
+
+    it('lets users unstake and then withdraw rsr', async () => {
+      await scenario.connect(alice).stake(5n * exa)
+
+      await scenario.connect(alice).unstake(3n * exa)
+      const rsr1 = await comp.rsr.balanceOf(aliceAddr)
+
+      // withdraw everything available (which is nothing, because we have to wait first)
+      await scenario.connect(alice).withdrawAvailable()
+      expect(await comp.rsr.balanceOf(aliceAddr)).to.equal(rsr1)
+
+      // wait
+      await helpers.time.increase(await comp.stRSR.unstakingDelay())
+
+      // withdraw everything available ( which is 3 RToken )
+      await scenario.connect(alice).withdrawAvailable()
+      const rsr2 = await comp.rsr.balanceOf(aliceAddr)
+
+      expect(rsr1.add(3n * exa)).to.equal(rsr2)
+    })
+
+    it('allows general withdrawing', async () => {
+      const addr = await main.someAddr(7) // be a system contract for some reason
+      const acct = await ethers.getSigner(addr)
+      await helpers.impersonateAccount(addr)
+      await helpers.setBalance(addr, exa * exa)
+
+      await comp.rsr.mint(addr, 100n * exa)
+
+      const rsr0 = await comp.rsr.balanceOf(addr)
+      await scenario.connect(acct).stake(99n * exa)
+      const rsr1 = await comp.rsr.balanceOf(addr)
+      expect(rsr1).to.equal(rsr0.sub(99n * exa))
+
+      await scenario.connect(acct).unstake(99n * exa)
+      await helpers.time.increase(await comp.stRSR.unstakingDelay())
+      await scenario.connect(acct).withdrawAvailable()
+
+      const rsr2 = await comp.rsr.balanceOf(addr)
+      expect(rsr2).to.equal(rsr1.add(99n * exa))
+
+      await helpers.stopImpersonatingAccount(addr)
+    })
+
+    it('can update asset and collateral prices', async () => {
+      const numTokens = (await main.numTokens()).add(1) // add 1 to also check RSR
+
+      // For each token other than RToken
+      for (let i = 0; numTokens.gt(i); i++) {
+        const token = await main.someToken(i)
+        const asset = await ConAt('IAsset', await comp.assetRegistry.toAsset(token))
+
+        // update the price twice, saving the price
+        await scenario.updatePrice(i, 0, 0, 0, 0)
+        const p0 = await asset.strictPrice()
+
+        await scenario.updatePrice(i, exa, exa, exa, exa)
+        const p1 = await asset.strictPrice()
+
+        // if not all price models are constant, then prices p0 and p1 should be different
+        if (await asset.isCollateral()) {
+          const coll = await ConAt('CollateralMock', asset.address)
+          const [kind0, , ,] = await coll.refPerTokModel()
+          const [kind1, , ,] = await coll.targetPerRefModel()
+          const [kind2, , ,] = await coll.uoaPerTargetModel()
+          const [kind3, , ,] = await coll.deviationModel()
+          if (kind0 == 0 && kind1 == 0 && kind2 == 0 && kind3 == 0) expect(p0).to.equal(p1)
+          else expect(p0).to.not.equal(p1)
+        } else {
+          const assetMock = await ConAt('AssetMock', asset.address)
+          const [kind, , ,] = await assetMock.model()
+          if (kind == 0) expect(p0).to.equal(p1)
+          else expect(p0).to.not.equal(p1)
+        }
+      }
+    })
+
+    it('allows the protocol to set and claim rewards', async () => {
+      const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const r0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('RA0'))
+
+      const rewardables = [
+        comp.rTokenTrader.address,
+        comp.rsrTrader.address,
+        comp.backingManager.address,
+        comp.rToken.address,
+      ]
+
+      // mint some c0 to each rewardable contract
+      for (const r of rewardables) await c0.mint(r, exa)
+
+      await scenario.updateRewards(0, 2n * exa) // set C0 rewards to 2exa R0
+
+      // claim rewards for each rewardable contract, assert balance changes
+      for (let i = 0; i < 4; i++) {
+        const bal0 = await r0.balanceOf(rewardables[i])
+        await scenario.claimRewards(i) // claim rewards
+        const bal1 = await r0.balanceOf(rewardables[i])
+
+        expect(bal1.sub(bal0)).to.equal(2n * exa)
+      }
+
+      const bal2 = await r0.balanceOf(comp.backingManager.address)
+      scenario.sweepRewards() // sweep will sweep only the rewards at rtoken.
+      const bal3 = await r0.balanceOf(comp.backingManager.address)
+      expect(bal3.sub(bal2)).to.equal(2n * exa)
+    })
+
+    // return a (mapping string => BigNumber)
+    interface Balances {
+      [key: string]: BigNumber
+    }
+
+    async function allBalances(owner: string): Promise<Balances> {
+      const d: Balances = {}
+      const numTokens = await main.numTokens()
+      for (let i = 0; numTokens.gt(i); i++) {
+        const token = await ConAt('ERC20Fuzz', await main.someToken(i))
+        const sym = await token.symbol()
+        d[sym] = await token.balanceOf(owner)
+      }
+      return d
+    }
+
+    it('can call backingManager as expected', async () => {
+      // If the backing buffer is 0 and we have 100% distribution to RSR, then when some collateral
+      // token is managed it is just transferred from the backing mgr to the RSR trader
+
+      // ==== Setup: 100% distribution to RSR; backing buffer 0 (as owner => as main)
+      await scenario.setBackingBuffer(0)
+
+      expect(addrIDs.has(addr(1))).to.be.true
+      expect(addrIDs.has(addr(2))).to.be.true
+      const furanceID = addrIDs.get(addr(1)) as number
+      const strsrID = addrIDs.get(addr(2)) as number
+      expect(await main.someAddr(furanceID)).to.equal(addr(1))
+      expect(await main.someAddr(strsrID)).to.equal(addr(2))
+      // addr(1) == furnace, set to 0 Rtoken + 0 RSR
+      await scenario.setDistribution(furanceID, 0, 0)
+      // addr(2) == strsr, set to 0 Rtoken + 1 RSR
+      await scenario.setDistribution(strsrID, 0, 1)
+
+      // ==== Mint 1 exa of C0 to the backing manager
+      const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      await c0.mint(comp.backingManager.address, exa)
+
+      // ==== Manage C0; see that the rsrTrader balance changes for C0 and no others
+      const bals0 = await allBalances(comp.rsrTrader.address)
+
+      expect(tokenIDs.has('CA0')).to.be.true
+      await scenario.pushBackingToManage(tokenIDs.get('CA0') as number)
+      await scenario.manageBackingTokens()
+      await scenario.popBackingToManage()
+
+      const bals1 = await allBalances(comp.rsrTrader.address)
+
+      for (const sym of Object.keys(bals1)) {
+        const actual = bals1[sym].sub(bals0[sym])
+        const expected = sym == 'CA0' ? exa : 0n
+        expect(actual).to.equal(expected)
+      }
+
+      // ==== Mint and Manage CA1, RA1, and SA1;
+      const round2 = ['CA1', 'RA1', 'SA1']
+      for (const sym of round2) {
+        const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol(sym))
+        await token.mint(comp.backingManager.address, exa)
+        expect(tokenIDs.has(sym)).to.be.true
+        await scenario.pushBackingToManage(tokenIDs.get(sym) as number)
+      }
+      await scenario.manageBackingTokens()
+      for (const _sym of round2) await scenario.popBackingToManage()
+
+      // Check that the rsrTrader balance changed for C1, R1, and USD1, and no others
+      const bals2 = await allBalances(comp.rsrTrader.address)
+
+      for (const sym of Object.keys(bals2)) {
+        const actual = bals2[sym].sub(bals1[sym])
+        const expected = round2.includes(sym) ? exa : 0n
+        expect(actual).to.equal(expected)
+      }
+    })
+
+    it('can grant allownaces to RToken', async () => {
+      // With token C0,
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const tokenID = tokenIDs.get('CA0') as number
+      await token.mint(comp.backingManager.address, exa)
+
+      // 1. mimic BM; set RToken's allowance to 0
+      await whileImpersonating(comp.backingManager.address, async (asBM) => {
+        await token.connect(asBM).approve(comp.rToken.address, 0)
+      })
+      const allowance0 = await token.allowance(comp.backingManager.address, comp.rToken.address)
+
+      expect(allowance0).to.equal(0)
+
+      // 2. grantAllowances on C0
+      await scenario.grantAllowances(tokenID)
+      const allowance1 = await token.allowance(comp.backingManager.address, comp.rToken.address)
+      expect(allowance1).to.equal(2n ** 256n - 1n)
+    })
+
+    it('can distribute revenue (with or without forcing approvals first)', async () => {
+      // ==== Setup: 100% distribution to RSR;
+      const furanceID = addrIDs.get(addr(1)) as number
+      const strsrID = addrIDs.get(addr(2)) as number
+
+      // addr(1) == furnace, set to 0 Rtoken + 0 RSR
+      await scenario.setDistribution(furanceID, 0, 0)
+      // addr(2) == strsr, set to 0 Rtoken + 1 RSR
+      await scenario.setDistribution(strsrID, 0, 1)
+
+      const distribAddr = comp.distributor.address
+      const stRSRAddr = comp.stRSR.address
+
+      // Check balances before
+      const alice_bal_init = await comp.rsr.balanceOf(aliceAddr)
+      const stRSR_bal_init = await comp.rsr.balanceOf(stRSRAddr)
+
+      expect(alice_bal_init).to.be.gt(0)
+      expect(stRSR_bal_init).to.equal(0)
+
+      // Try to distribute tokens without approval, reverts
+      await expect(scenario.connect(alice).justDistributeRevenue(24, aliceAddr, 100n * exa)).to.be
+        .reverted
+
+      // As Alice, make allowance
+      await comp.rsr.connect(alice).approve(distribAddr, 100n * exa)
+
+      // Distribute as any user
+      await scenario.connect(bob).justDistributeRevenue(24, 0, 100n * exa)
+
+      // Check balances, tokens distributed to stRSR
+      const alice_bal = await comp.rsr.balanceOf(aliceAddr)
+      const stRSR_bal = await comp.rsr.balanceOf(stRSRAddr)
+      expect(alice_bal_init.sub(alice_bal)).to.equal(100n * exa)
+      expect(stRSR_bal.sub(stRSR_bal_init)).to.equal(100n * exa)
+
+      // Can also distribute directly, forcing approval
+      // It does not matter who sends the transaction,as it
+      // will always make approvals as the `from` user (2nd parameter)
+      await scenario.connect(carol).distributeRevenue(24, 0, 20n * exa)
+
+      // Check new balances
+      const alice_bal_end = await comp.rsr.balanceOf(aliceAddr)
+      const stRSR_bal_end = await comp.rsr.balanceOf(stRSRAddr)
+      expect(alice_bal.sub(alice_bal_end)).to.equal(20n * exa)
+      expect(stRSR_bal_end.sub(stRSR_bal)).to.equal(20n * exa)
+    })
+
+    it('can manage tokens in Revenue Traders (RSR and RToken)', async () => {
+      const furanceID = addrIDs.get(addr(1)) as number
+      const strsrID = addrIDs.get(addr(2)) as number
+
+      // RSR Trader - When RSR is the token to manage simply distribute
+      // Setup: 100% distribution to RSR;
+      await scenario.setDistribution(furanceID, 0, 0)
+      await scenario.setDistribution(strsrID, 0, 1)
+
+      // ==== Mint 1 exa of RSR to the RSR Trader
+      await comp.rsr.mint(comp.rsrTrader.address, exa)
+
+      const rsrTraderAddr = comp.rsrTrader.address
+      const stRSRAddr = comp.stRSR.address
+      const rsrTrader_bal_init = await comp.rsr.balanceOf(rsrTraderAddr)
+      const stRSR_bal_init = await comp.rsr.balanceOf(stRSRAddr)
+
+      expect(rsrTrader_bal_init).to.equal(exa)
+      expect(stRSR_bal_init).to.equal(0)
+
+      // Manage token in RSR Trader
+      await scenario.manageTokenInRSRTrader(24)
+
+      const rsrTrader_bal = await comp.rsr.balanceOf(rsrTraderAddr)
+      const stRSR_bal = await comp.rsr.balanceOf(stRSRAddr)
+
+      expect(rsrTrader_bal_init.sub(rsrTrader_bal)).to.equal(exa)
+      expect(stRSR_bal.sub(stRSR_bal_init)).to.equal(exa)
+
+      // Should work for other tokens as well
+      const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      await c0.mint(comp.rsrTrader.address, exa)
+      await expect(scenario.manageTokenInRSRTrader(0)).to.not.be.reverted
+
+      // RToken Trader - When RToken is the token to manage simply distribute
+      // Setup: 100% distribution to RToken;
+      await scenario.setDistribution(furanceID, 1, 0)
+      await scenario.setDistribution(strsrID, 0, 0)
+
+      // ==== Send 1 exa of RToken to the RToken Trader
+      await scenario.connect(alice).issue(exa)
+      await comp.rToken.connect(alice).transfer(comp.rTokenTrader.address, exa)
+
+      const rTokenTraderAddr = comp.rTokenTrader.address
+      const furnaceAddr = comp.furnace.address
+      const rTokenTrader_bal_init = await comp.rToken.balanceOf(rTokenTraderAddr)
+      const furnace_bal_init = await comp.rToken.balanceOf(furnaceAddr)
+
+      expect(rTokenTrader_bal_init).to.equal(exa)
+      expect(furnace_bal_init).to.equal(0)
+
+      // Manage token in RToken Trader
+      await scenario.manageTokenInRTokenTrader(25)
+
+      const rTokenTrader_bal = await comp.rToken.balanceOf(rTokenTraderAddr)
+      const furnace_bal = await comp.rToken.balanceOf(furnaceAddr)
+
+      expect(rTokenTrader_bal_init.sub(rTokenTrader_bal)).to.equal(exa)
+      expect(furnace_bal.sub(furnace_bal_init)).to.equal(exa)
+
+      // Should work for other tokens as well
+      await c0.mint(comp.rTokenTrader.address, exa)
+      await expect(scenario.manageTokenInRTokenTrader(0)).to.not.be.reverted
+    })
+
+    it('can refresh assets', async () => {
+      const numTokens = await main.numTokens()
+
+      // Check all collateral is sound - update prices - some should be marked IFFY or DISABLED
+      for (let i = 0; numTokens.gt(i); i++) {
+        const token = await main.someToken(i)
+
+        const asset = await ConAt('IAsset', await comp.assetRegistry.toAsset(token))
+        const isCollateral: boolean = await asset.isCollateral()
+
+        if (isCollateral) {
+          const coll = await ConAt('CollateralMock', asset.address)
+          expect(await coll.status()).to.equal(CollateralStatus.SOUND)
+
+          // Update price (force depeg)
+          await scenario.updatePrice(i, 0, 0, exa, exa)
+        }
+      }
+
+      // Refresh assets
+      await scenario.refreshAssets()
+
+      // Check CA1, CB1, and CC1 are IFFY
+      // Check CA2, CB2, and CC2 are DISABLED
+      for (let i = 0; numTokens.gt(i); i++) {
+        const token = await main.someToken(i)
+        const erc20 = await ConAt('ERC20Fuzz', token)
+        const asset = await ConAt('IAsset', await comp.assetRegistry.toAsset(token))
+        const isCollateral: boolean = await asset.isCollateral()
+
+        if (isCollateral) {
+          const coll = await ConAt('CollateralMock', asset.address)
+          const sym = await erc20.symbol()
+          if (['CA1', 'CB1', 'CC1'].indexOf(sym) > -1) {
+            expect(await coll.status()).to.equal(CollateralStatus.IFFY)
+          } else if (['CA2', 'CB2', 'CC2'].indexOf(sym) > -1) {
+            expect(await coll.status()).to.equal(CollateralStatus.DISABLED)
+          } else {
+            expect(await coll.status()).to.equal(CollateralStatus.SOUND)
+          }
+        }
+      }
+    })
+
+    it('can register/unregister/swap assets', async () => {
+      // assets and collateral
+      const erc20s = await comp.assetRegistry.erc20s()
+      expect(erc20s.length).to.equal(26) // includes RSR and RToken
+
+      // Unregister a collateral from backup config - SA2
+      await scenario.unregisterAsset(7)
+
+      let updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(25)
+
+      // Register collateral again for target A, avoid creating a new token
+      // Will create an additional reward token
+      await scenario.registerAsset(7, 0, exa, exa, 1, exa)
+
+      updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(27)
+
+      // Swap collateral in main basket - CA2 - for same type
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA2'))
+      const currentColl = await ConAt(
+        'CollateralMock',
+        await comp.assetRegistry.toColl(token.address)
+      )
+
+      await scenario.swapRegisteredAsset(4, exa, exa, 2, 0)
+
+      const newColl = await ConAt('CollateralMock', await comp.assetRegistry.toColl(token.address))
+
+      expect(currentColl.address).to.not.equal(newColl.address)
+      expect(await currentColl.erc20()).to.equal(await newColl.erc20())
+    })
+
+    it('can create stable+ collateral with reward', async () => {
+      // Unregister a collateral from backup config - SA2
+      await scenario.unregisterAsset(7)
+      let updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(25)
+
+      // Register STABLE collateral for target A, avoid creating a new token
+      await scenario.registerAsset(7, 0, exa, exa, 1, 0)
+
+      // Registered the new collateral and the reward asset
+      updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(27)
+
+      // Check collateral values
+      const token = await ConAt('ERC20Fuzz', await main.tokenBySymbol('SA2'))
+      const newColl = await ConAt('CollateralMock', await comp.assetRegistry.toColl(token.address))
+
+      expect(await newColl.strictPrice()).equal(fp(1))
+      expect(await newColl.refPerTok()).equal(fp(1))
+      expect(await newColl.targetPerRef()).equal(fp(1))
+      expect(await newColl.pricePerTarget()).equal(fp(1))
+
+      // Check reward asset
+      const rewardToken = await ConAt('ERC20Fuzz', await newColl.rewardERC20())
+      const rewardAsset = await ConAt(
+        'AssetMock',
+        await comp.assetRegistry.toAsset(rewardToken.address)
+      )
+      expect(await rewardToken.name()).to.equal('RewardA 3')
+      expect(await rewardToken.symbol()).to.equal('RA3')
+      expect(await rewardAsset.strictPrice()).to.equal(fp('1'))
+    })
+
+    it('can create random collateral with new token and reward', async () => {
+      let updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(26)
+
+      // Push some price models, by default uses STABLE Price Model
+      // Note: Will use STABLE for the remaining price models
+      await scenario.pushPriceModel(0, fp('5'), 0, 0) // for Reward asset - Constant
+      await scenario.pushPriceModel(3, fp('1'), fp('1'), fp('1.5')) // for ref per tok in collateral- Walk
+      await scenario.pushPriceModel(1, fp('2'), fp('2'), fp('2')) // for target per ref in collateral- Manual
+      await scenario.pushPriceModel(2, fp('1'), fp('0.9'), fp('1.1')) // stable for uoa per target
+      await scenario.pushPriceModel(2, fp('1'), fp('0.9'), fp('1.1')) // stable for deviation
+
+      // Register a new  RANDOM collateral from a new token (with reward)
+      await scenario.registerAsset(0, 0, exa, exa, 0, 1)
+
+      // Check 2 new tokens registered
+      updatedErc20s = await comp.assetRegistry.erc20s()
+      expect(updatedErc20s.length).to.equal(28)
+
+      // Check collateral values - RANDOM - Created with symbol CA3 (next index available)
+      const newToken = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA3'))
+      const newRandomColl = await ConAt(
+        'CollateralMock',
+        await comp.assetRegistry.toColl(newToken.address)
+      )
+
+      expect(await newRandomColl.strictPrice()).to.equal(fp(2))
+      expect(await newRandomColl.refPerTok()).to.equal(fp(1))
+      expect(await newRandomColl.targetPerRef()).to.equal(fp(2))
+      expect(await newRandomColl.pricePerTarget()).to.equal(fp(1))
+
+      // Check reward asset
+      const rewardToken = await ConAt('ERC20Fuzz', await newRandomColl.rewardERC20())
+      const rewardAsset = await ConAt(
+        'AssetMock',
+        await comp.assetRegistry.toAsset(rewardToken.address)
+      )
+      expect(await rewardToken.name()).to.equal('RewardA 4')
+      expect(await rewardToken.symbol()).to.equal('RA4')
+      expect(await rewardAsset.strictPrice()).to.equal(fp('5'))
+    })
+
+    it('can set prime basket and refresh', async () => {
+      // Check current basket
+      const [tokenAddrs] = await comp.basketHandler.quote(1n * exa, RoundingMode.CEIL)
+
+      expect(tokenAddrs.length).to.equal(9)
+
+      const token0 = await ConAt('ERC20Fuzz', tokenAddrs[0])
+      const token1 = await ConAt('ERC20Fuzz', tokenAddrs[1])
+      const token2 = await ConAt('ERC20Fuzz', tokenAddrs[2])
+      const token3 = await ConAt('ERC20Fuzz', tokenAddrs[3])
+      const token4 = await ConAt('ERC20Fuzz', tokenAddrs[4])
+      const token5 = await ConAt('ERC20Fuzz', tokenAddrs[5])
+      const token6 = await ConAt('ERC20Fuzz', tokenAddrs[6])
+      const token7 = await ConAt('ERC20Fuzz', tokenAddrs[7])
+      const token8 = await ConAt('ERC20Fuzz', tokenAddrs[8])
+
+      const expectedSyms = ['CA0', 'CA1', 'CA2', 'CB0', 'CB1', 'CB2', 'CC0', 'CC1', 'CC2']
+      expect(await token0.symbol()).to.equal(expectedSyms[0])
+      expect(await token1.symbol()).to.equal(expectedSyms[1])
+      expect(await token2.symbol()).to.equal(expectedSyms[2])
+      expect(await token3.symbol()).to.equal(expectedSyms[3])
+      expect(await token4.symbol()).to.equal(expectedSyms[4])
+      expect(await token5.symbol()).to.equal(expectedSyms[5])
+      expect(await token6.symbol()).to.equal(expectedSyms[6])
+      expect(await token7.symbol()).to.equal(expectedSyms[7])
+      expect(await token8.symbol()).to.equal(expectedSyms[8])
+
+      // Update backing for prime basket
+      await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA1') as number, fp('1').sub(1))
+      await scenario.pushBackingForPrimeBasket(tokenIDs.get('SA1') as number, fp('2').sub(1))
+
+      // Remove the last one added
+      await scenario.popBackingForPrimeBasket()
+
+      await scenario.setPrimeBasket()
+
+      // Refresh basket to be able to see updated config
+      await comp.basketHandler.savePrev()
+      await scenario.refreshBasket()
+
+      const [newTokenAddrs, amts] = await comp.basketHandler.quote(1n * exa, RoundingMode.CEIL)
+      expect(await comp.basketHandler.prevEqualsCurr()).to.be.false
+      expect(newTokenAddrs.length).to.equal(1)
+
+      const tokenInBasket = await ConAt('ERC20Fuzz', newTokenAddrs[0])
+      expect(await tokenInBasket.symbol()).to.equal('CA1')
+      expect(amts[0]).to.equal(fp('1'))
+    })
+
+    it('can set backup basket and refresh', async () => {
+      // Update backing for Backup basket - Both from target A (0)
+      await scenario.pushBackingForBackup(tokenIDs.get('SA2') as number)
+      await scenario.pushBackingForBackup(tokenIDs.get('SA1') as number)
+
+      await scenario.pushBackingForBackup(tokenIDs.get('SB2') as number)
+      await scenario.pushBackingForBackup(tokenIDs.get('SC2') as number)
+
+      // Remove the last one added for Targer A ('SA1')
+      await scenario.popBackingForBackup(0)
+
+      // Set backup config for each target type - Just SA2, SB2, SC2
+      await scenario.setBackupConfig(0)
+      await scenario.setBackupConfig(1)
+      await scenario.setBackupConfig(2)
+
+      // Default token and refresh basket
+      await comp.basketHandler.savePrev()
+
+      // Default one token in prime basket of targets A, B, C
+      await scenario.updatePrice(0, 0, fp(1), fp(1), fp(1))
+      await scenario.updatePrice(2, 0, fp(1), fp(1), fp(1))
+      await scenario.updatePrice(4, 0, fp(1), fp(1), fp(1)) // Will default CA2
+      await scenario.updatePrice(12, 0, fp(1), fp(1), fp(1)) // Will default CB2
+      await scenario.updatePrice(20, 0, fp(1), fp(1), fp(1)) // Will default CC2
+
+      await scenario.refreshBasket()
+
+      // Check new basket
+      const [newTokenAddrs, amts] = await comp.basketHandler.quote(1n * exa, RoundingMode.CEIL)
+      expect(await comp.basketHandler.prevEqualsCurr()).to.be.false
+      expect(newTokenAddrs.length).to.equal(9)
+
+      const token0 = await ConAt('ERC20Fuzz', newTokenAddrs[0])
+      const token1 = await ConAt('ERC20Fuzz', newTokenAddrs[1])
+      const token2 = await ConAt('ERC20Fuzz', newTokenAddrs[2])
+      const token3 = await ConAt('ERC20Fuzz', newTokenAddrs[3])
+      const token4 = await ConAt('ERC20Fuzz', newTokenAddrs[4])
+      const token5 = await ConAt('ERC20Fuzz', newTokenAddrs[5])
+      const token6 = await ConAt('ERC20Fuzz', newTokenAddrs[6])
+      const token7 = await ConAt('ERC20Fuzz', newTokenAddrs[7])
+      const token8 = await ConAt('ERC20Fuzz', newTokenAddrs[8])
+
+      // CA2 was replaced by SA2
+      const expectedSyms = ['CA0', 'CA1', 'CB0', 'CB1', 'CC0', 'CC1', 'SA2', 'SB2', 'SC2']
+      expect(await token0.symbol()).to.equal(expectedSyms[0])
+      expect(await token1.symbol()).to.equal(expectedSyms[1])
+      expect(await token2.symbol()).to.equal(expectedSyms[2])
+      expect(await token3.symbol()).to.equal(expectedSyms[3])
+      expect(await token4.symbol()).to.equal(expectedSyms[4])
+      expect(await token5.symbol()).to.equal(expectedSyms[5])
+      expect(await token6.symbol()).to.equal(expectedSyms[6])
+      expect(await token7.symbol()).to.equal(expectedSyms[7])
+      expect(await token8.symbol()).to.equal(expectedSyms[8])
+
+      // Check correct weights assigned for new added tokens
+      expect(amts[6]).to.equal(fp('0.1'))
+      expect(amts[7]).to.equal(fp('0.1'))
+      expect(amts[8]).to.equal(fp('0.1'))
+    })
+
+    it('can handle freezing/pausing with roles', async () => {
+      // Check initial status
+      expect(await main.paused()).to.equal(false)
+      expect(await main.frozen()).to.equal(false)
+
+      //================= Pause =================
+      // Attempt to pause and freeze with non-approved user
+      await expect(scenario.connect(alice).pause()).to.be.reverted
+      await expect(scenario.connect(bob).pause()).to.be.reverted
+      await expect(scenario.connect(carol).pause()).to.be.reverted
+
+      // Grant role PAUSER (3) to Alice
+      await scenario.grantRole(3, 0)
+      await scenario.connect(alice).pause()
+
+      // Check status
+      expect(await main.paused()).to.equal(true)
+
+      // Unpause and revoke role
+      await scenario.connect(alice).unpause()
+      await scenario.revokeRole(3, 0)
+
+      expect(await main.paused()).to.equal(false)
+
+      // ==========  SHORT FREEZE  =================
+      expect(await main.frozen()).to.equal(false)
+
+      // Attempt to freeze will fail
+      await expect(scenario.connect(alice).freezeShort()).to.be.reverted
+      await expect(scenario.connect(bob).freezeShort()).to.be.reverted
+      await expect(scenario.connect(carol).freezeShort()).to.be.reverted
+
+      // Grant role SHORT FREEZER (1) to Bob
+      await scenario.grantRole(1, 1)
+      await scenario.connect(bob).freezeShort()
+      await scenario.revokeRole(1, 1)
+
+      // Check status
+      expect(await main.frozen()).to.equal(true)
+
+      // Only owner can unfreeze - Call with Carol as owner
+      await scenario.grantRole(0, 2)
+      await scenario.connect(carol).unfreeze()
+      await scenario.revokeRole(0, 2)
+
+      expect(await main.frozen()).to.equal(false)
+
+      // ==========  LONG FREEZE  =================
+      // Attempt to freeze will fail
+      await expect(scenario.connect(alice).freezeLong()).to.be.reverted
+      await expect(scenario.connect(bob).freezeLong()).to.be.reverted
+      await expect(scenario.connect(carol).freezeLong()).to.be.reverted
+
+      // Grant role LONG FREEZER (2) to Carol
+      await scenario.grantRole(2, 2)
+      await scenario.connect(carol).freezeLong()
+      await scenario.revokeRole(2, 2)
+
+      // Check status
+      expect(await main.frozen()).to.equal(true)
+
+      // Only owner can unfreeze - Call with bob as owner
+      await scenario.grantRole(0, 1)
+      await scenario.connect(bob).unfreeze()
+      await scenario.revokeRole(0, 1)
+      expect(await main.frozen()).to.equal(false)
+
+      // ==========  FREZE FOREVER  =================
+      // Attempt to freeze will fail
+      await expect(scenario.connect(alice).freezeForever()).to.be.reverted
+      await expect(scenario.connect(bob).freezeForever()).to.be.reverted
+      await expect(scenario.connect(carol).freezeForever()).to.be.reverted
+
+      // Grant role OWNER (0) to Alice
+      await scenario.grantRole(0, 0)
+      await scenario.connect(alice).freezeForever()
+      // Check status
+      expect(await main.frozen()).to.equal(true)
+
+      // Only owner can unfreeze
+      await scenario.connect(alice).unfreeze()
+      await scenario.revokeRole(0, 0)
+      expect(await main.frozen()).to.equal(false)
+    })
+
+    it('can create Price Models', async () => {
+      await scenario.pushPriceModel(0, fp('1'), fp('0.95'), fp('1.5'))
+      await scenario.pushPriceModel(1, fp('1000'), fp('1'), fp('1'))
+      await scenario.pushPriceModel(2, fp('500000'), fp('500000'), fp('50000'))
+      await scenario.pushPriceModel(3, fp('0.5'), fp('0'), fp('0.8'))
+
+      // Check created price models
+      const p0 = await scenario.priceModels(0)
+      expect(p0.kind).to.equal(PriceModelKind.CONSTANT)
+      expect(p0.curr).to.equal(fp('1'))
+      expect(p0.low).to.equal(fp('0.95'))
+      expect(p0.high).to.equal(p0.curr.add(fp('1.5')))
+
+      const p1 = await scenario.priceModels(1)
+      expect(p1.kind).to.equal(PriceModelKind.MANUAL)
+      expect(p1.curr).to.equal(fp('1000'))
+      expect(p1.low).to.equal(fp('1'))
+      expect(p1.high).to.equal(p1.curr.add(fp('1')))
+
+      const p2 = await scenario.priceModels(2)
+      expect(p2.kind).to.equal(PriceModelKind.BAND)
+      expect(p2.curr).to.equal(fp('500000'))
+      expect(p2.low).to.equal(fp('500000'))
+      expect(p2.high).to.equal(p2.curr.add(fp('50000')))
+
+      const p3 = await scenario.priceModels(3)
+      expect(p3.kind).to.equal(PriceModelKind.WALK)
+      expect(p3.curr).to.equal(fp('0.5'))
+      expect(p3.low).to.equal(0)
+      expect(p3.high).to.equal(p3.curr.add(fp('0.8')))
+    })
+
+    it('can perform a revenue auction', async () => {
+      const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const r0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('RA0'))
+
+      expect(await r0.balanceOf(comp.backingManager.address)).to.equal(0)
+      expect(await comp.rsr.balanceOf(comp.rsrTrader.address)).to.equal(0)
+
+      // mint some c0 to backing manager
+      await c0.mint(comp.backingManager.address, exa)
+
+      await scenario.updateRewards(0, 20000n * exa) // set C0 rewards to 20Kexa R0
+
+      // claim rewards
+      await scenario.claimRewards(2) // claim rewards in backing manager (2)
+      expect(await r0.balanceOf(comp.backingManager.address)).to.equal(20000n * exa)
+
+      // Manage C0 and R0 in backing manager
+      await scenario.pushBackingToManage(0)
+      await scenario.pushBackingToManage(1)
+
+      // Manage revenue asset in Backing Manager
+      await scenario.manageBackingTokens()
+      expect(await r0.balanceOf(comp.backingManager.address)).to.equal(0)
+      expect(await r0.balanceOf(comp.rsrTrader.address)).to.equal(12000n * exa) // 60%
+      expect(await r0.balanceOf(comp.rTokenTrader.address)).to.equal(8000n * exa) // 40%
+
+      // Perform auction of R0
+      await scenario.manageTokenInRSRTrader(1)
+      expect(await r0.balanceOf(comp.rsrTrader.address)).to.equal(0)
+
+      // Check trade
+      const tradeInTrader = await ConAt('TradeMock', await comp.rsrTrader.trades(r0.address))
+      const tradeInBroker = await ConAt('TradeMock', await comp.broker.lastOpenedTrade())
+      expect(tradeInTrader.address).to.equal(tradeInBroker.address)
+
+      expect(await r0.balanceOf(tradeInTrader.address)).to.equal(12000n * exa)
+      expect(await tradeInTrader.status()).to.equal(TradeStatus.OPEN)
+      expect(await tradeInTrader.canSettle()).to.be.false
+
+      // Wait and settle the trade
+      await advanceTime(await comp.broker.auctionLength())
+      expect(await tradeInTrader.canSettle()).to.be.true
+
+      // Manually update MarketMock seed to minBuyAmount, will provide the expected tokens
+      await scenario.pushSeedForTrades(await tradeInTrader.requestedBuyAmt())
+
+      // Settle trades
+      await scenario.settleTrades()
+      expect(await tradeInTrader.status()).to.equal(TradeStatus.CLOSED)
+
+      expect(await r0.balanceOf(tradeInTrader.address)).to.equal(0)
+      // Check received RSR
+      expect(await comp.rsr.balanceOf(comp.rsrTrader.address)).to.be.gt(0)
+    })
+
+    it('can perform a recollateralization', async () => {
+      const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+      const c2 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA2'))
+
+      // Setup backup
+      await scenario.pushBackingForBackup(tokenIDs.get('CA0') as number)
+      await scenario.setBackupConfig(0)
+
+      // Setup a simple basket of two tokens, only target type A
+      await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA1') as number, fp('0.5').sub(1))
+      await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA2') as number, fp('0.5').sub(1))
+      await scenario.setPrimeBasket()
+
+      // Switch basket
+      await scenario.refreshBasket()
+
+      // Issue some RTokens
+      // As Alice, make allowances
+      const [tokenAddrs, amts] = await comp.rToken.quote(15000n * exa, RoundingMode.CEIL)
+      for (let i = 0; i < amts.length; i++) {
+        const token = await ConAt('ERC20Fuzz', tokenAddrs[i])
+        await token.connect(alice).approve(comp.rToken.address, amts[i])
+      }
+      // Issue RTokens
+      await scenario.connect(alice).justIssue(15000n * exa)
+
+      // Wait, then vest as Alice
+      await helpers.mine(100)
+      await scenario.connect(alice).vestIssuance(1)
+
+      // No c0 tokens in backing manager
+      expect(await c0.balanceOf(comp.backingManager.address)).to.equal(0)
+
+      // Stake RSR
+      await scenario.connect(alice).stake(100000n * exa)
+
+      // Default one token in the basket CA2
+      const defaultTokenId = Number(tokenIDs.get('CA2'))
+      const coll = await ConAt('CollateralMock', await comp.assetRegistry.toColl(c2.address))
+      expect(await coll.status()).to.equal(CollateralStatus.SOUND)
+      expect(await comp.basketHandler.fullyCollateralized()).to.equal(true)
+
+      await scenario.updatePrice(defaultTokenId, 0, fp(1), fp(1), fp(1)) // Will default CA2
+
+      // Call main poke to perform refresh on assets
+      await scenario.poke()
+
+      // Collateral defaulted
+      expect(await coll.status()).to.equal(CollateralStatus.DISABLED)
+      expect(await comp.basketHandler.fullyCollateralized()).to.equal(false)
+
+      // Trying to manage tokens will fail due to unsound basket
+      await scenario.pushBackingToManage(2)
+      await scenario.pushBackingToManage(4)
+      await expect(scenario.manageBackingTokens()).to.be.reverted
+
+      // Refresh basket - will perform basket switch - New basket: CA1 and CA0
+      await scenario.refreshBasket()
+
+      // Manage backing tokens, will create auction
+      await scenario.manageBackingTokens()
+
+      // Check trade
+      const tradeInBackingManager = await ConAt(
+        'TradeMock',
+        await comp.backingManager.trades(c2.address)
+      )
+      const tradeInBroker = await ConAt('TradeMock', await comp.broker.lastOpenedTrade())
+      expect(tradeInBackingManager.address).to.equal(tradeInBroker.address)
+
+      expect(await tradeInBackingManager.status()).to.equal(TradeStatus.OPEN)
+      expect(await tradeInBackingManager.canSettle()).to.be.false
+
+      // All defaulted tokens moved to trader
+      expect(await c2.balanceOf(comp.backingManager.address)).to.equal(0)
+      expect(await c2.balanceOf(tradeInBackingManager.address)).to.be.gt(0)
+
+      // Wait and settle the trade
+      await advanceTime(await comp.broker.auctionLength())
+      expect(await tradeInBackingManager.canSettle()).to.be.true
+
+      // No C0 tokens in backing manager
+      expect(await c0.balanceOf(comp.backingManager.address)).to.equal(0)
+
+      // Settle trades - set some seed > 0
+      await scenario.pushSeedForTrades(fp(1000000))
+      await scenario.settleTrades()
+
+      expect(await tradeInBackingManager.status()).to.equal(TradeStatus.CLOSED)
+
+      // Check balances after
+      expect(await c2.balanceOf(tradeInBackingManager.address)).to.equal(0)
+      expect(await c0.balanceOf(comp.backingManager.address)).to.be.gt(0)
+    })
+  })
+
+  it('has only initially-true properties', async () => {
+    expect(await scenario.echidna_isFullyCollateralizedIfNotRebalancing()).to.be.true
+    expect(await scenario.echidna_quoteProportionalToBasketIfNotRebalancing()).to.be.true
+    expect(await scenario.echidna_RTokenRateNeverFallInNormalOps()).to.be.true
+    expect(await scenario.echidna_mainInvariants()).to.be.true
+    expect(await scenario.echidna_assetRegistryInvariants()).to.be.true
+    expect(await scenario.echidna_backingManagerInvariants()).to.be.true
+    expect(await scenario.echidna_basketInvariants()).to.be.true
+    expect(await scenario.echidna_brokerInvariants()).to.be.true
+    expect(await scenario.echidna_distributorInvariants()).to.be.true
+    expect(await scenario.echidna_furnaceInvariants()).to.be.true
+    expect(await scenario.echidna_rsrTraderInvariants()).to.be.true
+    expect(await scenario.echidna_rTokenTraderInvariants()).to.be.true
+    expect(await scenario.echidna_rTokenInvariants()).to.be.true
+    expect(await scenario.echidna_stRSRInvariants()).to.be.true
+    expect(await scenario.callStatic.echidna_refreshBasketIsNoopDuringAfterRebalancing()).to.be.true
+    expect(await scenario.callStatic.echidna_refreshBasketProperties()).to.be.true
+    expect(await scenario.callStatic.echidna_rebalancingProperties()).to.be.true
+  })
+
+  it('does not fail on refreshBasket after just one call to updatePrice', async () => {
+    await scenario.updatePrice(0, 0, 0, 0, 0)
+
+    // emulate echidna_refreshBasketIsNoop, since it's not a view and we need its value
+    await comp.basketHandler.savePrev()
+    await whileImpersonating(scenario.address, async (asOwner) => {
+      await comp.basketHandler.connect(asOwner).refreshBasket()
+    })
+    expect(await comp.basketHandler.prevEqualsCurr()).to.be.true
+  })
+
+  it('maintains basket invariants after refresh', async () => {
+    await scenario.setBackupConfig(0)
+    await scenario.unregisterAsset(0)
+    // emulate echidna_refreshBasketProperties, since it's not a view and we need its value
+    await comp.basketHandler.savePrev()
+    await whileImpersonating(scenario.address, async (asOwner) => {
+      await comp.basketHandler.connect(asOwner).refreshBasket()
+    })
+    expect(await comp.basketHandler.isValidBasketAfterRefresh()).to.be.true
+
+    expect(await comp.basketHandler.status()).to.equal(CollateralStatus.DISABLED)
+  })
+
+  it('maintains stRSR invariants after seizing RSR', async () => {
+    await scenario.connect(alice).stake(4)
+    await scenario.seizeRSR(1)
+    expect(await scenario.echidna_stRSRInvariants()).to.be.true
+  })
+
+  it('maintains RToken invariants after calling issue', async () => {
+    // As Alice, make allowances
+    const [tokenAddrs, amts] = await comp.rToken.quote(20000n * exa, RoundingMode.CEIL)
+    for (let i = 0; i < amts.length; i++) {
+      const token = await ConAt('ERC20Fuzz', tokenAddrs[i])
+      await token.connect(alice).approve(comp.rToken.address, amts[i])
+    }
+    // Issue RTokens and succeed
+    await scenario.connect(alice).justIssue(20000n * exa)
+
+    await comp.rToken.assertIssuances(aliceAddr)
+
+    expect(await scenario.echidna_rTokenInvariants()).to.be.true
+  })
+
+  it('does not have the backingManager double-revenue bug', async () => {
+    // Have some RToken in existance
+    await scenario.connect(alice).issue(1e6)
+
+    // cause C0 to grow against its ref unit
+    await scenario.updatePrice(0, fp(1.1), 0, 0, fp(1))
+
+    // call manageTokens([C0, C0])
+    await scenario.pushBackingToManage(0)
+    await scenario.pushBackingToManage(0)
+    await expect(scenario.manageBackingTokens()).to.be.reverted
+  })
+
+  it('can manage scenario states - basket switch - covered by RSR', async () => {
+    // Scenario starts in BEFORE_REBALANCING
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.BEFORE_REBALANCING)
+
+    // Set a simple basket
+    const c0 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA0'))
+    const c2 = await ConAt('ERC20Fuzz', await main.tokenBySymbol('CA2'))
+
+    // Setup a simple basket of two tokens, only target type A
+    await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA1') as number, fp('0.5').sub(1))
+    await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA2') as number, fp('0.5').sub(1))
+    await scenario.setPrimeBasket()
+
+    // Switch basket
+    await scenario.refreshBasket()
+
+    // Status remains - still fully collateralized as no RTokens were issued
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.BEFORE_REBALANCING)
+
+    // Issue some RTokens
+    // As Alice, make allowances
+    const [tokenAddrs, amts] = await comp.rToken.quote(30000n * exa, RoundingMode.CEIL)
+    for (let i = 0; i < amts.length; i++) {
+      const token = await ConAt('ERC20Fuzz', tokenAddrs[i])
+      await token.connect(alice).approve(comp.rToken.address, amts[i])
+    }
+    // Issue RTokens
+    await scenario.connect(alice).justIssue(30000n * exa)
+
+    // Wait, then vest as Alice
+    await helpers.mine(100)
+    await scenario.connect(alice).vestIssuance(1)
+
+    // No c0 tokens in backing manager
+    expect(await c0.balanceOf(comp.backingManager.address)).to.equal(0)
+
+    // Stake large amount of RSR
+    await scenario.connect(alice).stake(100000n * exa)
+
+    // Perform another basket switch - CA0 enters for CA2
+    await scenario.popBackingForPrimeBasket()
+    await scenario.pushBackingForPrimeBasket(tokenIDs.get('CA0') as number, fp('0.5').sub(1))
+    await scenario.setPrimeBasket()
+
+    // We are still in initial state
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.BEFORE_REBALANCING)
+
+    // Refresh basket - will perform basket switch - New basket: CA1 and CA0
+    await scenario.refreshBasket()
+
+    // Rebalancing has started
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.REBALANCING_ONGOING)
+
+    // Cannot perform a basket switch or change basket configs at this point
+    await expect(scenario.popBackingForPrimeBasket()).to.be.revertedWith(
+      'Not valid for current state'
+    )
+    await expect(
+      scenario.pushBackingForPrimeBasket(tokenIDs.get('CB0') as number, fp('0.5').sub(1))
+    ).to.be.revertedWith('Not valid for current state')
+    await expect(scenario.setPrimeBasket()).to.be.revertedWith('Not valid for current state')
+
+    await expect(scenario.pushBackingForBackup(tokenIDs.get('SA2') as number)).to.be.revertedWith(
+      'Not valid for current state'
+    )
+    await expect(scenario.popBackingForBackup(0)).to.be.revertedWith('Not valid for current state')
+    await expect(scenario.setBackupConfig(0)).to.be.revertedWith('Not valid for current state')
+
+    // Does not allow to change registered assets
+    await expect(scenario.pushPriceModel(0, fp('5'), 0, 0)).to.be.revertedWith(
+      'Not valid for current state'
+    )
+    await expect(scenario.unregisterAsset(7)).to.be.revertedWith('Not valid for current state')
+    await expect(scenario.registerAsset(7, 0, exa, exa, 1, exa)).to.be.revertedWith(
+      'Not valid for current state'
+    )
+    await expect(scenario.swapRegisteredAsset(4, exa, exa, 2, 0)).to.be.revertedWith(
+      'Not valid for current state'
+    )
+
+    // Check echidna property is true at all times in the process
+    expect(await scenario.callStatic.echidna_rebalancingProperties()).to.equal(true)
+
+    // Manage backing tokens, will create auction
+    await scenario.manageBackingTokens()
+
+    // Check trade
+    let tradeInBackingManager = await ConAt(
+      'TradeMock',
+      await comp.backingManager.trades(c2.address)
+    )
+    let tradeInBroker = await ConAt('TradeMock', await comp.broker.lastOpenedTrade())
+    expect(tradeInBackingManager.address).to.equal(tradeInBroker.address)
+
+    expect(await comp.backingManager.tradesOpen()).to.equal(1)
+    expect(await tradeInBackingManager.status()).to.equal(TradeStatus.OPEN)
+    expect(await tradeInBackingManager.canSettle()).to.be.false
+
+    // All c2 tokens moved to trader
+    expect(await c2.balanceOf(comp.backingManager.address)).to.equal(0)
+    expect(await c2.balanceOf(tradeInBackingManager.address)).to.be.gt(0)
+
+    // Wait and settle the trade
+    await advanceTime(await comp.broker.auctionLength())
+    expect(await tradeInBackingManager.canSettle()).to.be.true
+
+    // No C0 tokens in backing manager
+    expect(await c0.balanceOf(comp.backingManager.address)).to.equal(0)
+
+    // State remains ongoing
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.REBALANCING_ONGOING)
+
+    // Check echidna property is true at all times in the process
+    expect(await scenario.callStatic.echidna_rebalancingProperties()).to.equal(true)
+
+    // Settle trades - set some seed > 0
+    await scenario.pushSeedForTrades(fp(1000000))
+    await scenario.settleTrades()
+
+    // Check echidna property is true at all times in the process
+    expect(await scenario.callStatic.echidna_rebalancingProperties()).to.equal(true)
+
+    // State changed to Rebalancing Done
+    // expect(await scenario.status()).to.equal(RebalancingScenarioStatus.REBALANCING_DONE)
+    expect(await tradeInBackingManager.status()).to.equal(TradeStatus.CLOSED)
+    expect(await comp.backingManager.tradesOpen()).to.equal(0)
+
+    // Check balances after
+    expect(await c2.balanceOf(tradeInBackingManager.address)).to.equal(0)
+    expect(await c0.balanceOf(comp.backingManager.address)).to.be.gt(0)
+
+    // Manage backing tokens, will create auction for RSR
+    await scenario.manageBackingTokens()
+
+    tradeInBackingManager = await ConAt(
+      'TradeMock',
+      await comp.backingManager.trades(comp.rsr.address)
+    )
+    tradeInBroker = await ConAt('TradeMock', await comp.broker.lastOpenedTrade())
+    expect(tradeInBackingManager.address).to.equal(tradeInBroker.address)
+
+    expect(await comp.backingManager.tradesOpen()).to.equal(1)
+    expect(await tradeInBackingManager.status()).to.equal(TradeStatus.OPEN)
+    expect(await tradeInBackingManager.canSettle()).to.be.false
+
+    // RSR tokens moved to trader
+    expect(await comp.rsr.balanceOf(tradeInBackingManager.address)).to.be.gt(0)
+
+    // Wait and settle the trade
+    await advanceTime(await comp.broker.auctionLength())
+    expect(await tradeInBackingManager.canSettle()).to.be.true
+
+    // Settle trades - set some seed > 0
+    await scenario.pushSeedForTrades(fp(1000000))
+    await scenario.settleTrades()
+
+    // Check echidna property is true at all times in the process
+    expect(await scenario.callStatic.echidna_rebalancingProperties()).to.equal(true)
+
+    // State changed to Rebalancing Done
+    expect(await scenario.status()).to.equal(RebalancingScenarioStatus.REBALANCING_DONE)
+
+    expect(await comp.basketHandler.fullyCollateralized()).to.equal(true)
+  })
+})

--- a/test/fuzz/common.ts
+++ b/test/fuzz/common.ts
@@ -4,6 +4,12 @@ import { IConfig } from '../../common/configuration'
 import { bn, fp } from '../../common/numbers'
 import { ZERO_ADDRESS } from '../../common/constants'
 
+export enum RebalancingScenarioStatus {
+  BEFORE_REBALANCING,
+  REBALANCING_ONGOING,
+  REBALANCING_DONE,
+}
+
 export enum PriceModelKind {
   CONSTANT,
   MANUAL,


### PR DESCRIPTION
* Adds a Rebalancing scenario for fuzzing and its corresponding tests
* Adds tracking of `basketRange` and suplus and deficit tokens in the BackingManagerP1Fuzz for property checking.
* Fixes an issue when calculating `actualBuyAmount` in trade settlements. Handles now the case of selling defaulted tokens correctly.
* Replaces the way the `Broker` settles trades. It needs to be called via `Traders` for proper tracking of auctions. Also replaces a previous deprecated test for the actual auctions in all scenarios
