### PR TITLE
Recollateralization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,21 +112,19 @@ Finally, inside particular testing, it's quite useful to distinguish unit tests 
 
 Target: Full branch coverage, and testing of any semantically-relevant situations
 
-Status as of 2022-05-27: These are essentially complete, and provide near-complete coverage of our system.
-
 ### End-to-End Tests
 
 - Driven by `hardhat test`
 - Uses mainnet forking
-- Checks that the `p1` protocol works as expected when deployed
-- Tests all needed contracts, contract deployment, any migrations, etc.
+- Can run the same tests against both p0 and p1
+- Tests all needed plugin contracts, contract deployment, any migrations, etc.
 - Mock out as little as possible; use instances of real contracts
 
 Target: Each integration we plan to deploy behaves correctly under all actually-anticipated scenarios.
 
-Status as of 2022-05-27: We have initial drafts of a few of these.
-
 ### Property Testing
+
+Located in `fuzz` branch only.
 
 - Driven by Echidna
 - Asserts that contract invariants and functional properties of contract implementations hold for many executions
@@ -134,20 +132,18 @@ Status as of 2022-05-27: We have initial drafts of a few of these.
 
 Target: The handful of our most depended-upon system properties and invariants are articulated and thoroughly fuzz-tested. Examples of such properties include:
 
-- Unless the basket is switched (due to token default or governance) the protocol always remains fully-capitalized.
+- Unless the basket is switched (due to token default or governance) the protocol always remains fully-collateralized.
 - Unless the protocol is paused, RToken holders can always redeem
 - If the protocol is paused, and governance does not act further, the protocol will later become unpaused.
 
-Status as of 2022-05-27: We've gotten some simple proofs-of-concept to run, but they aren't well-integrated into our testing flow and they're certainly incomplete.
-
 ### Differential Testing
+
+Located in `fuzz` branch only.
 
 - Driven by Echidna
 - Asserts that the behavior of each p1 contract matches that of p0
 
-Target: Intensivve equivalence testing, run continuously for days or weeks, sensitive to any difference between observable behaviors of p0 and p1.
-
-Status as of 2022-05-27: Beyond proof-of-concept work with Echidna, we haven't begun this (beyond actually having p0 and p1 implementations).
+Target: Intensive equivalence testing, run continuously for days or weeks, sensitive to any difference between observable behaviors of p0 and p1.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -150,3 +150,7 @@ Target: Intensive equivalence testing, run continuously for days or weeks, sensi
 If you would like to contribute, you'll need to configure a secret in your fork repo in order for our integration tests to pass in CI. The name of the secret should `ALCHEMY_MAINNET_KEY` and it should be equal to the suffix portion of the full URL.
 
 Usage: `https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_MAINNET_KEY }}`
+
+## External Documentation
+
+[Video overview](https://youtu.be/341MhkOWsJE)

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -268,7 +268,7 @@ contract FacadeRead is IFacadeRead {
         {
             IERC20[] memory erc20s = assetRegistry.erc20s();
 
-            // Bound each withdrawal by the prorata share, in case we're currently under-collateralized
+            // Bound each withdrawal by the prorata share, in case under-collateralized
             uint192 uoaHeld;
             for (uint256 i = 0; i < erc20s.length; i++) {
                 if (erc20s[i] == rsr) continue;

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -268,7 +268,7 @@ contract FacadeRead is IFacadeRead {
         {
             IERC20[] memory erc20s = assetRegistry.erc20s();
 
-            // Bound each withdrawal by the prorata share, in case we're currently under-capitalized
+            // Bound each withdrawal by the prorata share, in case we're currently under-collateralized
             uint192 uoaHeld;
             for (uint256 i = 0; i < erc20s.length; i++) {
                 if (erc20s[i] == rsr) continue;

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -9,7 +9,7 @@ import "./ITrading.sol";
  * @title IBackingManager
  * @notice The BackingManager handles changes in the ERC20 balances that back an RToken.
  *   - It computes which trades to perform, if any, and initiates these trades with the Broker.
- *   - If already capitalized, excess assets are transferred to RevenueTraders.
+ *   - If already collateralized, excess assets are transferred to RevenueTraders.
  *
  * `manageTokens(erc20s)` and `manageTokensSortedOrder(erc20s)` are handles for getting at the
  *   same underlying functionality. The former allows an ERC20 list in any order, while the

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -93,7 +93,7 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
              *
              * ======
              *
-             * If we run out of capital and are still undercapitalized, we compromise
+             * If we run out of capital and are still undercollateralized, we compromise
              * rToken.basketsNeeded to the current basket holdings. Haircut time.
              */
 

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -346,7 +346,7 @@ contract RTokenP0 is ComponentP0, RewardableP0, ERC20PermitUpgradeable, IRToken 
         IBackingManager backingMgr = main.backingManager();
 
         bool allZero = true;
-        // Bound each withdrawal by the prorata share, in case we're currently under-capitalized
+        // Bound each withdrawal by the prorata share, in case we're currently under-collateralized
         for (uint256 i = 0; i < erc20s.length; i++) {
             uint256 bal = IERC20Upgradeable(erc20s[i]).balanceOf(address(backingMgr)); // {qTok}
 

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -194,7 +194,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         main.poke();
 
         IBasketHandler bh = main.basketHandler();
-        require(bh.fullyCollateralized(), "RToken uncapitalized");
+        require(bh.fullyCollateralized(), "RToken uncollateralized");
         require(bh.status() == CollateralStatus.SOUND, "basket defaulted");
 
         Withdrawal[] storage queue = withdrawals[account];

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -154,7 +154,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     function handoutExcessAssets(IERC20[] calldata erc20s) private {
         /**
          * Assumptions:
-         *   - Fully collateralized. All collateral, and therefore assets, meet balance requirements.
+         *   - Fully collateralized. All collateral meet balance requirements.
          *   - All backing capital is held at BackingManager's address. No capital is out on-trade
          *   - Neither RToken nor RSR are in the basket
          *   - Each address in erc20s is unique

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -117,16 +117,17 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
             // == Interaction (then return) ==
             handoutExcessAssets(erc20s);
         } else {
-            /* Recollateralization
+            /*
+             * Recollateralization
              *
-             * Strategy: iteratively move the system on a forgiving path towards capitalization
+             * Strategy: iteratively move the system on a forgiving path towards collateralization
              * through a narrowing BU price band. The initial large spread reflects the
              * uncertainty associated with the market price of defaulted/volatile collateral, as
              * well as potential losses due to trading slippage. In the absence of further
              * collateral default, the size of the BU price band should decrease with each trade
-             * until it is 0, at which point capitalization is restored.
+             * until it is 0, at which point collateralization is restored.
              *
-             * If we run out of capital and are still undercapitalized, we compromise
+             * If we run out of capital and are still undercollateralized, we compromise
              * rToken.basketsNeeded to the current basket holdings. Haircut time.
              */
 
@@ -153,7 +154,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     function handoutExcessAssets(IERC20[] calldata erc20s) private {
         /**
          * Assumptions:
-         *   - Fully capitalized. All collateral, and therefore assets, meet balance requirements.
+         *   - Fully collateralized. All collateral, and therefore assets, meet balance requirements.
          *   - All backing capital is held at BackingManager's address. No capital is out on-trade
          *   - Neither RToken nor RSR are in the basket
          *   - Each address in erc20s is unique
@@ -206,7 +207,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         }
 
         // At this point, even though basketsNeeded may have changed:
-        // - We're fully capitalized
+        // - We're fully collateralized
         // - The BU exchange rate {BU/rTok} did not decrease
 
         // Keep a small buffer of individual collateral; "excess" assets are beyond the buffer.

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -474,7 +474,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
         // downcast is safe: amount <= balanceOf(redeemer) <= totalSupply(), so prorate < 1e18
         uint192 prorate = uint192((FIX_ONE_256 * amount) / supply);
 
-        // Bound each withdrawal by the prorata share, in case we're currently under-capitalized
+        // Bound each withdrawal by the prorata share, in case we're currently under-collateralized
         for (uint256 i = 0; i < erc20length; ++i) {
             // {qTok}
             uint256 bal = IERC20Upgradeable(erc20s[i]).balanceOf(address(backingManager));

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -302,7 +302,7 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
         assetRegistry.refresh();
 
         // == Checks + Effects ==
-        require(basketHandler.fullyCollateralized(), "RToken uncapitalized");
+        require(basketHandler.fullyCollateralized(), "RToken uncollateralized");
         require(basketHandler.status() == CollateralStatus.SOUND, "basket defaulted");
 
         uint256 firstId = firstRemainingDraft[draftEra][account];

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -60,24 +60,19 @@ hash -r && slither --version
 - Report compiled contract sizes: `yarn size`
 - There are many available test sets. A few of the most useful are:
   - Run only fast tests: `yarn test:fast`
-  - Run most tests: `yarn test`
-  - Run all tests (very slow!): `yarn test:exhaustive`
+  - Run P0 tests: `yarn test:p0`
+  - Run P1 tests: `yarn test:p1`
+  - Run plugin tests: `yarn test:plugins`
+  - Run integration tests: `yarn test:integration`
   - Run tests and report test coverage: `yarn test:coverage`
-- Lint Solidity code: `yarn lint`
-- Lint Typescript code: `yarn eslint`
+- Lint Solidity + Typescript code: `yarn lint`
 - Run the Slither static checker: `yarn slither`
 - Run a local mainnet fork devchain: `yarn devchain`
-- Deploy our system to your local evm devchain: `yarn deploy:run --network localhost`
+- Deploy to devchain: `yarn deploy:run --network localhost`
 
 ## Mainnet Forking
 
-The tests located in `test/integration` will require the Mainnet Forking setup in place. This is done by setting the `MAINNET_RPC_URL` variable in your local `.env`. An Alchemy node is recommended for Mainnet Forking to properly work. Additional information can be found [here](https://hardhat.org/hardhat-network/guides/mainnet-forking.html).
-
-For running scripts and tasks using Mainnet Forking a `FORK` environment variable can be defined. For example to run a local node using Mainnet forking you can run:
-
-```bash
-yarn devchain
-```
+The tests located in `test/integration` will require the Mainnet Forking setup in place. This is done by setting the `MAINNET_RPC_URL` variable in your local `.env`. An Alchemy or Ankr node (something with archive data) is needed for Mainnet Forking to properly work. Additional information can be found [here](https://hardhat.org/hardhat-network/guides/mainnet-forking.html).
 
 ## Pre-push Validation
 
@@ -89,7 +84,7 @@ However, ensure that you do not change the value of `.husky/pre-push` in our sha
 
 ## Echidna
 
-We _have_ some tooling for testing with Echidna, but it is immature, out-of-date, and shouldn't be expected to work out-of-the-box. Still, there is some useful, tested support for working with Echidna, see our [echidna usage docs](using-echidna.md)
+We _have_ some tooling for testing with Echidna, but it is specically in `fuzz` branch of the repo. See that branch and our [echidna usage docs](using-echidna.md)
 
 ## Test Deployment
 

--- a/test/FacadeRead.test.ts
+++ b/test/FacadeRead.test.ts
@@ -138,7 +138,7 @@ describe('FacadeRead contract', () => {
     it('Should return backingOverview correctly', async () => {
       let [backing, overCollateralization] = await facade.callStatic.backingOverview(rToken.address)
 
-      // Check values - Fully capitalized and no over-collateralization
+      // Check values - Fully collateralized and no over-collateralization
       expect(backing).to.be.closeTo(fp('1'), 10)
       expect(overCollateralization).to.equal(0)
 
@@ -151,7 +151,7 @@ describe('FacadeRead contract', () => {
       await stRSR.connect(addr1).stake(stakeAmount)
       ;[backing, overCollateralization] = await facade.callStatic.backingOverview(rToken.address)
 
-      // Check values - Fully capitalized and fully over-collateralized
+      // Check values - Fully collateralized and fully over-collateralized
       expect(backing).to.be.closeTo(fp('1'), 10)
       expect(overCollateralization).to.be.closeTo(fp('0.5'), 10)
 
@@ -181,7 +181,7 @@ describe('FacadeRead contract', () => {
         rToken.address
       )
 
-      // Check values - Fully capitalized and no over-collateralization
+      // Check values - Fully collateralized and no over-collateralization
       expect(backing).to.be.closeTo(fp('1'), 10)
       expect(overCollateralization).to.equal(0)
     })
@@ -199,7 +199,7 @@ describe('FacadeRead contract', () => {
         rToken.address
       )
 
-      // Check values - Fully capitalized and no over-collateralization
+      // Check values - Fully collateralized and no over-collateralization
       expect(backing).to.be.closeTo(fp('1'), 10)
       expect(overCollateralization).to.equal(fp('0.5'))
 
@@ -210,7 +210,7 @@ describe('FacadeRead contract', () => {
         rToken.address
       )
 
-      // Check values - Fully capitalized and no over-collateralization
+      // Check values - Fully collateralized and no over-collateralization
       expect(backing2).to.be.closeTo(fp('1'), 10)
       expect(overCollateralization2).to.equal(0)
     })

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -525,7 +525,7 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           .to.emit(basketHandler, 'BasketSet')
           .withArgs(1, [], [], true)
 
-        // Check state - Basket is disabled even though fully capitalized
+        // Check state - Basket is disabled even though fully collateralized
         expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
 

--- a/test/ZTradingExtremes.test.ts
+++ b/test/ZTradingExtremes.test.ts
@@ -534,13 +534,13 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
 
   context('Recovery from default', function () {
     const runRecollateralizationAuctions = async (basketSize: number) => {
-      let uncapitalized = true
+      let uncollateralized = true
       const basketsNeeded = await rToken.basketsNeeded()
 
       // Run recap auctions
       const erc20s = await assetRegistry.erc20s()
 
-      for (let i = 0; i < basketSize + 1 && uncapitalized; i++) {
+      for (let i = 0; i < basketSize + 1 && uncollateralized; i++) {
         // Close any open auctions and launch new ones
         await facadeTest.runAuctionsForAllTraders(rToken.address)
 
@@ -567,13 +567,13 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
 
         // Advance time till auction ends
         await advanceTime(config.auctionLength.add(100).toString())
-        uncapitalized = !(await basketHandler.fullyCollateralized())
+        uncollateralized = !(await basketHandler.fullyCollateralized())
       }
 
       // Should not have taken a haircut
       expect((await rToken.basketsNeeded()).gte(basketsNeeded)).to.equal(true)
 
-      // Should be capitalized or still capitalizing
+      // Should be collateralized or still capitalizing
       expect(
         (await basketHandler.fullyCollateralized()) || Boolean(await backingManager.tradesOpen())
       ).to.equal(true)
@@ -586,7 +586,7 @@ describe(`Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, () => {
     // Switch basket to remaining good collateral, if any.
     // Run non-RSR auctions to completion.
     // Seize RSR and use for remainder.
-    // Assert capitalized.
+    // Assert collateralized.
     //
     // DIMENSIONS
     //

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -676,8 +676,8 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
         expect(await stRSR.balanceOf(addr1.address)).to.equal(0)
       })
 
-      it('Should not complete withdrawal if not fully capitalized', async () => {
-        // Need to issue some RTokens to handle fully/not fully capitalized
+      it('Should not complete withdrawal if not fully collateralized', async () => {
+        // Need to issue some RTokens to handle fully/not fully collateralized
         await token0.connect(owner).mint(addr1.address, initialBal)
         await token1.connect(owner).mint(addr1.address, initialBal)
         await token2.connect(owner).mint(addr1.address, initialBal)
@@ -701,17 +701,17 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
         const erc20s = await facade.basketTokens(rToken.address)
 
-        // Set not fully capitalized by changing basket
+        // Set not fully collateralized by changing basket
         await basketHandler.connect(owner).setPrimeBasket([token0.address], [fp('1')])
         await basketHandler.connect(owner).refreshBasket()
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
 
         // Withdraw
         await expect(stRSR.connect(addr1).withdraw(addr1.address, 1)).to.be.revertedWith(
-          'RToken uncapitalized'
+          'RToken uncollateralized'
         )
 
-        // If fully capitalized should withdraw OK  - Set back original basket
+        // If fully collateralized should withdraw OK  - Set back original basket
         await basketHandler.connect(owner).setPrimeBasket(erc20s, basketsNeededAmts)
         await basketHandler.connect(owner).refreshBasket()
 

--- a/test/integration/EasyAuction.test.ts
+++ b/test/integration/EasyAuction.test.ts
@@ -274,7 +274,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
         },
       ])
 
-      // Check state - Should be undercapitalized
+      // Check state - Should be undercollateralized
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt.sub(1))
@@ -333,7 +333,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
         },
       ])
 
-      // Check state - Should be undercapitalized
+      // Check state - Should be undercollateralized
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt)
@@ -363,7 +363,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
         },
       ])
 
-      // Check state - Should be undercapitalized
+      // Check state - Should be undercollateralized
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await token0.balanceOf(backingManager.address)).to.equal(bidAmt)

--- a/test/scenario/BadCollateralPlugin.test.ts
+++ b/test/scenario/BadCollateralPlugin.test.ts
@@ -262,7 +262,7 @@ describe(`Bad Collateral Plugin - P${IMPLEMENTATION}`, () => {
       expect(await rToken.balanceOf(addr1.address)).to.equal(initialBal)
     })
 
-    it('should not be undercapitalized from its perspective', async () => {
+    it('should not be undercollateralized from its perspective', async () => {
       await setOraclePrice(collateral0.address, bn('0.5e8')) // 50% decrease, would normally trigger soft default
       await assetRegistry.refresh()
       expect(await collateral0.status()).to.equal(CollateralStatus.SOUND)

--- a/test/scenario/EURT.test.ts
+++ b/test/scenario/EURT.test.ts
@@ -206,7 +206,7 @@ describe(`EUR fiatcoins (eg EURT) - P${IMPLEMENTATION}`, () => {
       await targetUnitOracle.updateAnswer(bn('0.25e8'))
       await assetRegistry.refresh()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)
@@ -216,7 +216,7 @@ describe(`EUR fiatcoins (eg EURT) - P${IMPLEMENTATION}`, () => {
       await assetRegistry.connect(owner).unregister(eurtCollateral.address)
       await basketHandler.refreshBasket()
 
-      // Should be in an undercapitalized state but SOUND
+      // Should be in an undercollateralized state but SOUND
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
     })

--- a/test/scenario/WBTC.test.ts
+++ b/test/scenario/WBTC.test.ts
@@ -237,7 +237,7 @@ describe(`Non-fiat collateral (eg WBTC) - P${IMPLEMENTATION}`, () => {
       await targetUnitOracle.updateAnswer(bn('10000e8'))
       await assetRegistry.refresh()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)
@@ -247,7 +247,7 @@ describe(`Non-fiat collateral (eg WBTC) - P${IMPLEMENTATION}`, () => {
       await assetRegistry.connect(owner).unregister(wbtcCollateral.address)
       await basketHandler.refreshBasket()
 
-      // Should be in an undercapitalized state but SOUND
+      // Should be in an undercollateralized state but SOUND
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
     })

--- a/test/scenario/WETH.test.ts
+++ b/test/scenario/WETH.test.ts
@@ -225,7 +225,7 @@ describe(`Self-referential collateral (eg ETH via WETH) - P${IMPLEMENTATION}`, (
       await setOraclePrice(wethCollateral.address, bn('0.5e8')) // halving of price
       await assetRegistry.refresh()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)
@@ -243,7 +243,7 @@ describe(`Self-referential collateral (eg ETH via WETH) - P${IMPLEMENTATION}`, (
       await basketHandler.connect(owner).setPrimeBasket([token0.address], [fp('1')])
       await basketHandler.refreshBasket()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)

--- a/test/scenario/cETH.test.ts
+++ b/test/scenario/cETH.test.ts
@@ -284,7 +284,7 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
       await setOraclePrice(wethCollateral.address, bn('0.5e8')) // doubling of price
       await assetRegistry.refresh()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)
@@ -294,7 +294,7 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
       await assetRegistry.connect(owner).unregister(cETHCollateral.address)
       await basketHandler.refreshBasket()
 
-      // Should be in an undercapitalized state but SOUND
+      // Should be in an undercollateralized state but SOUND
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
     })
@@ -309,7 +309,7 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
       expect(tokens[0]).to.equal(token0.address)
       expect(tokens[1]).to.equal(weth.address)
 
-      // Should not be fully capitalized
+      // Should not be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(0)

--- a/test/scenario/cWBTC.test.ts
+++ b/test/scenario/cWBTC.test.ts
@@ -310,7 +310,7 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
       await targetUnitOracle.updateAnswer(bn('10000e8'))
       await assetRegistry.refresh()
 
-      // Should be fully capitalized
+      // Should be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(true)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(issueAmt)
@@ -320,7 +320,7 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
       await assetRegistry.connect(owner).unregister(cWBTCCollateral.address)
       await basketHandler.refreshBasket()
 
-      // Should be in an undercapitalized state but SOUND
+      // Should be in an undercollateralized state but SOUND
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
     })
@@ -335,7 +335,7 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
       expect(tokens[0]).to.equal(token0.address)
       expect(tokens[1]).to.equal(wbtc.address)
 
-      // Should not be fully capitalized
+      // Should not be fully collateralized
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.basketsHeldBy(backingManager.address)).to.equal(0)

--- a/test/utils/oracles.ts
+++ b/test/utils/oracles.ts
@@ -32,7 +32,7 @@ export const expectPrice = async (
 }
 
 // Expects a price around `avgPrice` assuming a consistent percentage oracle error
-// If the RToken is fully capitalized, there's no need to provide maxTradeSlippage/dustLoss
+// If the RToken is fully collateralized, there's no need to provide maxTradeSlippage/dustLoss
 // If maxTradeSlippage is truthy, applies a % reduction to the expected lower price
 // If dustLoss is additionally truthy, applies a nominal reduction to the expected lower price
 export const expectRTokenPrice = async (


### PR DESCRIPTION
This is mainly just the new `docs/recollateralization.md` file, but I took the opportunity to make sure we properly use `*collateralization` instead of `*capitalization` everywhere, as well as fine tune some other docs a teensy bit. 

...and with that, I am officially on vacation!