### PR TITLE
Gas snapshots

### DIFF
--- a/contracts/p1/Furnace.sol
+++ b/contracts/p1/Furnace.sol
@@ -21,8 +21,8 @@ contract FurnaceP1 is ComponentP1, IFurnace {
     uint192 public ratio; // {1} What fraction of balance to melt each period
 
     // === Cached ===
-    uint256 public lastPayoutBal; // {qRTok} The balance of RToken at the last payout
     uint48 public lastPayout; // {seconds} The last time we did a payout
+    uint256 public lastPayoutBal; // {qRTok} The balance of RToken at the last payout
 
     // ==== Invariants ====
     // ratio <= MAX_RATIO = 1e18
@@ -83,7 +83,7 @@ contract FurnaceP1 is ComponentP1, IFurnace {
     /// @custom:governance
     function setRatio(uint192 ratio_) public governance {
         // solhint-disable-next-line no-empty-blocks
-        try this.melt() {} catch {}
+        if (lastPayout > 0) try this.melt() {} catch {}
         require(ratio_ <= MAX_RATIO, "invalid ratio");
         // The ratio can safely be set to 0 to turn off payouts, though it is not recommended
         emit RatioSet(ratio, ratio_);

--- a/test/Furnace.test.ts
+++ b/test/Furnace.test.ts
@@ -539,8 +539,9 @@ describe(`FurnaceP${IMPLEMENTATION} contract`, () => {
       expect(await rToken.balanceOf(furnace.address)).to.equal(expAmt)
     })
 
-    it('Melt - Many periods, all at once', async () => {
+    it('Melt - A million periods, all at once', async () => {
       const hndAmt: BigNumber = bn('10e18')
+      const numPeriods = bn('1e6')
 
       // Transfer
       await rToken.connect(addr1).transfer(furnace.address, hndAmt)
@@ -550,10 +551,12 @@ describe(`FurnaceP${IMPLEMENTATION} contract`, () => {
 
       await snapshotGasCost(furnace.connect(addr1).melt())
       // Advance to the end to melt full amount
-      await setNextBlockTimestamp(Number(await getLatestBlockTimestamp()) + 10 * Number(ONE_PERIOD))
+      await setNextBlockTimestamp(
+        Number(await getLatestBlockTimestamp()) + Number(ONE_PERIOD.mul(numPeriods))
+      )
 
       const decayFn = makeDecayFn(await furnace.ratio())
-      const expAmt = decayFn(hndAmt, 10) // 10 periods
+      const expAmt = decayFn(hndAmt, Number(numPeriods)) // 10 periods
 
       await snapshotGasCost(furnace.connect(addr1).melt())
 

--- a/test/__snapshots__/Broker.test.ts.snap
+++ b/test/__snapshots__/Broker.test.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrokerP1 contract #fast Gas Reporting Initialize Trade  1`] = `452739`;
+exports[`BrokerP1 contract #fast Gas Reporting Initialize Trade  1`] = `452693`;
 
-exports[`BrokerP1 contract #fast Gas Reporting Open Trade  1`] = `553598`;
+exports[`BrokerP1 contract #fast Gas Reporting Open Trade  1`] = `553529`;
 
-exports[`BrokerP1 contract #fast Gas Reporting Open Trade  2`] = `541436`;
+exports[`BrokerP1 contract #fast Gas Reporting Open Trade  2`] = `541367`;
 
-exports[`BrokerP1 contract #fast Gas Reporting Open Trade  3`] = `543574`;
+exports[`BrokerP1 contract #fast Gas Reporting Open Trade  3`] = `543505`;
 
 exports[`BrokerP1 contract #fast Gas Reporting Settle Trade  1`] = `113592`;

--- a/test/__snapshots__/FacadeAct.test.ts.snap
+++ b/test/__snapshots__/FacadeAct.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FacadeAct contract Gas Reporting getActCalldata - gas reporting for 128 registered assets 1`] = `20520536`;
+exports[`FacadeAct contract Gas Reporting getActCalldata - gas reporting for 128 registered assets 1`] = `19349910`;

--- a/test/__snapshots__/FacadeWrite.test.ts.snap
+++ b/test/__snapshots__/FacadeWrite.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `8754465`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `8854764`;
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Deploy governance 1`] = `5671949`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Deploy governance 1`] = `5671971`;
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Without governance 1`] = `334228`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Without governance 1`] = `334250`;

--- a/test/__snapshots__/Furnace.test.ts.snap
+++ b/test/__snapshots__/Furnace.test.ts.snap
@@ -1,35 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, all at once 1`] = `81334`;
+exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 1`] = `86174`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, all at once 2`] = `85833`;
+exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 2`] = `96515`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 1`] = `81334`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 1`] = `86174`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  1`] = `43192`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  1`] = `66274`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  2`] = `81334`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  2`] = `82933`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `83393`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `85131`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  4`] = `43192`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  4`] = `41088`;

--- a/test/__snapshots__/Main.test.ts.snap
+++ b/test/__snapshots__/Main.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Refresh 1`] = `294661`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Refresh 1`] = `296808`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 1`] = `133871`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 1`] = `194268`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 2`] = `133871`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 2`] = `194256`;

--- a/test/__snapshots__/RToken.test.ts.snap
+++ b/test/__snapshots__/RToken.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `815215`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `765677`;
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `625048`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `589639`;
 
-exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `581688`;
+exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `524010`;
 
 exports[`RTokenP1 contract Gas Reporting Transfer 1`] = `56564`;
 

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -2,16 +2,16 @@
 
 exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `63844`;
 
-exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1922005`;
+exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1736932`;
 
-exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `388004`;
+exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `396642`;
 
 exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `186068`;
 
-exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `1902760`;
+exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `1707540`;
 
 exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `186086`;
 
-exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `1973900`;
+exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 7`] = `1781230`;
 
 exports[`Recollateralization - P1 Gas Reporting Settle Trades / Manage Funds 8`] = `214212`;

--- a/test/__snapshots__/Revenues.test.ts.snap
+++ b/test/__snapshots__/Revenues.test.ts.snap
@@ -1,34 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 1`] = `174585`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 1`] = `171339`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 2`] = `174527`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 2`] = `171209`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 3`] = `174527`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 3`] = `171209`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 4`] = `173258`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 4`] = `252788`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 5`] = `144958`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 5`] = `218458`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 6`] = `256034`;
+exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 6`] = `218458`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 7`] = `221776`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `727877`;
 
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 8`] = `221776`;
-
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 9`] = `220507`;
-
-exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 10`] = `163219`;
-
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `727878`;
-
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `956029`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `950384`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `244827`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `197050`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `196954`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `710778`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `710777`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `47140`;
 

--- a/test/__snapshots__/ZZStRSR.test.ts.snap
+++ b/test/__snapshots__/ZZStRSR.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StRSRP1 contract Gas Reporting Stake 1`] = `154453`;
+exports[`StRSRP1 contract Gas Reporting Stake 1`] = `152102`;
 
-exports[`StRSRP1 contract Gas Reporting Stake 2`] = `149653`;
+exports[`StRSRP1 contract Gas Reporting Stake 2`] = `147302`;
 
 exports[`StRSRP1 contract Gas Reporting Transfer 1`] = `63265`;
 
@@ -10,10 +10,10 @@ exports[`StRSRP1 contract Gas Reporting Transfer 2`] = `41365`;
 
 exports[`StRSRP1 contract Gas Reporting Transfer 3`] = `58477`;
 
-exports[`StRSRP1 contract Gas Reporting Unstake 1`] = `222717`;
+exports[`StRSRP1 contract Gas Reporting Unstake 1`] = `222596`;
 
-exports[`StRSRP1 contract Gas Reporting Unstake 2`] = `139850`;
+exports[`StRSRP1 contract Gas Reporting Unstake 2`] = `139729`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `512220`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `510058`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `483078`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `480916`;

--- a/test/plugins/__snapshots__/Collateral.test.ts.snap
+++ b/test/plugins/__snapshots__/Collateral.test.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Collateral contracts Gas Reporting Force Updates - Hard Default - ATokens/CTokens 1`] = `70264`;
+exports[`Collateral contracts Gas Reporting Force Updates - Hard Default - ATokens/CTokens 1`] = `72347`;
 
-exports[`Collateral contracts Gas Reporting Force Updates - Hard Default - ATokens/CTokens 2`] = `71677`;
+exports[`Collateral contracts Gas Reporting Force Updates - Hard Default - ATokens/CTokens 2`] = `73827`;
 
-exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 1`] = `61267`;
+exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 1`] = `60054`;
 
-exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 2`] = `53998`;
+exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 2`] = `52786`;
 
-exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 3`] = `53718`;
+exports[`Collateral contracts Gas Reporting Force Updates - Soft Default 3`] = `52506`;

--- a/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
+++ b/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11668527`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11731434`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `8999991`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `8670380`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should claim rewards correctly 1`] = `2407239`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should claim rewards correctly 1`] = `2402799`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 1`] = `8833070`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 1`] = `8846091`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `23113544`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `21371273`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10727227`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10650380`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `8064941`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `7596130`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 1`] = `4137879`;
+exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 1`] = `4139340`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `15083019`;
+exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `14525655`;


### PR DESCRIPTION
Increases:
- `Furnace.melt()`: +2%

Reductions:
- `RToken.issue()`: -6% (this includes the melt call that went up in cost, within!)
- `RToken.redeem()`: -10% (this, too!)
- Recollateralization txs via `BackingManager.manageToken()`: -10%
- StRSR.*(): -2-3%

And asset plugins were a little up, little down. The ones with appreciating `refPerTok()`'s should be a bit less efficient and the others a bit more efficient. Not much of a change on average, though. 