### PR TITLE
Rocket Pool Reth Collateral plugin - Hackathon Submission

### DIFF
--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -32,6 +32,7 @@ export interface ITokens {
   WBTC?: string
   EURT?: string
   RSR?: string
+  rETH?: string
 }
 
 interface INetworkConfig {
@@ -81,6 +82,7 @@ export const networkConfig: { [key: string]: INetworkConfig } = {
       WBTC: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
       EURT: '0xC581b735A1688071A1746c968e0798D642EDE491',
       RSR: '0x320623b8E4fF03373931769A31Fc52A4E78B5d70',
+      rETH: '0xae78736Cd615f374D3085123A210448E74Fc6393',
     },
     chainlinkFeeds: {
       RSR: '0x759bBC1be8F90eE6457C44abc7d443842a976d02',
@@ -141,6 +143,7 @@ export const networkConfig: { [key: string]: INetworkConfig } = {
       WBTC: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
       EURT: '0xC581b735A1688071A1746c968e0798D642EDE491',
       RSR: '0x320623b8e4ff03373931769a31fc52a4e78b5d70',
+      rETH: '0xae78736Cd615f374D3085123A210448E74Fc6393',
     },
     chainlinkFeeds: {
       RSR: '0x759bBC1be8F90eE6457C44abc7d443842a976d02',
@@ -190,6 +193,7 @@ export const networkConfig: { [key: string]: INetworkConfig } = {
       WBTC: '0x528FdEd7CC39209ed67B4edA11937A9ABe1f6249',
       EURT: '0xD6da5A7ADE2a906d9992612752A339E3485dB508',
       RSR: '0xB58b5530332D2E9e15bfd1f2525E6fD84e830307',
+      rETH: '0xae78736Cd615f374D3085123A210448E74Fc6393',
     },
     chainlinkFeeds: {
       ETH: '0xD4a33860578De61DBAbDc8BFdb98FD742fA7028e', // canonical chainlink

--- a/contracts/plugins/mocks/RETHMock.sol
+++ b/contracts/plugins/mocks/RETHMock.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "../../libraries/Fixed.sol";
+import "./ERC20Mock.sol";
+
+contract RETHMock is ERC20Mock {
+    using FixLib for uint192;
+    uint256 internal _exchangeRate;
+
+    constructor(
+        string memory name,
+        string memory symbol
+    ) ERC20Mock(name, symbol) {
+        _exchangeRate = FIX_ONE;
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 18;
+    }
+
+    function getExchangeRate() external view returns (uint256) {
+        return _exchangeRate;
+    }
+
+    function setExchangeRate(uint256 exchangeRate) external {
+        _exchangeRate = exchangeRate;
+    }
+}

--- a/contracts/plugins/mocks/RETHMock.sol
+++ b/contracts/plugins/mocks/RETHMock.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.9;
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "../../libraries/Fixed.sol";
 import "./ERC20Mock.sol";
+import "../../plugins/reth/IRocketNetworkBalances.sol";
 
 contract RETHMock is ERC20Mock {
     using FixLib for uint192;

--- a/contracts/plugins/reth/IRETH.sol
+++ b/contracts/plugins/reth/IRETH.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+interface IRETH {
+    function getEthValue(uint256 _rethAmount) external view returns (uint256);
+    function getRethValue(uint256 _ethAmount) external view returns (uint256);
+    function getExchangeRate() external view returns (uint256);
+    function getTotalCollateral() external view returns (uint256);
+    function getCollateralRate() external view returns (uint256);
+    function depositExcess() external payable;
+    function depositExcessCollateral() external;
+    function mint(uint256 _ethAmount, address _to) external;
+    function burn(uint256 _rethAmount) external;
+}

--- a/contracts/plugins/reth/README.md
+++ b/contracts/plugins/reth/README.md
@@ -13,11 +13,6 @@ network.
 |-----------------|------------|---------------------------------------------------------|----------|-------|
 | **Description** | rETH | ETH  | ETH | USD   |
 
-tok = rETH
-ref = ETH
-target = ETH
-UoA = USD/fiat
-
 ## Defaulting Conditions
 
 The rETH collateral can default in scenarios where there's a large number of

--- a/contracts/plugins/reth/README.md
+++ b/contracts/plugins/reth/README.md
@@ -1,0 +1,54 @@
+# rETH Collateral Plugin - Hackathon Submission
+### Author: [shalzz](https://github.com/shalzz) 
+Twitter: https://twitter.com/shalzzj
+
+## Overview
+This plugin provides for using rETH token as a collateral plugin using 
+[revenue hiding][1] for smoothing for short dips in total ETH balance of the rocket pool
+network.
+
+## Units
+
+tok = rETH
+ref = ETH
+target = ETH
+UoA = USD/fiat
+
+## Defaulting Conditions
+
+The rETH collateral can default in scenarios where there's a large number of
+rocketpool validators that are slashed and the RPL token collateral is unable
+to act as a sufficient backstop to prevent the exchange rate from decreasing.
+
+In situations where there's a few small rocketpool validators that are slashed, revenue
+hiding bring stability over these small fluctuations.
+
+### Hard default:
+
+$\text{actualRefPerTok}  \lt \text{refPerTok} $
+
+Where refPerTok is 
+$\frac{\text{refPerTok}.\text{marginRatio}}{10000} $
+
+## Deployment
+
+Deploy [RETHCollateral.sol](./RETHCollateral.sol) with construct args: 
+
+```
+uint192 fallbackPrice_,  // fallback price
+AggregatorV3Interface refUnitUSDChainlinkFeed_, // {uoa/ref} chainlink feed, mostly USD/ETH
+IERC20Metadata erc20_, // address of the rETH token - 0xae78736Cd615f374D3085123A210448E74Fc6393
+uint192 maxTradeVolume_, // max trade volume - default
+uint48 oracleTimeout_, // oracle price request timeout - default
+bytes32 targetName_, // ETH
+uint16 _allowedDropBasisPoints, // Basis point out of 10000 that is used to discount refPerTok
+uint256 delayUntilDefault_ // decimals of underlying token - default
+```
+
+## Testing
+The unit and integrations tests are implemented in
+[RETHCollateral.test.ts](../../../test/integration/individual-collateral/RETHCollateral.test.ts) at 
+`test/integration/individual-collateral/RETHCollateral.test.ts`
+and can run with the default blocknumber `14916729`
+
+[1]: https://github.com/reserve-protocol/protocol/blob/master/docs/collateral.md#revenue-hiding

--- a/contracts/plugins/reth/README.md
+++ b/contracts/plugins/reth/README.md
@@ -9,6 +9,10 @@ network.
 
 ## Units
 
+| **Units**       | `tok`      | `ref`                                                   | `target` | `UoA` |
+|-----------------|------------|---------------------------------------------------------|----------|-------|
+| **Description** | rETH | ETH  | ETH | USD   |
+
 tok = rETH
 ref = ETH
 target = ETH
@@ -25,10 +29,10 @@ hiding bring stability over these small fluctuations.
 
 ### Hard default:
 
-$\text{actualRefPerTok}  \lt \text{refPerTok} $
+- $\text{actualRefPerTok}  \lt \text{refPerTok} $
 
-Where refPerTok is 
-$\frac{\text{refPerTok}.\text{marginRatio}}{10000} $
+Where refPerTok is:
+- $\frac{\text{refPerTok} * \text{marginRatio}}{10000} $
 
 ## Deployment
 

--- a/contracts/plugins/reth/RETHCollateral.sol
+++ b/contracts/plugins/reth/RETHCollateral.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "contracts/plugins/assets/AbstractCollateral.sol";
+import "contracts/plugins/assets/ICToken.sol";
+import "contracts/plugins/assets/OracleLib.sol";
+import "contracts/libraries/Fixed.sol";
+import "./IRETH.sol";
+
+/**
+ * @title RETHCollateral
+ * @notice Collateral plugin for the reth token as collateral that requires default checks.
+ * Expected: {tok} != {ref}, {ref} == {target}, {target} != {UoA}
+ * tok = rETH, ref = ETH, target = ETH, UoA = USD/fiat
+ */
+contract RETHCollateral is Collateral {
+    using FixLib for uint192;
+    using OracleLib for AggregatorV3Interface;
+
+    /// Should not use Collateral.chainlinkFeed, since naming is ambiguous
+
+    uint192 public immutable defaultThreshold; // {%} e.g. 0.05
+
+    uint192 public prevReferencePrice; // previous rate, {collateral/reference}
+
+    IRETH public immutable rETH;
+
+    /// @param refUnitUSDChainlinkFeed_ Feed units: {UoA/ref}
+    /// @param maxTradeVolume_ {UoA} The max trade volume, in UoA
+    /// @param oracleTimeout_ {s} The number of seconds until a oracle value becomes invalid
+    /// @param defaultThreshold_ {%} A value like 0.05 that represents a deviation tolerance
+    /// @param delayUntilDefault_ {s} The number of seconds deviation must occur before default
+    constructor(
+        uint192 fallbackPrice_,
+        AggregatorV3Interface refUnitUSDChainlinkFeed_,
+        IERC20Metadata erc20_,
+        uint192 maxTradeVolume_,
+        uint48 oracleTimeout_,
+        bytes32 targetName_,
+        uint192 defaultThreshold_,
+        uint256 delayUntilDefault_,
+        IRETH rETH_ 
+    )
+        Collateral(
+            fallbackPrice_,
+            refUnitUSDChainlinkFeed_,
+            erc20_,
+            maxTradeVolume_,
+            oracleTimeout_,
+            targetName_,
+            delayUntilDefault_
+        )
+    {
+        require(defaultThreshold_ > 0, "defaultThreshold zero");
+        require(
+            address(refUnitUSDChainlinkFeed_) != address(0),
+            "missing target unit chainlink feed"
+        );
+        require(address(rETH_) != address(0), "reth missing");
+        defaultThreshold = defaultThreshold_;
+        rETH = rETH_;
+
+        prevReferencePrice = refPerTok();
+    }
+
+    /// @return {UoA/tok} Our best guess at the market price of 1 whole token in UoA
+    function strictPrice() public view virtual override returns (uint192) {
+        // {UoA/tok} = {UoA/target} * {target/ref} * {ref/tok}
+        return chainlinkFeed.price(oracleTimeout)
+                .mul(refPerTok());
+    }
+
+    /// Refresh exchange rates and update default status.
+    /// @custom:interaction RCEI
+    function refresh() external virtual override {
+        if (alreadyDefaulted()) return;
+        CollateralStatus oldStatus = status();
+
+        // Check for hard default
+        uint192 referencePrice = refPerTok();
+        // uint192(<) is equivalent to Fix.lt
+        if (referencePrice < prevReferencePrice) {
+            markStatus(CollateralStatus.DISABLED);
+        } else {
+            // p {target/ref}
+            try this.strictPrice() returns (uint192) {
+                markStatus(CollateralStatus.SOUND);
+            } catch (bytes memory errData) {
+                // see: docs/solidity-style.md#Catching-Empty-Data
+                if (errData.length == 0) revert(); // solhint-disable-line reason-string
+                markStatus(CollateralStatus.IFFY);
+            }
+        }
+        prevReferencePrice = referencePrice;
+
+        CollateralStatus newStatus = status();
+        if (oldStatus != newStatus) {
+            emit DefaultStatusChanged(oldStatus, newStatus);
+        }
+    }
+
+    /// @return {ref/tok} Quantity of whole reference units per whole collateral tokens
+    function refPerTok() public view override returns (uint192) {
+        uint192(rETH.getExchangeRate());
+    }
+
+    /// @return {UoA/target} The price of a target unit in UoA
+    function pricePerTarget() public view override returns (uint192) {
+        return chainlinkFeed.price(oracleTimeout);
+    }
+}

--- a/contracts/plugins/reth/RETHCollateral.sol
+++ b/contracts/plugins/reth/RETHCollateral.sol
@@ -24,8 +24,6 @@ contract RETHCollateral is Collateral {
 
     uint192 public prevReferencePrice; // previous rate, {collateral/reference}
 
-    IRETH public immutable rETH;
-
     /// @param refUnitUSDChainlinkFeed_ Feed units: {UoA/ref}
     /// @param maxTradeVolume_ {UoA} The max trade volume, in UoA
     /// @param oracleTimeout_ {s} The number of seconds until a oracle value becomes invalid
@@ -57,7 +55,6 @@ contract RETHCollateral is Collateral {
             "missing target unit chainlink feed"
         );
         defaultThreshold = defaultThreshold_;
-        rETH = IRETH(address(erc20));
 
         prevReferencePrice = refPerTok();
     }
@@ -100,7 +97,7 @@ contract RETHCollateral is Collateral {
 
     /// @return {ref/tok} Quantity of whole reference units per whole collateral tokens
     function refPerTok() public view override returns (uint192) {
-        return uint192(rETH.getExchangeRate());
+        return uint192(IRETH(address(erc20)).getExchangeRate());
     }
 
     /// @return {UoA/target} The price of a target unit in UoA

--- a/contracts/plugins/reth/RETHCollateral.sol
+++ b/contracts/plugins/reth/RETHCollateral.sol
@@ -39,8 +39,7 @@ contract RETHCollateral is Collateral {
         uint48 oracleTimeout_,
         bytes32 targetName_,
         uint192 defaultThreshold_,
-        uint256 delayUntilDefault_,
-        IRETH rETH_ 
+        uint256 delayUntilDefault_
     )
         Collateral(
             fallbackPrice_,
@@ -57,9 +56,8 @@ contract RETHCollateral is Collateral {
             address(refUnitUSDChainlinkFeed_) != address(0),
             "missing target unit chainlink feed"
         );
-        require(address(rETH_) != address(0), "reth missing");
         defaultThreshold = defaultThreshold_;
-        rETH = rETH_;
+        rETH = IRETH(address(erc20));
 
         prevReferencePrice = refPerTok();
     }
@@ -102,7 +100,7 @@ contract RETHCollateral is Collateral {
 
     /// @return {ref/tok} Quantity of whole reference units per whole collateral tokens
     function refPerTok() public view override returns (uint192) {
-        uint192(rETH.getExchangeRate());
+        return uint192(rETH.getExchangeRate());
     }
 
     /// @return {UoA/target} The price of a target unit in UoA

--- a/contracts/plugins/reth/RETHCollateral.sol
+++ b/contracts/plugins/reth/RETHCollateral.sol
@@ -96,7 +96,7 @@ contract RETHCollateral is Collateral {
 
         CollateralStatus newStatus = status();
         if (oldStatus != newStatus) {
-            emit DefaultStatusChanged(oldStatus, newStatus);
+            emit CollateralStatusChanged(oldStatus, newStatus);
         }
     }
 

--- a/contracts/plugins/reth/RETHCollateral.sol
+++ b/contracts/plugins/reth/RETHCollateral.sol
@@ -55,6 +55,7 @@ contract RETHCollateral is Collateral {
         );
         require(_allowedDropBasisPoints < 10000, "Allowed refPerTok drop out of range");
 
+        maxRefPerTok = actualRefPerTok();
         marginRatio = 10000 - _allowedDropBasisPoints;
     }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@aave/protocol-v2": "^1.0.1",
     "@chainlink/contracts": "^0.4.1",
+    "@defi-wonderland/smock": "^2.3.4",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",
     "@nomiclabs/hardhat-ethers": "^2.0.3",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,8 @@
+{
+  "filter_paths": "node_modules",
+  "solc_remaps": [
+    "@openzeppelin/=node_modules/@openzeppelin/",
+    "@chainlink/=node_modules/@chainlink/"
+  ]
+}
+

--- a/test/integration/individual-collateral/RETHCollateral.test.ts
+++ b/test/integration/individual-collateral/RETHCollateral.test.ts
@@ -339,7 +339,7 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
       const rethRefPerTok2: BigNumber = await rethCollateral.refPerTok() // reth in ref
 
       // Check rates and price increase
-      // expect(rethPrice2).to.be.gt(rethPrice1)
+      expect(rethPrice2).to.be.gt(rethPrice1)
       expect(rethRefPerTok2).to.be.gt(rethRefPerTok1)
 
       // Still close to the original values
@@ -361,16 +361,16 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
       expect(await rethCollateral.status()).to.equal(CollateralStatus.SOUND)
 
       // Check rates and prices - Have changed significantly
-      const cDaiPrice3: BigNumber = await rethCollateral.strictPrice() // ~0.03294
-      const cDaiRefPerTok3: BigNumber = await rethCollateral.refPerTok() // ~0.03294
+      const rethPrice3: BigNumber = await rethCollateral.strictPrice() // reth in UoA
+      const rethRefPerTok3: BigNumber = await rethCollateral.refPerTok() // reth in ref
 
       // Check rates and price increase
-      expect(cDaiPrice3).to.be.gt(cDaiPrice2)
-      expect(cDaiRefPerTok3).to.be.gt(cDaiRefPerTok2)
+      expect(rethPrice3).to.be.gt(rethPrice2)
+      expect(rethRefPerTok3).to.be.gt(rethRefPerTok2)
 
       // Need to adjust ranges
-      expect(cDaiPrice3).to.be.closeTo(fp('0.032'), fp('0.001'))
-      expect(cDaiRefPerTok3).to.be.closeTo(fp('0.032'), fp('0.001'))
+      expect(rethPrice3).to.be.closeTo(fp('2000'), fp('1000'))
+      expect(rethRefPerTok3).to.be.closeTo(fp('1.080'), fp('1.000'))
 
       // Check total asset value increased
       const totalAssetValue3: BigNumber = await facadeTest.callStatic.totalAssetValue(
@@ -409,17 +409,8 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
       const MIN_ISSUANCE_PER_BLOCK = bn('5000e18')
       const issueAmount: BigNumber = MIN_ISSUANCE_PER_BLOCK
 
-      // Try to claim rewards at this point - Nothing for Backing Manager
-      // expect(await compToken.balanceOf(backingManager.address)).to.equal(0)
-
-      // await expectEvents(backingManager.claimRewards(), [
-      //   {
-      //     contract: backingManager,
-      //     name: 'RewardsClaimed',
-      //     args: [ZERO_ADDRESS, bn(0)],
-      //     emitted: true,
-      //   },
-      // ])
+      // Trying to claim should not revert
+      await expect(backingManager.claimRewards()).to.not.reverted
 
       // Provide approvals for issuances
       await reth.connect(addr1).approve(rToken.address, issueAmount)
@@ -468,7 +459,7 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         })
       ).deploy(
         fp('0.02'),
-        mockChainlinkFeed.address,
+        NO_PRICE_DATA_FEED,
         reth.address,
         config.rTokenMaxTradeVolume,
         ORACLE_TIMEOUT,

--- a/test/integration/individual-collateral/RETHCollateral.test.ts
+++ b/test/integration/individual-collateral/RETHCollateral.test.ts
@@ -146,7 +146,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         ethers.utils.formatBytes32String('USD'),
         defaultThreshold,
         delayUntilDefault,
-        reth.address
       )
     )
 
@@ -223,11 +222,11 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
       expect(await rethCollateral.erc20()).to.equal(reth.address)
       expect(await reth.decimals()).to.equal(18)
       expect(await rethCollateral.targetName()).to.equal(ethers.utils.formatBytes32String('USD'))
-      expect(await rethCollateral.refPerTok()).to.be.closeTo(fp('0.022'), fp('0.001'))
+      expect(await rethCollateral.refPerTok()).to.be.closeTo(fp('1.080'), fp('1.000'))
       expect(await rethCollateral.targetPerRef()).to.equal(fp('1'))
-      expect(await rethCollateral.pricePerTarget()).to.equal(fp('1'))
+      expect(await rethCollateral.pricePerTarget()).to.be.closeTo(fp('1000'), fp('5000'))
       expect(await rethCollateral.prevReferencePrice()).to.equal(await rethCollateral.refPerTok())
-      expect(await rethCollateral.strictPrice()).to.be.closeTo(fp('0.022'), fp('0.001')) // close to $0.022 cents
+      expect(await rethCollateral.strictPrice()).to.be.closeTo(fp('1000'), fp('5000'))
 
       // Check claim data
       // await expect(rethCollateral.claimRewards())
@@ -296,8 +295,7 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
           ORACLE_TIMEOUT,
           ethers.utils.formatBytes32String('USD'),
           bn(0),
-          delayUntilDefault,
-          reth.address
+          delayUntilDefault
         )
       ).to.be.revertedWith('defaultThreshold zero')
     })
@@ -484,7 +482,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         ethers.utils.formatBytes32String('USD'),
         defaultThreshold,
         delayUntilDefault,
-        reth.address
       )
 
       // CTokens - Collateral with no price info should revert
@@ -508,7 +505,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         ethers.utils.formatBytes32String('USD'),
         defaultThreshold,
         delayUntilDefault,
-        reth.address
       )
 
       await setOraclePrice(invalidpriceRethCollateral.address, bn(0))
@@ -545,7 +541,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         await rethCollateral.targetName(),
         await rethCollateral.defaultThreshold(),
         await rethCollateral.delayUntilDefault(),
-        reth.address
       )
 
       // Check initial state
@@ -599,7 +594,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         await rethCollateral.targetName(),
         await rethCollateral.defaultThreshold(),
         await rethCollateral.delayUntilDefault(),
-        reth.address
       )
 
       // Check initial state
@@ -634,7 +628,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
           await rethCollateral.targetName(),
           await rethCollateral.defaultThreshold(),
           await rethCollateral.delayUntilDefault(),
-          reth.address
         )
       )
 

--- a/test/integration/individual-collateral/RETHCollateral.test.ts
+++ b/test/integration/individual-collateral/RETHCollateral.test.ts
@@ -588,9 +588,6 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
         await rethCollateral.delayUntilDefault(),
       )
 
-      // Force updates - Should update whenDefault and status for rETH 
-      await newRethCollateral.refresh()
-
       // Check initial state
       expect(await newRethCollateral.status()).to.equal(CollateralStatus.SOUND)
       expect(await newRethCollateral.whenDefault()).to.equal(MAX_UINT256)

--- a/test/integration/individual-collateral/RETHCollateral.test.ts
+++ b/test/integration/individual-collateral/RETHCollateral.test.ts
@@ -151,9 +151,9 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
 
     // Setup balances for addr1 - Transfer from Mainnet holder
     // rETH 
-    initialBal = bn('2000000e18')
+    initialBal = bn('8000e18')
     await whileImpersonating(holderRETH, async (rethSigner) => {
-      await reth.connect(rethSigner).transfer(addr1.address, toBNDecimals(initialBal, 8))
+      await reth.connect(rethSigner).transfer(addr1.address, initialBal)
     })
 
     // Set parameters
@@ -273,13 +273,13 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
       expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
       const [isFallback, price] = await basketHandler.price(true)
       expect(isFallback).to.equal(false)
-      expect(price).to.be.closeTo(fp('1'), fp('0.015'))
+      expect(price).to.be.closeTo(fp('2000'), fp('1000'))
 
       // Check RToken price
-      const issueAmount: BigNumber = bn('10000e18')
-      await reth.connect(addr1).approve(rToken.address, toBNDecimals(issueAmount, 8).mul(100))
+      const issueAmount: BigNumber = bn('5000e18')
+      await reth.connect(addr1).approve(rToken.address, issueAmount)
       await expect(rToken.connect(addr1).issue(issueAmount)).to.emit(rToken, 'Issuance')
-      expect(await rTokenAsset.strictPrice()).to.be.closeTo(fp('1'), fp('0.015'))
+      expect(await rTokenAsset.strictPrice()).to.be.closeTo(fp('2000'), fp('1000'))
     })
 
     // Validate constructor arguments
@@ -302,7 +302,7 @@ describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () 
   })
 
   describe('Issuance/Appreciation/Redemption', () => {
-    const MIN_ISSUANCE_PER_BLOCK = bn('10000e18')
+    const MIN_ISSUANCE_PER_BLOCK = bn('5000e18')
 
     // Issuance and redemption, making the collateral appreciate over time
     it('Should issue, redeem, and handle appreciation rates correctly', async () => {

--- a/test/integration/individual-collateral/RETHCollateral.test.ts
+++ b/test/integration/individual-collateral/RETHCollateral.test.ts
@@ -1,0 +1,652 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { BigNumber, ContractFactory, Wallet } from 'ethers'
+import hre, { ethers, waffle } from 'hardhat'
+import { IMPLEMENTATION } from '../../fixtures'
+import { defaultFixture, ORACLE_TIMEOUT } from './fixtures'
+import { getChainId } from '../../../common/blockchain-utils'
+import {
+  IConfig,
+  IGovParams,
+  IRevenueShare,
+  IRTokenConfig,
+  IRTokenSetup,
+  networkConfig,
+} from '../../../common/configuration'
+import { CollateralStatus, MAX_UINT256, ZERO_ADDRESS } from '../../../common/constants'
+import { expectEvents, expectInIndirectReceipt } from '../../../common/events'
+import { bn, fp, toBNDecimals } from '../../../common/numbers'
+import { whileImpersonating } from '../../utils/impersonation'
+import { setOraclePrice } from '../../utils/oracles'
+import { advanceBlocks, advanceTime, getLatestBlockTimestamp } from '../../utils/time'
+import {
+  Asset,
+  CTokenFiatCollateral,
+  ERC20Mock,
+  FacadeRead,
+  FacadeTest,
+  FacadeWrite,
+  IAssetRegistry,
+  IBasketHandler,
+  InvalidMockV3Aggregator,
+  OracleLib,
+  MockV3Aggregator,
+  RTokenAsset,
+  RETHCollateral,
+  TestIBackingManager,
+  TestIDeployer,
+  TestIMain,
+  TestIRToken,
+} from '../../../typechain'
+import { useEnv } from '#/utils/env'
+
+const createFixtureLoader = waffle.createFixtureLoader
+
+// Holder address in Mainnet
+const holderRETH = '0xEADB3840596cabF312F2bC88A4Bb0b93A4E1FF5F'
+
+const NO_PRICE_DATA_FEED = '0x51597f405303C4377E36123cBc172b13269EA163'
+
+const describeFork = useEnv('FORK') ? describe : describe.skip
+
+describeFork(`RETHCollateral - Mainnet Forking P${IMPLEMENTATION}`, function () {
+  let owner: SignerWithAddress
+  let addr1: SignerWithAddress
+
+  // Tokens/Assets
+  let reth: ERC20Mock
+  let rethCollateral: RETHCollateral
+  let rsr: ERC20Mock
+  let rsrAsset: Asset
+
+  // Core Contracts
+  let main: TestIMain
+  let rToken: TestIRToken
+  let rTokenAsset: RTokenAsset
+  let assetRegistry: IAssetRegistry
+  let backingManager: TestIBackingManager
+  let basketHandler: IBasketHandler
+
+  let deployer: TestIDeployer
+  let facade: FacadeRead
+  let facadeTest: FacadeTest
+  let facadeWrite: FacadeWrite
+  let oracleLib: OracleLib
+  let govParams: IGovParams
+
+  // RToken Configuration
+  const dist: IRevenueShare = {
+    rTokenDist: bn(40), // 2/5 RToken
+    rsrDist: bn(60), // 3/5 RSR
+  }
+  const config: IConfig = {
+    dist: dist,
+    minTradeVolume: fp('1e4'), // $10k
+    rTokenMaxTradeVolume: fp('1e6'), // $1M
+    shortFreeze: bn('259200'), // 3 days
+    longFreeze: bn('2592000'), // 30 days
+    rewardPeriod: bn('604800'), // 1 week
+    rewardRatio: fp('0.02284'), // approx. half life of 30 pay periods
+    unstakingDelay: bn('1209600'), // 2 weeks
+    tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
+    auctionLength: bn('900'), // 15 minutes
+    backingBuffer: fp('0.0001'), // 0.01%
+    maxTradeSlippage: fp('0.01'), // 1%
+    issuanceRate: fp('0.00025'), // 0.025% per block or ~0.1% per minute
+    scalingRedemptionRate: fp('0.05'), // 5%
+    redemptionRateFloor: fp('1e6'), // 1M RToken
+  }
+
+  const defaultThreshold = fp('0.05') // 5%
+  const delayUntilDefault = bn('86400') // 24h
+
+  let initialBal: BigNumber
+
+  let loadFixture: ReturnType<typeof createFixtureLoader>
+  let wallet: Wallet
+
+  let chainId: number
+
+  let RETHCollateralFactory: ContractFactory
+  let MockV3AggregatorFactory: ContractFactory
+  let mockChainlinkFeed: MockV3Aggregator
+
+  before(async () => {
+    ;[wallet] = (await ethers.getSigners()) as unknown as Wallet[]
+    loadFixture = createFixtureLoader([wallet])
+
+    chainId = await getChainId(hre)
+    if (!networkConfig[chainId]) {
+      throw new Error(`Missing network configuration for ${hre.network.name}`)
+    }
+  })
+
+  beforeEach(async () => {
+    ;[owner, addr1] = await ethers.getSigners()
+    ;({ rsr, rsrAsset, deployer, facade, facadeTest, facadeWrite, oracleLib, govParams } =
+      await loadFixture(defaultFixture))
+
+    // Get required contracts for reth
+    // RETH token
+    reth = <ERC20Mock>(
+      await ethers.getContractAt('ERC20Mock', networkConfig[chainId].tokens.rETH || '')
+    )
+
+    // Deploy rETH collateral plugin
+    RETHCollateralFactory = await ethers.getContractFactory('RETHCollateral', {
+      // libraries: { OracleLib: oracleLib.address },
+    })
+    rethCollateral = <RETHCollateral>(
+      await RETHCollateralFactory.deploy(
+        fp('0.02'),
+        networkConfig[chainId].chainlinkFeeds.ETH as string,
+        reth.address,
+        config.rTokenMaxTradeVolume,
+        ORACLE_TIMEOUT,
+        ethers.utils.formatBytes32String('USD'),
+        defaultThreshold,
+        delayUntilDefault,
+        reth.address
+      )
+    )
+
+    // Setup balances for addr1 - Transfer from Mainnet holder
+    // rETH 
+    initialBal = bn('2000000e18')
+    await whileImpersonating(holderRETH, async (rethSigner) => {
+      await reth.connect(rethSigner).transfer(addr1.address, toBNDecimals(initialBal, 8))
+    })
+
+    // Set parameters
+    const rTokenConfig: IRTokenConfig = {
+      name: 'RTKN RToken',
+      symbol: 'RTKN',
+      mandate: 'mandate',
+      params: config,
+    }
+
+    // Set primary basket
+    const rTokenSetup: IRTokenSetup = {
+      assets: [],
+      primaryBasket: [rethCollateral.address],
+      weights: [fp('1')],
+      backups: [],
+      beneficiaries: [],
+    }
+
+    // Deploy RToken via FacadeWrite
+    const receipt = await (
+      await facadeWrite.connect(owner).deployRToken(rTokenConfig, rTokenSetup)
+    ).wait()
+
+    // Get Main
+    const mainAddr = expectInIndirectReceipt(receipt, deployer.interface, 'RTokenCreated').args.main
+    main = <TestIMain>await ethers.getContractAt('TestIMain', mainAddr)
+
+    // Get core contracts
+    assetRegistry = <IAssetRegistry>(
+      await ethers.getContractAt('IAssetRegistry', await main.assetRegistry())
+    )
+    backingManager = <TestIBackingManager>(
+      await ethers.getContractAt('TestIBackingManager', await main.backingManager())
+    )
+    basketHandler = <IBasketHandler>(
+      await ethers.getContractAt('IBasketHandler', await main.basketHandler())
+    )
+    rToken = <TestIRToken>await ethers.getContractAt('TestIRToken', await main.rToken())
+    rTokenAsset = <RTokenAsset>(
+      await ethers.getContractAt('RTokenAsset', await assetRegistry.toAsset(rToken.address))
+    )
+
+    // Setup owner and unpause
+    await facadeWrite.connect(owner).setupGovernance(
+      rToken.address,
+      false, // do not deploy governance
+      true, // unpaused
+      govParams, // mock values, not relevant
+      owner.address, // owner
+      ZERO_ADDRESS, // no guardian
+      ZERO_ADDRESS // no pauser
+    )
+
+    // Setup mock chainlink feed for some of the tests (so we can change the value)
+    MockV3AggregatorFactory = await ethers.getContractFactory('MockV3Aggregator')
+    mockChainlinkFeed = <MockV3Aggregator>await MockV3AggregatorFactory.deploy(8, bn('1e8'))
+  })
+
+  describe('Deployment', () => {
+    // Check the initial state
+    it('Should setup RToken, Assets, and Collateral correctly', async () => {
+      // Check Collateral plugin
+      // rETH (RETHCollateral)
+      expect(await rethCollateral.isCollateral()).to.equal(true)
+      expect(await rethCollateral.erc20()).to.equal(reth.address)
+      expect(await reth.decimals()).to.equal(18)
+      expect(await rethCollateral.targetName()).to.equal(ethers.utils.formatBytes32String('USD'))
+      expect(await rethCollateral.refPerTok()).to.be.closeTo(fp('0.022'), fp('0.001'))
+      expect(await rethCollateral.targetPerRef()).to.equal(fp('1'))
+      expect(await rethCollateral.pricePerTarget()).to.equal(fp('1'))
+      expect(await rethCollateral.prevReferencePrice()).to.equal(await rethCollateral.refPerTok())
+      expect(await rethCollateral.strictPrice()).to.be.closeTo(fp('0.022'), fp('0.001')) // close to $0.022 cents
+
+      // Check claim data
+      // await expect(rethCollateral.claimRewards())
+      //   .to.emit(rethCollateral, 'RewardsClaimed')
+      //   .withArgs(compToken.address, 0)
+      // expect(await rethCollateral.maxTradeVolume()).to.equal(config.rTokenMaxTradeVolume)
+
+      // Should setup contracts
+      expect(main.address).to.not.equal(ZERO_ADDRESS)
+    })
+
+    // Check assets/collaterals in the Asset Registry
+    it('Should register ERC20s and Assets/Collateral correctly', async () => {
+      // Check assets/collateral
+      // const ERC20s = await assetRegistry.erc20s()
+      // expect(ERC20s[0]).to.equal(rToken.address)
+      // expect(ERC20s[1]).to.equal(rsr.address)
+      // expect(ERC20s[2]).to.equal(compToken.address)
+      // expect(ERC20s[3]).to.equal(cDai.address)
+      // expect(ERC20s.length).to.eql(4)
+      //
+      // // Assets
+      // expect(await assetRegistry.toAsset(ERC20s[0])).to.equal(rTokenAsset.address)
+      // expect(await assetRegistry.toAsset(ERC20s[1])).to.equal(rsrAsset.address)
+      // expect(await assetRegistry.toAsset(ERC20s[2])).to.equal(compAsset.address)
+      // expect(await assetRegistry.toAsset(ERC20s[3])).to.equal(rethCollateral.address)
+      //
+      // // Collaterals
+      // expect(await assetRegistry.toColl(ERC20s[3])).to.equal(rethCollateral.address)
+    })
+
+    // Check RToken basket
+    it('Should register Basket correctly', async () => {
+      // Basket
+      expect(await basketHandler.fullyCollateralized()).to.equal(true)
+      const backing = await facade.basketTokens(rToken.address)
+      expect(backing[0]).to.equal(reth.address)
+      expect(backing.length).to.equal(1)
+
+      // Check other values
+      expect(await basketHandler.nonce()).to.be.gt(bn(0))
+      expect(await basketHandler.timestamp()).to.be.gt(bn(0))
+      expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+      const [isFallback, price] = await basketHandler.price(true)
+      expect(isFallback).to.equal(false)
+      expect(price).to.be.closeTo(fp('1'), fp('0.015'))
+
+      // Check RToken price
+      const issueAmount: BigNumber = bn('10000e18')
+      await reth.connect(addr1).approve(rToken.address, toBNDecimals(issueAmount, 8).mul(100))
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.emit(rToken, 'Issuance')
+      expect(await rTokenAsset.strictPrice()).to.be.closeTo(fp('1'), fp('0.015'))
+    })
+
+    // Validate constructor arguments
+    // Note: Adapt it to your plugin constructor validations
+    it('Should validate constructor arguments correctly', async () => {
+      // Default threshold
+      await expect(
+        RETHCollateralFactory.deploy(
+          fp('0.02'),
+          networkConfig[chainId].chainlinkFeeds.DAI as string,
+          reth.address,
+          config.rTokenMaxTradeVolume,
+          ORACLE_TIMEOUT,
+          ethers.utils.formatBytes32String('USD'),
+          bn(0),
+          delayUntilDefault,
+          reth.address
+        )
+      ).to.be.revertedWith('defaultThreshold zero')
+    })
+  })
+
+  describe('Issuance/Appreciation/Redemption', () => {
+    const MIN_ISSUANCE_PER_BLOCK = bn('10000e18')
+
+    // Issuance and redemption, making the collateral appreciate over time
+    it('Should issue, redeem, and handle appreciation rates correctly', async () => {
+      const issueAmount: BigNumber = MIN_ISSUANCE_PER_BLOCK // instant issuance
+
+      // Provide approvals for issuances
+      await reth.connect(addr1).approve(rToken.address, toBNDecimals(issueAmount, 8).mul(100))
+
+      // Issue rTokens
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.emit(rToken, 'Issuance')
+
+      // Check RTokens issued to user
+      expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
+
+      // Store Balances after issuance
+      const balanceAddr1cDai: BigNumber = await reth.balanceOf(addr1.address)
+
+      // Check rates and prices
+      const cDaiPrice1: BigNumber = await rethCollateral.strictPrice() // ~ 0.022015 cents
+      const cDaiRefPerTok1: BigNumber = await rethCollateral.refPerTok() // ~ 0.022015 cents
+
+      expect(cDaiPrice1).to.be.closeTo(fp('0.022'), fp('0.001'))
+      expect(cDaiRefPerTok1).to.be.closeTo(fp('0.022'), fp('0.001'))
+
+      // Check total asset value
+      const totalAssetValue1: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
+      expect(totalAssetValue1).to.be.closeTo(issueAmount, fp('150')) // approx 10K in value
+
+      // Advance time and blocks slightly, causing refPerTok() to increase
+      await advanceTime(10000)
+      await advanceBlocks(10000)
+
+      // Refresh cToken manually (required)
+      await rethCollateral.refresh()
+      expect(await rethCollateral.status()).to.equal(CollateralStatus.SOUND)
+
+      // Check rates and prices - Have changed, slight inrease
+      const cDaiPrice2: BigNumber = await rethCollateral.strictPrice() // ~0.022016
+      const cDaiRefPerTok2: BigNumber = await rethCollateral.refPerTok() // ~0.022016
+
+      // Check rates and price increase
+      expect(cDaiPrice2).to.be.gt(cDaiPrice1)
+      expect(cDaiRefPerTok2).to.be.gt(cDaiRefPerTok1)
+
+      // Still close to the original values
+      expect(cDaiPrice2).to.be.closeTo(fp('0.022'), fp('0.001'))
+      expect(cDaiRefPerTok2).to.be.closeTo(fp('0.022'), fp('0.001'))
+
+      // Check total asset value increased
+      const totalAssetValue2: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
+      expect(totalAssetValue2).to.be.gt(totalAssetValue1)
+
+      // Advance time and blocks slightly, causing refPerTok() to increase
+      await advanceTime(100000000)
+      await advanceBlocks(100000000)
+
+      // Refresh cToken manually (required)
+      await rethCollateral.refresh()
+      expect(await rethCollateral.status()).to.equal(CollateralStatus.SOUND)
+
+      // Check rates and prices - Have changed significantly
+      const cDaiPrice3: BigNumber = await rethCollateral.strictPrice() // ~0.03294
+      const cDaiRefPerTok3: BigNumber = await rethCollateral.refPerTok() // ~0.03294
+
+      // Check rates and price increase
+      expect(cDaiPrice3).to.be.gt(cDaiPrice2)
+      expect(cDaiRefPerTok3).to.be.gt(cDaiRefPerTok2)
+
+      // Need to adjust ranges
+      expect(cDaiPrice3).to.be.closeTo(fp('0.032'), fp('0.001'))
+      expect(cDaiRefPerTok3).to.be.closeTo(fp('0.032'), fp('0.001'))
+
+      // Check total asset value increased
+      const totalAssetValue3: BigNumber = await facadeTest.callStatic.totalAssetValue(
+        rToken.address
+      )
+      expect(totalAssetValue3).to.be.gt(totalAssetValue2)
+
+      // Redeem Rtokens with the updated rates
+      await expect(rToken.connect(addr1).redeem(issueAmount)).to.emit(rToken, 'Redemption')
+
+      // Check funds were transferred
+      expect(await rToken.balanceOf(addr1.address)).to.equal(0)
+      expect(await rToken.totalSupply()).to.equal(0)
+
+      // Check balances - Fewer cTokens should have been sent to the user
+      const newBalanceAddr1cDai: BigNumber = await reth.balanceOf(addr1.address)
+
+      // Check received tokens represent ~10K in value at current prices
+      expect(newBalanceAddr1cDai.sub(balanceAddr1cDai)).to.be.closeTo(bn('303570e8'), bn('8e7')) // ~0.03294 * 303571 ~= 10K (100% of basket)
+
+      // Check remainders in Backing Manager
+      expect(await reth.balanceOf(backingManager.address)).to.be.closeTo(bn(150663e8), bn('5e7')) // ~= 4962.8 usd in value
+
+      //  Check total asset value (remainder)
+      expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(
+        fp('4962.8'), // ~= 4962.8 usd (from above)
+        fp('0.5')
+      )
+    })
+  })
+
+  // Note: Even if the collateral does not provide reward tokens, this test should be performed to check that
+  // claiming calls throughout the protocol are handled correctly and do not revert.
+  describe('Rewards', () => {
+    it('Should be able to claim rewards (if applicable)', async () => {
+      const MIN_ISSUANCE_PER_BLOCK = bn('10000e18')
+      const issueAmount: BigNumber = MIN_ISSUANCE_PER_BLOCK
+
+      // Try to claim rewards at this point - Nothing for Backing Manager
+      // expect(await compToken.balanceOf(backingManager.address)).to.equal(0)
+
+      await expectEvents(backingManager.claimRewards(), [
+        {
+          contract: backingManager,
+          name: 'RewardsClaimed',
+          args: [ZERO_ADDRESS, bn(0)],
+          emitted: true,
+        },
+      ])
+
+      // Provide approvals for issuances
+      await reth.connect(addr1).approve(rToken.address, toBNDecimals(issueAmount, 8).mul(100))
+
+      // Issue rTokens
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.emit(rToken, 'Issuance')
+
+      // Check RTokens issued to user
+      expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
+
+      // Advance Time
+      await advanceTime(8000)
+
+      // Claim rewards
+      await expect(backingManager.claimRewards()).to.emit(backingManager, 'RewardsClaimed')
+
+      // Keep moving time
+      await advanceTime(3600)
+
+      // Get additional rewards
+      await expect(backingManager.claimRewards()).to.emit(backingManager, 'RewardsClaimed')
+    })
+  })
+
+  describe('Price Handling', () => {
+    it('Should handle invalid/stale Price', async () => {
+      // Reverts with stale price
+      await advanceTime(ORACLE_TIMEOUT.toString())
+
+      // Compound
+      await expect(rethCollateral.strictPrice()).to.be.revertedWith('StalePrice()')
+
+      // Fallback price is returned
+      const [isFallback, price] = await rethCollateral.price(true)
+      expect(isFallback).to.equal(true)
+      expect(price).to.equal(fp('0.02'))
+
+      // Refresh should mark status IFFY
+      await rethCollateral.refresh()
+      expect(await rethCollateral.status()).to.equal(CollateralStatus.IFFY)
+
+      // Reth Collateral with no price
+      const nonpriceRethCollateral: RETHCollateral = <RETHCollateral>await (
+        await ethers.getContractFactory('RETHCollateral', {
+          // libraries: { OracleLib: oracleLib.address },
+        })
+      ).deploy(
+        fp('0.02'),
+        mockChainlinkFeed.address,
+        reth.address,
+        config.rTokenMaxTradeVolume,
+        ORACLE_TIMEOUT,
+        ethers.utils.formatBytes32String('USD'),
+        defaultThreshold,
+        delayUntilDefault,
+        reth.address
+      )
+
+      // CTokens - Collateral with no price info should revert
+      await expect(nonpriceRethCollateral.strictPrice()).to.be.reverted
+
+      // Refresh should also revert - status is not modified
+      await expect(nonpriceRethCollateral.refresh()).to.be.reverted
+      expect(await nonpriceRethCollateral.status()).to.equal(CollateralStatus.SOUND)
+
+      // Reverts with a feed with zero price
+      const invalidpriceRethCollateral: RETHCollateral = <RETHCollateral>await (
+        await ethers.getContractFactory('RETHCollateral', {
+          // libraries: { OracleLib: oracleLib.address },
+        })
+      ).deploy(
+        fp('0.02'),
+        mockChainlinkFeed.address,
+        reth.address,
+        config.rTokenMaxTradeVolume,
+        ORACLE_TIMEOUT,
+        ethers.utils.formatBytes32String('USD'),
+        defaultThreshold,
+        delayUntilDefault,
+        reth.address
+      )
+
+      await setOraclePrice(invalidpriceRethCollateral.address, bn(0))
+
+      // Reverts with zero price
+      await expect(invalidpriceRethCollateral.strictPrice()).to.be.revertedWith(
+        'PriceOutsideRange()'
+      )
+
+      // Refresh should mark status IFFY
+      await invalidpriceRethCollateral.refresh()
+      expect(await invalidpriceRethCollateral.status()).to.equal(CollateralStatus.IFFY)
+    })
+  })
+
+  // Note: Here the idea is to test all possible statuses and check all possible paths to default
+  // soft default = SOUND -> IFFY -> DISABLED due to sustained misbehavior
+  // hard default = SOUND -> DISABLED due to an invariant violation
+  // This may require to deploy some mocks to be able to force some of these situations
+  describe('Collateral Status', () => {
+    // Test for soft default
+    it('Updates status in case of soft default', async () => {
+      // Redeploy plugin using a Chainlink mock feed where we can change the price
+      const newRethCollateral: RETHCollateral = <RETHCollateral>await (
+        await ethers.getContractFactory('RETHCollateral', {
+          // libraries: { OracleLib: oracleLib.address },
+        })
+      ).deploy(
+        fp('0.02'),
+        mockChainlinkFeed.address,
+        reth.address,
+        await rethCollateral.maxTradeVolume(),
+        await rethCollateral.oracleTimeout(),
+        await rethCollateral.targetName(),
+        await rethCollateral.defaultThreshold(),
+        await rethCollateral.delayUntilDefault(),
+        reth.address
+      )
+
+      // Check initial state
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.SOUND)
+      expect(await newRethCollateral.whenDefault()).to.equal(MAX_UINT256)
+
+      // Depeg one of the underlying tokens - Reducing price 20%
+      await setOraclePrice(newRethCollateral.address, bn('8e7')) // -20%
+
+      // Force updates - Should update whenDefault and status
+      await expect(newRethCollateral.refresh())
+        .to.emit(newRethCollateral, 'CollateralStatusChanged')
+        .withArgs(CollateralStatus.SOUND, CollateralStatus.IFFY)
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.IFFY)
+
+      const expectedDefaultTimestamp: BigNumber = bn(await getLatestBlockTimestamp()).add(
+        delayUntilDefault
+      )
+      expect(await newRethCollateral.whenDefault()).to.equal(expectedDefaultTimestamp)
+
+      // Move time forward past delayUntilDefault
+      await advanceTime(Number(delayUntilDefault))
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.DISABLED)
+
+      // Nothing changes if attempt to refresh after default
+      // CToken
+      const prevWhenDefault: BigNumber = await newRethCollateral.whenDefault()
+      await expect(newRethCollateral.refresh()).to.not.emit(
+        newRethCollateral,
+        'CollateralStatusChanged'
+      )
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.DISABLED)
+      expect(await newRethCollateral.whenDefault()).to.equal(prevWhenDefault)
+    })
+
+    // Test for hard default
+    it('Updates status in case of hard default', async () => {
+      // Note: In this case requires to use a CToken mock to be able to change the rate
+
+      // Redeploy plugin using the new cDai mock
+      const newRethCollateral: RETHCollateral = <RETHCollateral>await (
+        await ethers.getContractFactory('RETHCollateral', {
+          // libraries: { OracleLib: oracleLib.address },
+        })
+      ).deploy(
+        fp('0.02'),
+        await rethCollateral.chainlinkFeed(),
+        reth.address,
+        await rethCollateral.maxTradeVolume(),
+        await rethCollateral.oracleTimeout(),
+        await rethCollateral.targetName(),
+        await rethCollateral.defaultThreshold(),
+        await rethCollateral.delayUntilDefault(),
+        reth.address
+      )
+
+      // Check initial state
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.SOUND)
+      expect(await newRethCollateral.whenDefault()).to.equal(MAX_UINT256)
+
+      // Force updates - Should update whenDefault and status for Atokens/CTokens
+      await expect(newRethCollateral.refresh())
+        .to.emit(newRethCollateral, 'CollateralStatusChanged')
+        .withArgs(CollateralStatus.SOUND, CollateralStatus.DISABLED)
+
+      expect(await newRethCollateral.status()).to.equal(CollateralStatus.DISABLED)
+      const expectedDefaultTimestamp: BigNumber = bn(await getLatestBlockTimestamp())
+      expect(await newRethCollateral.whenDefault()).to.equal(expectedDefaultTimestamp)
+    })
+
+    it('Reverts if oracle reverts or runs out of gas, maintains status', async () => {
+      const InvalidMockV3AggregatorFactory = await ethers.getContractFactory(
+        'InvalidMockV3Aggregator'
+      )
+      const invalidChainlinkFeed: InvalidMockV3Aggregator = <InvalidMockV3Aggregator>(
+        await InvalidMockV3AggregatorFactory.deploy(8, bn('1e8'))
+      )
+
+      const invalidCTokenCollateral: CTokenFiatCollateral = <CTokenFiatCollateral>(
+        await RETHCollateralFactory.deploy(
+          fp('0.02'),
+          invalidChainlinkFeed.address,
+          await rethCollateral.erc20(),
+          await rethCollateral.maxTradeVolume(),
+          await rethCollateral.oracleTimeout(),
+          await rethCollateral.targetName(),
+          await rethCollateral.defaultThreshold(),
+          await rethCollateral.delayUntilDefault(),
+          reth.address
+        )
+      )
+
+      // Reverting with no reason
+      await invalidChainlinkFeed.setSimplyRevert(true)
+      await expect(invalidCTokenCollateral.refresh()).to.be.revertedWith('')
+      expect(await invalidCTokenCollateral.status()).to.equal(CollateralStatus.SOUND)
+
+      // Runnning out of gas (same error)
+      await invalidChainlinkFeed.setSimplyRevert(false)
+      await expect(invalidCTokenCollateral.refresh()).to.be.revertedWith('')
+      expect(await invalidCTokenCollateral.status()).to.equal(CollateralStatus.SOUND)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -414,6 +414,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@defi-wonderland/smock@npm:^2.3.4":
+  version: 2.3.4
+  resolution: "@defi-wonderland/smock@npm:2.3.4"
+  dependencies:
+    "@nomicfoundation/ethereumjs-evm": ^1.0.0-rc.3
+    "@nomicfoundation/ethereumjs-util": ^8.0.0-rc.3
+    "@nomicfoundation/ethereumjs-vm": ^6.0.0-rc.3
+    diff: ^5.0.0
+    lodash.isequal: ^4.5.0
+    lodash.isequalwith: ^4.4.0
+    rxjs: ^7.2.0
+    semver: ^7.3.5
+  peerDependencies:
+    "@ethersproject/abi": ^5
+    "@ethersproject/abstract-provider": ^5
+    "@ethersproject/abstract-signer": ^5
+    "@nomiclabs/hardhat-ethers": ^2
+    ethers: ^5
+    hardhat: ^2
+  checksum: 316026d672364a02c5d83c15110b2d5df4358768a6f645e9fd0786fbb230c0c7983a39b928521ee7d0b917a478e07c454b7d7bdf22ff10ed140f520340c28267
+  languageName: node
+  linkType: hard
+
 "@ensdomains/ens@npm:^0.4.4":
   version: 0.4.5
   resolution: "@ensdomains/ens@npm:0.4.5"
@@ -1452,7 +1475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/ethereumjs-evm@npm:^1.0.0":
+"@nomicfoundation/ethereumjs-evm@npm:^1.0.0, @nomicfoundation/ethereumjs-evm@npm:^1.0.0-rc.3":
   version: 1.0.0
   resolution: "@nomicfoundation/ethereumjs-evm@npm:1.0.0"
   dependencies:
@@ -1516,7 +1539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/ethereumjs-util@npm:^8.0.0":
+"@nomicfoundation/ethereumjs-util@npm:^8.0.0, @nomicfoundation/ethereumjs-util@npm:^8.0.0-rc.3":
   version: 8.0.0
   resolution: "@nomicfoundation/ethereumjs-util@npm:8.0.0"
   dependencies:
@@ -1526,7 +1549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/ethereumjs-vm@npm:^6.0.0":
+"@nomicfoundation/ethereumjs-vm@npm:^6.0.0, @nomicfoundation/ethereumjs-vm@npm:^6.0.0-rc.3":
   version: 6.0.0
   resolution: "@nomicfoundation/ethereumjs-vm@npm:6.0.0"
   dependencies:
@@ -5458,6 +5481,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "diff@npm:5.1.0"
+  checksum: c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90
   languageName: node
   linkType: hard
 
@@ -9887,6 +9917,20 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: da27515dc5230eb1140ba65ff8de3613649620e8656b19a6270afe4866b7bd461d9ba2ac8a48dcc57f7adac4ee80e1de9f965d89d4d81a0ad52bb3eec2609644
+  languageName: node
+  linkType: hard
+
+"lodash.isequalwith@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "lodash.isequalwith@npm:4.4.0"
+  checksum: 428ba7a57c47ec05e2dd18c03a4b4c45dac524a46af7ce3f412594bfc7be6a5acaa51acf9ea113d0002598e9aafc6e19ee8d20bc28363145fcb4d21808c9039f
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -12397,6 +12441,7 @@ fsevents@~2.1.1:
   dependencies:
     "@aave/protocol-v2": ^1.0.1
     "@chainlink/contracts": ^0.4.1
+    "@defi-wonderland/smock": ^2.3.4
     "@nomicfoundation/hardhat-chai-matchers": ^1.0.3
     "@nomiclabs/hardhat-ethers": ^2.0.3
     "@nomiclabs/hardhat-etherscan": ^3.1.0
@@ -12678,6 +12723,15 @@ resolve@1.17.0:
   dependencies:
     tslib: ^1.9.0
   checksum: bc334edef1bb8bbf56590b0b25734ba0deaf8825b703256a93714308ea36dff8a11d25533671adf8e104e5e8f256aa6fdfe39b2e248cdbd7a5f90c260acbbd1b
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.2.0":
+  version: 7.6.0
+  resolution: "rxjs@npm:7.6.0"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: b3abbbfe1ddfd06fca9314b83cbd13bcddc3320429218136f75c79a4802ac430dd13873364aac1ded54fd457f8c77df332d205a92d8a1c61656565bb718c50af
   languageName: node
   linkType: hard
 
@@ -14167,6 +14221,13 @@ resolve@1.17.0:
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0":
+  version: 2.4.1
+  resolution: "tslib@npm:2.4.1"
+  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# rETH Collateral Plugin - Hackathon Submission
### Author: [shalzz](https://github.com/shalzz) 
Twitter: https://twitter.com/shalzzj
Telegram: https://t.me/shalzzj
Discord: shalzz#5282

Fixes #415

## Overview
This plugin provides for using rETH token as a collateral plugin using 
[revenue hiding][1] for smoothing for short dips in total ETH balance of the rocket pool
network.

## Units

| **Units**       | `tok`      | `ref`                                                   | `target` | `UoA` |
|-----------------|------------|---------------------------------------------------------|----------|-------|
| **Description** | rETH | ETH  | ETH | USD   |

## Defaulting Conditions

The rETH collateral can default in scenarios where there's a large number of
rocketpool validators that are slashed and the RPL token collateral is unable
to act as a sufficient backstop to prevent the exchange rate from decreasing.

In situations where there's a few small rocketpool validators that are slashed, revenue
hiding bring stability over these small fluctuations.

### Hard default:

- $\text{actualRefPerTok}  \lt \text{refPerTok} $

Where refPerTok is:
- $\frac{\text{refPerTok} * \text{marginRatio}}{10000} $

## Deployment

Deploy [RETHCollateral.sol](./RETHCollateral.sol) with construct args: 

```
uint192 fallbackPrice_,  // fallback price
AggregatorV3Interface refUnitUSDChainlinkFeed_, // {uoa/ref} chainlink feed, mostly USD/ETH
IERC20Metadata erc20_, // address of the rETH token - 0xae78736Cd615f374D3085123A210448E74Fc6393
uint192 maxTradeVolume_, // max trade volume - default
uint48 oracleTimeout_, // oracle price request timeout - default
bytes32 targetName_, // ETH
uint16 _allowedDropBasisPoints, // Basis point out of 10000 that is used to discount refPerTok
uint256 delayUntilDefault_ // decimals of underlying token - default
```

## Testing
The unit and integrations tests are implemented in
[RETHCollateral.test.ts](../../../test/integration/individual-collateral/RETHCollateral.test.ts) at 
`test/integration/individual-collateral/RETHCollateral.test.ts`
and can run with the default blocknumber `14916729`

[1]: https://github.com/reserve-protocol/protocol/blob/master/docs/collateral.md#revenue-hiding
