### PR TITLE
Multiple beneficiaries

### DIFF
--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -279,13 +279,17 @@ export interface IBackupInfo {
   backupCollateral: string[]
 }
 
+export interface IBeneficiaryInfo {
+  beneficiary: string
+  revShare: IRevenueShare
+}
+
 export interface IRTokenSetup {
   assets: string[]
   primaryBasket: string[]
   weights: BigNumber[]
   backups: IBackupInfo[]
-  beneficiary: string
-  revShare: IRevenueShare
+  beneficiaries: IBeneficiaryInfo[]
 }
 
 export interface IGovParams {

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -36,9 +36,9 @@ contract FacadeWrite is IFacadeWrite {
         // Validate beneficiaries
         for (uint256 i = 0; i < setup.beneficiaries.length; ++i) {
             require(
-                setup.beneficiaries[i].beneficiary != address(0) ||
-                    (setup.beneficiaries[i].revShare.rTokenDist == 0 &&
-                        setup.beneficiaries[i].revShare.rsrDist == 0),
+                setup.beneficiaries[i].beneficiary != address(0) &&
+                    (setup.beneficiaries[i].revShare.rTokenDist > 0 ||
+                        setup.beneficiaries[i].revShare.rsrDist > 0),
                 "beneficiary revShare mismatch"
             );
         }

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -33,12 +33,15 @@ contract FacadeWrite is IFacadeWrite {
             require(setup.backups[i].backupCollateral.length > 0, "no backup collateral");
         }
 
-        // Validate beneficiary was set intentionally
-        require(
-            setup.beneficiary != address(0) ||
-                (setup.revShare.rTokenDist == 0 && setup.revShare.rsrDist == 0),
-            "beneficiary revShare mismatch"
-        );
+        // Validate beneficiaries
+        for (uint256 i = 0; i < setup.beneficiaries.length; ++i) {
+            require(
+                setup.beneficiaries[i].beneficiary != address(0) ||
+                    (setup.beneficiaries[i].revShare.rTokenDist == 0 &&
+                        setup.beneficiaries[i].revShare.rsrDist == 0),
+                "beneficiary revShare mismatch"
+            );
+        }
 
         // Deploy contracts
         IRToken rToken = IRToken(
@@ -103,9 +106,12 @@ contract FacadeWrite is IFacadeWrite {
             }
         }
 
-        // Setup revshare beneficiary
-        if (setup.beneficiary != address(0)) {
-            main.distributor().setDistribution(setup.beneficiary, setup.revShare);
+        // Setup revshare beneficiaries
+        for (uint256 i = 0; i < setup.beneficiaries.length; ++i) {
+            main.distributor().setDistribution(
+                setup.beneficiaries[i].beneficiary,
+                setup.beneficiaries[i].revShare
+            );
         }
 
         // Pause until setupGovernance

--- a/contracts/interfaces/IFacadeWrite.sol
+++ b/contracts/interfaces/IFacadeWrite.sol
@@ -28,9 +28,8 @@ struct SetupParams {
     uint192[] weights;
     // === Basket Backup ===
     BackupInfo[] backups;
-    // === Revenue Sharing ===
-    address beneficiary;
-    RevenueShare revShare;
+    // === Beneficiaries - Revenue Sharing ===
+    BeneficiaryInfo[] beneficiaries;
 }
 
 /**
@@ -41,6 +40,15 @@ struct BackupInfo {
     bytes32 backupUnit;
     uint256 diversityFactor;
     ICollateral[] backupCollateral;
+}
+
+/**
+ * @title BeneficiaryInfo
+ * @notice The set of params to define a beneficiary
+ */
+struct BeneficiaryInfo {
+    address beneficiary;
+    RevenueShare revShare;
 }
 
 /**

--- a/scripts/deployment/phase3-rtoken/1_deploy_rtoken.ts
+++ b/scripts/deployment/phase3-rtoken/1_deploy_rtoken.ts
@@ -65,11 +65,16 @@ async function main() {
         backupCollateral: [assetCollDeployments.collateral.USDC as string],
       },
     ],
-    beneficiary: deployerUser.address, // doesn't matter what this is since it won't get used
-    revShare: {
-      rTokenDist: bn('0'),
-      rsrDist: bn('0'),
-    },
+    // doesn't matter what this is since it won't get used
+    beneficiaries: [
+      {
+        beneficiary: deployerUser.address,
+        revShare: {
+          rTokenDist: bn('0'),
+          rsrDist: bn('0'),
+        },
+      },
+    ],
   }
 
   // Validate assets

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -154,7 +154,7 @@ describe('FacadeWrite contract', () => {
     })
     facadeWrite = <FacadeWrite>await FacadeFactory.deploy(deployer.address)
 
-    revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.1% in total for each beneficiary
+    revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.5% for each beneficiary
 
     // Decrease revenue splits for nicer rounding
     config.dist.rTokenDist = bn('396')

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -154,11 +154,11 @@ describe('FacadeWrite contract', () => {
     })
     facadeWrite = <FacadeWrite>await FacadeFactory.deploy(deployer.address)
 
-    revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.1%
+    revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.1% in total for each beneficiary
 
     // Decrease revenue splits for nicer rounding
-    config.dist.rTokenDist = bn('398')
-    config.dist.rsrDist = bn('597')
+    config.dist.rTokenDist = bn('396')
+    config.dist.rsrDist = bn('594')
 
     // Set parameters
     rTokenConfig = {

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -2,7 +2,13 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { ContractFactory, Wallet } from 'ethers'
 import { ethers, waffle } from 'hardhat'
-import { IConfig, IGovParams, IRTokenConfig, IRTokenSetup } from '../common/configuration'
+import {
+  IConfig,
+  IGovParams,
+  IRevenueShare,
+  IRTokenConfig,
+  IRTokenSetup,
+} from '../common/configuration'
 import {
   CollateralStatus,
   SHORT_FREEZER,
@@ -55,7 +61,8 @@ describe('FacadeWrite contract', () => {
   let owner: SignerWithAddress
   let addr1: SignerWithAddress
   let addr2: SignerWithAddress
-  let beneficiary: SignerWithAddress
+  let beneficiary1: SignerWithAddress
+  let beneficiary2: SignerWithAddress
 
   // RSR
   let rsr: ERC20Mock
@@ -110,6 +117,7 @@ describe('FacadeWrite contract', () => {
   let rTokenSetup: IRTokenSetup
   let govParams: IGovParams
 
+  let revShare: IRevenueShare
   let loadFixture: ReturnType<typeof createFixtureLoader>
   let wallet: Wallet
 
@@ -119,7 +127,7 @@ describe('FacadeWrite contract', () => {
   })
 
   beforeEach(async () => {
-    ;[deployerUser, owner, addr1, addr2, beneficiary] = await ethers.getSigners()
+    ;[deployerUser, owner, addr1, addr2, beneficiary1, beneficiary2] = await ethers.getSigners()
 
     // Deploy fixture
     ;({ rsr, compToken, compAsset, basket, config, facade, facadeTest, deployer } =
@@ -146,7 +154,8 @@ describe('FacadeWrite contract', () => {
     })
     facadeWrite = <FacadeWrite>await FacadeFactory.deploy(deployer.address)
 
-    const revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.1%
+    revShare = { rTokenDist: bn('2'), rsrDist: bn('3') } // 0.1%
+
     // Decrease revenue splits for nicer rounding
     config.dist.rTokenDist = bn('398')
     config.dist.rsrDist = bn('597')
@@ -170,8 +179,10 @@ describe('FacadeWrite contract', () => {
           backupCollateral: [cTokenAsset.address],
         },
       ],
-      beneficiary: beneficiary.address,
-      revShare,
+      beneficiaries: [
+        { beneficiary: beneficiary1.address, revShare },
+        { beneficiary: beneficiary2.address, revShare },
+      ],
     }
 
     // Set governance params
@@ -199,7 +210,7 @@ describe('FacadeWrite contract', () => {
 
   it('Should perform validations', async () => {
     // Should not accept zero addr beneficiary
-    rTokenSetup.beneficiary = ZERO_ADDRESS
+    rTokenSetup.beneficiaries = [{ beneficiary: ZERO_ADDRESS, revShare }]
     await expect(
       facadeWrite.connect(deployerUser).deployRToken(rTokenConfig, rTokenSetup)
     ).to.be.revertedWith('beneficiary revShare mismatch')
@@ -342,9 +353,13 @@ describe('FacadeWrite contract', () => {
         expect(await stRSR.main()).to.equal(main.address)
 
         // Distributor
-        const dist = await distributor.distribution(beneficiary.address)
-        expect(dist[0]).to.equal(rTokenSetup.revShare.rTokenDist)
-        expect(dist[1]).to.equal(rTokenSetup.revShare.rsrDist)
+        const dist1 = await distributor.distribution(beneficiary1.address)
+        expect(dist1[0]).to.equal(rTokenSetup.beneficiaries[0].revShare.rTokenDist)
+        expect(dist1[1]).to.equal(rTokenSetup.beneficiaries[0].revShare.rsrDist)
+
+        const dist2 = await distributor.distribution(beneficiary2.address)
+        expect(dist2[0]).to.equal(rTokenSetup.beneficiaries[1].revShare.rTokenDist)
+        expect(dist2[1]).to.equal(rTokenSetup.beneficiaries[1].revShare.rsrDist)
       })
 
       it('Should register Assets/Collateral correctly', async () => {

--- a/test/integration/Deployment.test.ts
+++ b/test/integration/Deployment.test.ts
@@ -90,8 +90,7 @@ describeFork(`Deployment - Integration - Mainnet Forking P${IMPLEMENTATION}`, fu
             backupCollateral: [usdtCollateral.address],
           },
         ],
-        beneficiary: ZERO_ADDRESS,
-        revShare: { rTokenDist: bn(0), rsrDist: bn(0) },
+        beneficiaries: [],
       }
       // Deploy RToken via FacadeWrite
       const receipt = await (

--- a/test/integration/individual-collateral/CTokenFiatCollateral.test.ts
+++ b/test/integration/individual-collateral/CTokenFiatCollateral.test.ts
@@ -203,8 +203,7 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
       primaryBasket: [cDaiCollateral.address],
       weights: [fp('1')],
       backups: [],
-      beneficiary: ZERO_ADDRESS,
-      revShare: { rTokenDist: bn('0'), rsrDist: bn('0') },
+      beneficiaries: [],
     }
 
     // Deploy RToken via FacadeWrite


### PR DESCRIPTION
* Adds support for multiple beneficiaries in `FacadeWrite`, each with its own Revenue share distribution.
* Adapts all tests and scripts.

Closes #489 