### PR TITLE
save 900k gas for disabling the basket: just enough at n=128

### DIFF
--- a/contracts/plugins/mocks/GasGuzzlingFiatCollateral.sol
+++ b/contracts/plugins/mocks/GasGuzzlingFiatCollateral.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.17;
+
+import "../assets/FiatCollateral.sol";
+
+contract GasGuzzlingFiatCollateral is FiatCollateral {
+    using FixLib for uint192;
+
+    bool public revertRefPerTok;
+
+    /// @param config.chainlinkFeed Feed units: {UoA/ref}
+    constructor(CollateralConfig memory config) FiatCollateral(config) {}
+
+    function refPerTok() public view virtual override returns (uint192) {
+        if (revertRefPerTok) {
+            // Use up all gas available
+            this.infiniteLoop();
+        }
+
+        return 1e18;
+    }
+
+    function setRevertRefPerTok(bool on) external {
+        revertRefPerTok = on;
+    }
+
+    function infiniteLoop() external pure {
+        uint256 n = 2;
+        for (uint256 i = 0; ; ++i) {
+            unchecked {
+                n = n**2;
+            }
+        }
+    }
+}

--- a/test/__snapshots__/Main.test.ts.snap
+++ b/test/__snapshots__/Main.test.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`MainP1 contract Gas Reporting Asset Registry - Refresh 1`] = `292627`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 1`] = `192824`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 1`] = `192869`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 2`] = `192812`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 2`] = `192869`;
+
+exports[`MainP1 contract Gas Reporting Asset Registry - Swap Registered Asset 1`] = `169192`;
+
+exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 1`] = `83401`;
+
+exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 2`] = `72913`;


### PR DESCRIPTION
Resolves #641

C4
- https://github.com/code-423n4/2023-02-reserve-mitigation-contest-findings/issues/73

I also added gas tests for `unregister` / `swapRegistered`, which were previously missing. 