### PR TITLE
chore: uncomment FORK=1 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ ETHERSCAN_API_KEY=ABC123ABC123ABC123ABC123ABC123ABC1
 # SLOW=1
 
 # Run tests and scripts using Mainnet forking - required for integration tests
-# FORK=1
+FORK=1
 
 # Block to use as default for mainnet forking
 MAINNET_BLOCK=14916729


### PR DESCRIPTION
Collateral plugin tests require the `FORK=1` flag to be set to be work (otherwise they get skipped), so I think this should be uncommented by default so collateral plugin devs don't get confused why their tests don't run