### PR TITLE
propose facade interface for new Register `run*Auctions` buttons

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn compile
+      - run: yarn test:plugins
       - name: 'Cache hardhat network fork'
         uses: actions/cache@v3
         with:
@@ -62,7 +63,6 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           TS_NODE_SKIP_IGNORE: true
           MAINNET_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_MAINNET_KEY }}
-      - run: yarn test:plugins
 
   p0-tests:
     name: 'P0 tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install --immutable
       - run: yarn compile
-      - run: yarn test:plugins
       - name: 'Cache hardhat network fork'
         uses: actions/cache@v3
         with:
@@ -63,6 +62,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           TS_NODE_SKIP_IGNORE: true
           MAINNET_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_MAINNET_KEY }}
+      - run: yarn test:plugins
 
   p0-tests:
     name: 'P0 tests'

--- a/contracts/facade/FacadeAct.sol
+++ b/contracts/facade/FacadeAct.sol
@@ -375,7 +375,7 @@ contract FacadeAct is IFacadeAct {
 
         // Try to launch auctions
         bm.manageTokensSortedOrder(new IERC20[](0));
-        return bm.tradesOpen() - tradesOpen > 0;
+        return bm.tradesOpen() > 0;
     }
 
     /// To use this, call via callStatic.

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -356,6 +356,28 @@ contract FacadeRead is IFacadeRead {
         return rToken.main().assetRegistry().toAsset(IERC20(address(rToken))).price();
     }
 
+    /// @return erc20s The list of ERC20s that have auctions that can be settled, for given trader
+    function auctionsSettleable(ITrading trader) external view returns (IERC20[] memory erc20s) {
+        IERC20[] memory allERC20s = trader.main().assetRegistry().erc20s();
+
+        // Calculate which erc20s can have auctions settled
+        uint256 num;
+        IERC20[] memory unfiltered = new IERC20[](allERC20s.length); // will filter down later
+        for (uint256 i = 0; i < allERC20s.length; ++i) {
+            ITrade trade = trader.trades(allERC20s[i]);
+            if (address(trade) != address(0) && trade.canSettle()) {
+                unfiltered[num] = allERC20s[i];
+                ++num;
+            }
+        }
+
+        // Filter down
+        erc20s = new IERC20[](num);
+        for (uint256 i = 0; i < num; ++i) {
+            erc20s[i] = unfiltered[i];
+        }
+    }
+
     // === Private ===
 
     /// Multiply two fixes, rounding up to FIX_MAX and down to 0

--- a/contracts/interfaces/IFacadeAct.sol
+++ b/contracts/interfaces/IFacadeAct.sol
@@ -19,4 +19,27 @@ interface IFacadeAct {
 
     /// Claims rewards from all places they can accrue.
     function claimRewards(RTokenP1 rToken) external;
+
+    /// To use this, call via callStatic.
+    /// @return toStart The ERC20s that have auctions that can be started
+    /// @custom:static-call
+    function getRevenueAuctionERC20s(IRevenueTrader revenueTrader)
+        external
+        returns (IERC20[] memory toStart);
+
+    /// To use this, first call:
+    ///   - IFacadeAct.auctionsSettleable(revenueTrader)
+    ///   - getRevenueAuctionERC20s(revenueTrader)
+    /// If either arrays returned are non-empty, then can call this function.
+    /// Logic:
+    ///   For each ERC20 in `toSettle`:
+    ///     - Settle any open ERC20 trades
+    ///   For each ERC20 in `toStart`:
+    ///     - Transfer any revenue for that ERC20 from the backingManager to revenueTrader
+    ///     - Call `revenueTrader.manageToken(ERC20)` to start an auction, if possible
+    function runRevenueAuctions(
+        IRevenueTrader revenueTrader,
+        IERC20[] memory toSettle,
+        IERC20[] memory toStart
+    ) external;
 }

--- a/contracts/interfaces/IFacadeAct.sol
+++ b/contracts/interfaces/IFacadeAct.sol
@@ -21,6 +21,11 @@ interface IFacadeAct {
     function claimRewards(RTokenP1 rToken) external;
 
     /// To use this, call via callStatic.
+    /// @return canStart true iff a recollateralization auction can be started
+    /// @custom:static-call
+    function canRunRecollateralizationAuctions(IBackingManager bm) external returns (bool canStart);
+
+    /// To use this, call via callStatic.
     /// @return toStart The ERC20s that have auctions that can be started
     /// @custom:static-call
     function getRevenueAuctionERC20s(IRevenueTrader revenueTrader)
@@ -28,7 +33,7 @@ interface IFacadeAct {
         returns (IERC20[] memory toStart);
 
     /// To use this, first call:
-    ///   - IFacadeAct.auctionsSettleable(revenueTrader)
+    ///   - FacadeRead.auctionsSettleable(revenueTrader)
     ///   - getRevenueAuctionERC20s(revenueTrader)
     /// If either arrays returned are non-empty, then can call this function.
     /// Logic:

--- a/contracts/interfaces/IFacadeRead.sol
+++ b/contracts/interfaces/IFacadeRead.sol
@@ -129,4 +129,7 @@ interface IFacadeRead {
     /// @return low {UoA/tok} The low price of the RToken as given by the relevant RTokenAsset
     /// @return high {UoA/tok} The high price of the RToken as given by the relevant RTokenAsset
     function price(IRToken rToken) external view returns (uint192 low, uint192 high);
+
+    /// @return erc20s The list of ERC20s that have auctions that can be settled, for given trader
+    function auctionsSettleable(ITrading trader) external view returns (IERC20[] memory erc20s);
 }

--- a/contracts/interfaces/ITrading.sol
+++ b/contracts/interfaces/ITrading.sol
@@ -57,6 +57,9 @@ interface ITrading is IComponent, IRewardableComponent {
     /// @return The ongoing trade for a sell token, or the zero address
     function trades(IERC20 sell) external view returns (ITrade);
 
+    /// @return The number of ongoing trades open
+    function tradesOpen() external view returns (uint48);
+
     /// Light wrapper around FixLib.mulDiv to support try-catch
     function mulDivCeil(
         uint192 x,
@@ -71,7 +74,4 @@ interface TestITrading is ITrading {
 
     /// @custom:governance
     function setMinTradeVolume(uint192 val) external;
-
-    /// @return The number of ongoing trades open
-    function tradesOpen() external view returns (uint48);
 }

--- a/test/FacadeAct.test.ts
+++ b/test/FacadeAct.test.ts
@@ -22,6 +22,7 @@ import {
   CTokenMock,
   ERC20Mock,
   FacadeAct,
+  IFacadeRead,
   FiatCollateral,
   GnosisMock,
   IAssetRegistry,
@@ -87,6 +88,7 @@ describe('FacadeAct contract', () => {
 
   // Facade
   let facadeAct: FacadeAct
+  let facade: IFacadeRead
 
   // Main
   let rToken: TestIRToken
@@ -139,6 +141,7 @@ describe('FacadeAct contract', () => {
       collateral,
       basket,
       facadeAct,
+      facade,
       rToken,
       stRSR,
       config,
@@ -168,7 +171,7 @@ describe('FacadeAct contract', () => {
   })
 
   // P1 only
-  describeP1('Keepers - getActCallData', () => {
+  describeP1('Keepers', () => {
     let issueAmount: BigNumber
 
     beforeEach(async () => {
@@ -200,515 +203,364 @@ describe('FacadeAct contract', () => {
       await rToken.connect(addr1).issue(issueAmount)
     })
 
-    it('No call required', async () => {
-      // Via Facade get next call - No action required
-      const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
-    })
-
-    it('Basket changes', async () => {
-      // Register Collateral
-      await assetRegistry.connect(owner).register(backupCollateral1.address)
-      await assetRegistry.connect(owner).register(backupCollateral2.address)
-
-      // Set backup configuration - USDT and aUSDT as backup
-      await basketHandler
-        .connect(owner)
-        .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(2), [
-          backupToken1.address,
-          backupToken2.address,
-        ])
-
-      // Check initial state
-      expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
-      expect(await basketHandler.fullyCollateralized()).to.equal(true)
-
-      // Set Token2 to hard default - Decrease rate
-      await aToken.setExchangeRate(fp('0.99'))
-
-      // Basket should switch as default is detected immediately
-      await assetRegistry.refresh()
-
-      // Check state
-      expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
-      expect(await basketHandler.fullyCollateralized()).to.equal(false)
-
-      //  Call via Facade - should detect call to Basket handler
-      const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(basketHandler.address)
-      expect(data).to.not.equal('0x')
-
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      ).to.emit(basketHandler, 'BasketSet')
-
-      // Check state - Basket switch
-      expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
-      expect(await basketHandler.fullyCollateralized()).to.equal(false)
-    })
-
-    it('Basket - Should handle no valid basket after refresh', async () => {
-      // Redeem all RTokens
-      await rToken.connect(addr1).redeem(issueAmount, await basketHandler.nonce())
-
-      // Set simple basket with only one collateral
-      await basketHandler.connect(owner).setPrimeBasket([aToken.address], [fp('1')])
-
-      // Set backup config with the same collateral
-      await basketHandler
-        .connect(owner)
-        .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(1), [aToken.address])
-
-      // Switch basket
-      await expect(basketHandler.connect(owner).refreshBasket())
-        .to.emit(basketHandler, 'BasketSet')
-        .withArgs(2, [aToken.address], [fp('1')], false)
-
-      // Now default the token, will not be able to find a valid basket
-      await aToken.setExchangeRate(fp('0.99'))
-      await assetRegistry.refresh()
-
-      // Check state
-      expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
-
-      //  Call via Facade - should not provide call to basket handler
-      const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
-    })
-
-    it('Trades in Backing Manager', async () => {
-      // Setup prime basket
-      await basketHandler.connect(owner).setPrimeBasket([usdc.address], [fp('1')])
-
-      // Switch Basket
-      await expect(basketHandler.connect(owner).refreshBasket())
-        .to.emit(basketHandler, 'BasketSet')
-        .withArgs(2, [usdc.address], [fp('1')], false)
-
-      // Trigger recollateralization
-      const sellAmt: BigNumber = await token.balanceOf(backingManager.address)
-      const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
-
-      // Run auction via Facade
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(backingManager, 'TradeStarted')
-        .withArgs(anyValue, token.address, usdc.address, sellAmt, toBNDecimals(minBuyAmt, 6).add(1))
-
-      // Check state
-      expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
-      expect(await basketHandler.fullyCollateralized()).to.equal(false)
-
-      // Perform Mock Bids for the new Token (addr1 has balance)
-      // Get fair price - all tokens
-      await usdc.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmt, 6))
-      await gnosis.placeBid(0, {
-        bidder: addr1.address,
-        sellAmount: sellAmt,
-        buyAmount: toBNDecimals(sellAmt, 6),
+    context('getActCalldata', () => {
+      it('No call required', async () => {
+        // Via Facade get next call - No action required
+        const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
       })
 
-      // Advance time till auction ended
-      await advanceTime(config.auctionLength.add(100).toString())
+      it('Basket changes', async () => {
+        // Register Collateral
+        await assetRegistry.connect(owner).register(backupCollateral1.address)
+        await assetRegistry.connect(owner).register(backupCollateral2.address)
 
-      // Trade is ready to be settled - Call settle trade via  Facade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
+        // Set backup configuration - USDT and aUSDT as backup
+        await basketHandler
+          .connect(owner)
+          .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(2), [
+            backupToken1.address,
+            backupToken2.address,
+          ])
 
-      // End current auction
-      await expect(
-        owner.sendTransaction({
+        // Check initial state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(true)
+
+        // Set Token2 to hard default - Decrease rate
+        await aToken.setExchangeRate(fp('0.99'))
+
+        // Basket should switch as default is detected immediately
+        await assetRegistry.refresh()
+
+        // Check state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
+        expect(await basketHandler.fullyCollateralized()).to.equal(false)
+
+        //  Call via Facade - should detect call to Basket handler
+        const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(basketHandler.address)
+        expect(data).to.not.equal('0x')
+
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        ).to.emit(basketHandler, 'BasketSet')
+
+        // Check state - Basket switch
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(false)
+      })
+
+      it('Basket - Should handle no valid basket after refresh', async () => {
+        // Redeem all RTokens
+        await rToken.connect(addr1).redeem(issueAmount, await basketHandler.nonce())
+
+        // Set simple basket with only one collateral
+        await basketHandler.connect(owner).setPrimeBasket([aToken.address], [fp('1')])
+
+        // Set backup config with the same collateral
+        await basketHandler
+          .connect(owner)
+          .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(1), [aToken.address])
+
+        // Switch basket
+        await expect(basketHandler.connect(owner).refreshBasket())
+          .to.emit(basketHandler, 'BasketSet')
+          .withArgs(2, [aToken.address], [fp('1')], false)
+
+        // Now default the token, will not be able to find a valid basket
+        await aToken.setExchangeRate(fp('0.99'))
+        await assetRegistry.refresh()
+
+        // Check state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.DISABLED)
+
+        //  Call via Facade - should not provide call to basket handler
+        const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
+      })
+
+      it('Trades in Backing Manager', async () => {
+        // Setup prime basket
+        await basketHandler.connect(owner).setPrimeBasket([usdc.address], [fp('1')])
+
+        // Switch Basket
+        await expect(basketHandler.connect(owner).refreshBasket())
+          .to.emit(basketHandler, 'BasketSet')
+          .withArgs(2, [usdc.address], [fp('1')], false)
+
+        // Trigger recollateralization
+        const sellAmt: BigNumber = await token.balanceOf(backingManager.address)
+        const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
+
+        // Confirm canRunRecollateralizationAuctions is true
+        expect(
+          await facadeAct.callStatic.canRunRecollateralizationAuctions(backingManager.address)
+        ).to.equal(true)
+
+        // Run auction via Facade
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(backingManager, 'TradeStarted')
+          .withArgs(
+            anyValue,
+            token.address,
+            usdc.address,
+            sellAmt,
+            toBNDecimals(minBuyAmt, 6).add(1)
+          )
+
+        // Confirm canRunRecollateralizationAuctions is false
+        expect(
+          await facadeAct.callStatic.canRunRecollateralizationAuctions(backingManager.address)
+        ).to.equal(false)
+
+        // Check state
+        expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+        expect(await basketHandler.fullyCollateralized()).to.equal(false)
+
+        // Perform Mock Bids for the new Token (addr1 has balance)
+        // Get fair price - all tokens
+        await usdc.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmt, 6))
+        await gnosis.placeBid(0, {
+          bidder: addr1.address,
+          sellAmount: sellAmt,
+          buyAmount: toBNDecimals(sellAmt, 6),
+        })
+
+        // Advance time till auction ended
+        await advanceTime(config.auctionLength.add(100).toString())
+
+        // Confirm auctionsSettleable returns trade
+        const settleable = await facade.auctionsSettleable(backingManager.address)
+        expect(settleable.length).to.equal(1)
+        expect(settleable[0]).to.equal(token.address)
+
+        // Trade is ready to be settled - Call settle trade via  Facade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        // End current auction
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(backingManager, 'TradeSettled')
+          .withArgs(anyValue, token.address, usdc.address, sellAmt, toBNDecimals(sellAmt, 6))
+      })
+
+      it('Revenues/Rewards', async () => {
+        const rewardAmountAAVE = bn('0.5e18')
+
+        // AAVE Rewards
+        await aToken.setRewards(backingManager.address, rewardAmountAAVE)
+
+        // Via Facade get next call - will claim rewards from backingManager
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        // Claim and sweep rewards
+        await owner.sendTransaction({
           to: addr,
           data,
         })
-      )
-        .to.emit(backingManager, 'TradeSettled')
-        .withArgs(anyValue, token.address, usdc.address, sellAmt, toBNDecimals(sellAmt, 6))
-    })
 
-    it('Revenues/Rewards', async () => {
-      const rewardAmountAAVE = bn('0.5e18')
+        // Collect revenue
+        // Expected values based on Prices between AAVE and RSR/RToken = 1 to 1 (for simplification)
+        const sellAmt: BigNumber = rewardAmountAAVE.mul(60).div(100) // due to f = 60%
+        const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
 
-      // AAVE Rewards
-      await aToken.setRewards(backingManager.address, rewardAmountAAVE)
+        const sellAmtRToken: BigNumber = rewardAmountAAVE.sub(sellAmt) // Remainder
+        const minBuyAmtRToken: BigNumber = await toMinBuyAmt(sellAmtRToken, fp('1'), fp('1'))
 
-      // Via Facade get next call - will claim rewards from backingManager
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
+        // Via Facade get next call - will transfer RToken to Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
 
-      // Claim and sweep rewards
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Collect revenue
-      // Expected values based on Prices between AAVE and RSR/RToken = 1 to 1 (for simplification)
-      const sellAmt: BigNumber = rewardAmountAAVE.mul(60).div(100) // due to f = 60%
-      const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
-
-      const sellAmtRToken: BigNumber = rewardAmountAAVE.sub(sellAmt) // Remainder
-      const minBuyAmtRToken: BigNumber = await toMinBuyAmt(sellAmtRToken, fp('1'), fp('1'))
-
-      // Via Facade get next call - will transfer RToken to Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in Backing Manager
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Next call would start Revenue auction - RTokenTrader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rTokenTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in RTokenTrader
-      await expect(
-        owner.sendTransaction({
+        // Manage tokens in Backing Manager
+        await owner.sendTransaction({
           to: addr,
           data,
         })
-      )
-        .to.emit(rTokenTrader, 'TradeStarted')
-        .withArgs(
-          anyValue,
-          aaveToken.address,
-          rToken.address,
-          sellAmtRToken,
-          withinQuad(minBuyAmtRToken)
+
+        // Next call would start Revenue auction - RTokenTrader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rTokenTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in RTokenTrader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rTokenTrader, 'TradeStarted')
+          .withArgs(
+            anyValue,
+            aaveToken.address,
+            rToken.address,
+            sellAmtRToken,
+            withinQuad(minBuyAmtRToken)
+          )
+
+        // Via Facade get next call - will open RSR trade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in RSRTrader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rsrTrader, 'TradeStarted')
+          .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
+
+        // Check funds in Market
+        expect(await aaveToken.balanceOf(gnosis.address)).to.equal(rewardAmountAAVE)
+
+        // Advance time till auction ended
+        await advanceTime(config.auctionLength.add(100).toString())
+
+        // Mock auction by minting the buy tokens (in this case RSR and RToken)
+        await rsr.connect(addr1).approve(gnosis.address, minBuyAmt)
+        await rToken.connect(addr1).approve(gnosis.address, minBuyAmtRToken)
+        await gnosis.placeBid(0, {
+          bidder: addr1.address,
+          sellAmount: sellAmtRToken,
+          buyAmount: minBuyAmtRToken,
+        })
+        await gnosis.placeBid(1, {
+          bidder: addr1.address,
+          sellAmount: sellAmt,
+          buyAmount: minBuyAmt,
+        })
+
+        // Settle RToken trades via Facade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rTokenTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Close auction in RToken Trader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rTokenTrader, 'TradeSettled')
+          .withArgs(anyValue, aaveToken.address, rToken.address, sellAmtRToken, minBuyAmtRToken)
+
+        // Now settle trade in RSR Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Close auction in RSR Trader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rsrTrader, 'TradeSettled')
+          .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
+
+        // Check no new calls to make from Facade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
+
+        // distribute Revenue from RToken trader
+        await rTokenTrader.manageToken(rToken.address)
+
+        // Claim additional Revenue but only send to RSR (to trigger RSR trader directly)
+        // Set f = 1
+        await distributor
+          .connect(owner)
+          .setDistribution(FURNACE_DEST, { rTokenDist: bn(0), rsrDist: bn(0) })
+
+        // Avoid dropping 20 qCOMP by making there be exactly 1 distribution share.
+        await distributor
+          .connect(owner)
+          .setDistribution(STRSR_DEST, { rTokenDist: bn(0), rsrDist: bn(1) })
+
+        // Set new rewards
+        await aToken.setRewards(backingManager.address, rewardAmountAAVE)
+
+        // Claim new rewards
+        await backingManager.claimRewards()
+
+        // Via Facade get next call - will transfer RSR to Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in Backing Manager
+        await owner.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // Next call would start Revenue auction - RSR Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in RTokenTrader
+        const minBuyAmtAAVE = await toMinBuyAmt(rewardAmountAAVE, fp('1'), fp('1'))
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rsrTrader, 'TradeStarted')
+          .withArgs(
+            anyValue,
+            aaveToken.address,
+            rsr.address,
+            rewardAmountAAVE,
+            withinQuad(minBuyAmtAAVE)
+          )
+      })
+
+      it('Revenues - Should handle assets with invalid claim logic', async () => {
+        // Redeem all RTokens
+        await rToken.connect(addr1).redeem(issueAmount, await basketHandler.nonce())
+
+        // Setup a new aToken with invalid claim data
+        const ATokenCollateralFactory = await ethers.getContractFactory(
+          'InvalidATokenFiatCollateralMock'
+        )
+        const chainlinkFeed = <MockV3Aggregator>(
+          await (await ethers.getContractFactory('MockV3Aggregator')).deploy(8, bn('1e8'))
         )
 
-      // Via Facade get next call - will open RSR trade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in RSRTrader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rsrTrader, 'TradeStarted')
-        .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
-
-      // Check funds in Market
-      expect(await aaveToken.balanceOf(gnosis.address)).to.equal(rewardAmountAAVE)
-
-      // Advance time till auction ended
-      await advanceTime(config.auctionLength.add(100).toString())
-
-      // Mock auction by minting the buy tokens (in this case RSR and RToken)
-      await rsr.connect(addr1).approve(gnosis.address, minBuyAmt)
-      await rToken.connect(addr1).approve(gnosis.address, minBuyAmtRToken)
-      await gnosis.placeBid(0, {
-        bidder: addr1.address,
-        sellAmount: sellAmtRToken,
-        buyAmount: minBuyAmtRToken,
-      })
-      await gnosis.placeBid(1, {
-        bidder: addr1.address,
-        sellAmount: sellAmt,
-        buyAmount: minBuyAmt,
-      })
-
-      // Settle RToken trades via Facade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rTokenTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Close auction in RToken Trader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rTokenTrader, 'TradeSettled')
-        .withArgs(anyValue, aaveToken.address, rToken.address, sellAmtRToken, minBuyAmtRToken)
-
-      // Now settle trade in RSR Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Close auction in RSR Trader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rsrTrader, 'TradeSettled')
-        .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
-
-      // Check no new calls to make from Facade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
-
-      // distribute Revenue from RToken trader
-      await rTokenTrader.manageToken(rToken.address)
-
-      // Claim additional Revenue but only send to RSR (to trigger RSR trader directly)
-      // Set f = 1
-      await distributor
-        .connect(owner)
-        .setDistribution(FURNACE_DEST, { rTokenDist: bn(0), rsrDist: bn(0) })
-
-      // Avoid dropping 20 qCOMP by making there be exactly 1 distribution share.
-      await distributor
-        .connect(owner)
-        .setDistribution(STRSR_DEST, { rTokenDist: bn(0), rsrDist: bn(1) })
-
-      // Set new rewards
-      await aToken.setRewards(backingManager.address, rewardAmountAAVE)
-
-      // Claim new rewards
-      await backingManager.claimRewards()
-
-      // Via Facade get next call - will transfer RSR to Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in Backing Manager
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Next call would start Revenue auction - RSR Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in RTokenTrader
-      const minBuyAmtAAVE = await toMinBuyAmt(rewardAmountAAVE, fp('1'), fp('1'))
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rsrTrader, 'TradeStarted')
-        .withArgs(
-          anyValue,
-          aaveToken.address,
-          rsr.address,
-          rewardAmountAAVE,
-          withinQuad(minBuyAmtAAVE)
-        )
-    })
-
-    it('Revenues - Should handle assets with invalid claim logic', async () => {
-      // Redeem all RTokens
-      await rToken.connect(addr1).redeem(issueAmount, await basketHandler.nonce())
-
-      // Setup a new aToken with invalid claim data
-      const ATokenCollateralFactory = await ethers.getContractFactory(
-        'InvalidATokenFiatCollateralMock'
-      )
-      const chainlinkFeed = <MockV3Aggregator>(
-        await (await ethers.getContractFactory('MockV3Aggregator')).deploy(8, bn('1e8'))
-      )
-
-      const invalidATokenCollateral: InvalidATokenFiatCollateralMock = <
-        InvalidATokenFiatCollateralMock
-      >await ATokenCollateralFactory.deploy(
-        {
-          priceTimeout: PRICE_TIMEOUT,
-          chainlinkFeed: chainlinkFeed.address,
-          oracleError: ORACLE_ERROR,
-          erc20: aToken.address,
-          maxTradeVolume: config.rTokenMaxTradeVolume,
-          oracleTimeout: await aTokenAsset.oracleTimeout(),
-          targetName: ethers.utils.formatBytes32String('USD'),
-          defaultThreshold: DEFAULT_THRESHOLD,
-          delayUntilDefault: await aTokenAsset.delayUntilDefault(),
-        },
-        REVENUE_HIDING
-      )
-
-      // Perform asset swap
-      await assetRegistry.connect(owner).swapRegistered(invalidATokenCollateral.address)
-
-      // Setup new basket with the invalid AToken
-      await basketHandler.connect(owner).setPrimeBasket([aToken.address], [fp('1')])
-
-      // Switch basket
-      await basketHandler.connect(owner).refreshBasket()
-
-      const rewardAmountAAVE = bn('0.5e18')
-
-      // AAVE Rewards
-      await aToken.setRewards(backingManager.address, rewardAmountAAVE)
-
-      // Via Facade get next call - will not attempt to claim - No action taken
-      const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
-
-      // Check status - nothing claimed
-      expect(await aaveToken.balanceOf(backingManager.address)).to.equal(0)
-    })
-
-    it('Revenues - Should handle minTradeVolume = 0', async () => {
-      // Set minTradeVolume = 0
-      await rsrTrader.connect(owner).setMinTradeVolume(bn(0))
-      await rTokenTrader.connect(owner).setMinTradeVolume(bn(0))
-
-      const rewardAmountAAVE = bn('0.5e18')
-
-      // AAVE Rewards
-      await aToken.setRewards(backingManager.address, rewardAmountAAVE)
-
-      // Via Facade get next call - will claim rewards from backingManager
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      // Claim and sweep rewards
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Collect revenue
-      // Expected values based on Prices between AAVE and RSR/RToken = 1 to 1 (for simplification)
-      const sellAmt: BigNumber = rewardAmountAAVE.mul(60).div(100) // due to f = 60%
-      const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
-
-      const sellAmtRToken: BigNumber = rewardAmountAAVE.sub(sellAmt) // Remainder
-      const minBuyAmtRToken: BigNumber = await toMinBuyAmt(sellAmtRToken, fp('1'), fp('1'))
-
-      // Via Facade get next call - will transfer RToken to Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in Backing Manager
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Next call would start Revenue auction - RTokenTrader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rTokenTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in RTokenTrader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rTokenTrader, 'TradeStarted')
-        .withArgs(
-          anyValue,
-          aaveToken.address,
-          rToken.address,
-          sellAmtRToken,
-          withinQuad(minBuyAmtRToken)
-        )
-
-      // Via Facade get next call - will open RSR trade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Manage tokens in RSRTrader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rsrTrader, 'TradeStarted')
-        .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
-
-      // Check funds in Market
-      expect(await aaveToken.balanceOf(gnosis.address)).to.equal(rewardAmountAAVE)
-
-      // Advance time till auction ended
-      await advanceTime(config.auctionLength.add(100).toString())
-
-      // Mock auction by minting the buy tokens (in this case RSR and RToken)
-      await rsr.connect(addr1).approve(gnosis.address, minBuyAmt)
-      await rToken.connect(addr1).approve(gnosis.address, minBuyAmtRToken)
-      await gnosis.placeBid(0, {
-        bidder: addr1.address,
-        sellAmount: sellAmtRToken,
-        buyAmount: minBuyAmtRToken,
-      })
-      await gnosis.placeBid(1, {
-        bidder: addr1.address,
-        sellAmount: sellAmt,
-        buyAmount: minBuyAmt,
-      })
-
-      // Settle RToken trades via Facade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rTokenTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Close auction in RToken Trader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rTokenTrader, 'TradeSettled')
-        .withArgs(anyValue, aaveToken.address, rToken.address, sellAmtRToken, minBuyAmtRToken)
-
-      // Now settle trade in RSR Trader
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      // Close auction in RSR Trader
-      await expect(
-        owner.sendTransaction({
-          to: addr,
-          data,
-        })
-      )
-        .to.emit(rsrTrader, 'TradeSettled')
-        .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
-    })
-
-    it('Revenues - Should handle multiple assets with same reward token', async () => {
-      // Update Reward token for AToken to use same as CToken
-      const ATokenCollateralFactory = await ethers.getContractFactory('ATokenFiatCollateral')
-      const chainlinkFeed = <MockV3Aggregator>(
-        await (await ethers.getContractFactory('MockV3Aggregator')).deploy(8, bn('1e8'))
-      )
-
-      const newATokenCollateral: ATokenFiatCollateral = <ATokenFiatCollateral>(
-        await ATokenCollateralFactory.deploy(
+        const invalidATokenCollateral: InvalidATokenFiatCollateralMock = <
+          InvalidATokenFiatCollateralMock
+        >await ATokenCollateralFactory.deploy(
           {
             priceTimeout: PRICE_TIMEOUT,
             chainlinkFeed: chainlinkFeed.address,
@@ -722,147 +574,368 @@ describe('FacadeAct contract', () => {
           },
           REVENUE_HIDING
         )
-      )
-      // Perform asset swap
-      await assetRegistry.connect(owner).swapRegistered(newATokenCollateral.address)
 
-      // Refresh basket
-      await basketHandler.connect(owner).refreshBasket()
+        // Perform asset swap
+        await assetRegistry.connect(owner).swapRegistered(invalidATokenCollateral.address)
 
-      const rewardAmount = bn('0.5e18')
+        // Setup new basket with the invalid AToken
+        await basketHandler.connect(owner).setPrimeBasket([aToken.address], [fp('1')])
 
-      // COMP Rewards for both tokens, in the RToken
-      await aToken.setAaveToken(compToken.address) // set it internally in our mock
-      await aToken.setRewards(backingManager.address, rewardAmount)
-      await compoundMock.setRewards(backingManager.address, rewardAmount)
+        // Switch basket
+        await basketHandler.connect(owner).refreshBasket()
 
-      // Via Facade get next call - will Claim and sweep rewards
-      const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
+        const rewardAmountAAVE = bn('0.5e18')
 
-      await owner.sendTransaction({
-        to: addr,
-        data,
+        // AAVE Rewards
+        await aToken.setRewards(backingManager.address, rewardAmountAAVE)
+
+        // Via Facade get next call - will not attempt to claim - No action taken
+        const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
+
+        // Check status - nothing claimed
+        expect(await aaveToken.balanceOf(backingManager.address)).to.equal(0)
       })
 
-      // Check status - rewards claimed for both collaterals
-      expect(await compToken.balanceOf(backingManager.address)).to.equal(rewardAmount.mul(2))
-    })
+      it('Revenues - Should handle minTradeVolume = 0', async () => {
+        // Set minTradeVolume = 0
+        await rsrTrader.connect(owner).setMinTradeVolume(bn(0))
+        await rTokenTrader.connect(owner).setMinTradeVolume(bn(0))
 
-    it('Revenues - Should claim rewards in Revenue Traders', async () => {
-      const rewardAmountAAVE = bn('0.5e18')
+        const rewardAmountAAVE = bn('0.5e18')
 
-      // AAVE Rewards - RSR Trader
-      await aToken.setRewards(rsrTrader.address, rewardAmountAAVE)
+        // AAVE Rewards
+        await aToken.setRewards(backingManager.address, rewardAmountAAVE)
 
-      // Via Facade get next call - will claim rewards from Traders, via Facade
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(facadeAct.address)
-      expect(data).to.not.equal('0x')
+        // Via Facade get next call - will claim rewards from backingManager
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
 
-      // Claim rewards
-      await owner.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // Check rewards collected
-      expect(await aaveToken.balanceOf(rsrTrader.address)).to.equal(rewardAmountAAVE)
-      expect(await aaveToken.balanceOf(rTokenTrader.address)).to.equal(bn(0))
-
-      // Via Facade get next call - will create a trade from the RSR Trader trade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(rsrTrader.address)
-      expect(data).to.not.equal('0x')
-
-      await expect(
-        owner.sendTransaction({
+        // Claim and sweep rewards
+        await owner.sendTransaction({
           to: addr,
           data,
         })
-      ).to.emit(rsrTrader, 'TradeStarted')
 
-      // AAVE Rewards - RToken Trader
-      await aToken.setRewards(rTokenTrader.address, rewardAmountAAVE)
+        // Collect revenue
+        // Expected values based on Prices between AAVE and RSR/RToken = 1 to 1 (for simplification)
+        const sellAmt: BigNumber = rewardAmountAAVE.mul(60).div(100) // due to f = 60%
+        const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
 
-      // Via Facade get next call - will claim rewards from Traders, via Facade
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(facadeAct.address)
-      expect(data).to.not.equal('0x')
+        const sellAmtRToken: BigNumber = rewardAmountAAVE.sub(sellAmt) // Remainder
+        const minBuyAmtRToken: BigNumber = await toMinBuyAmt(sellAmtRToken, fp('1'), fp('1'))
 
-      // Claim rewards
-      await owner.sendTransaction({
-        to: addr,
-        data,
+        // Via Facade get next call - will transfer RToken to Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in Backing Manager
+        await owner.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // Next call would start Revenue auction - RTokenTrader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rTokenTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in RTokenTrader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rTokenTrader, 'TradeStarted')
+          .withArgs(
+            anyValue,
+            aaveToken.address,
+            rToken.address,
+            sellAmtRToken,
+            withinQuad(minBuyAmtRToken)
+          )
+
+        // Via Facade get next call - will open RSR trade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Manage tokens in RSRTrader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rsrTrader, 'TradeStarted')
+          .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
+
+        // Check funds in Market
+        expect(await aaveToken.balanceOf(gnosis.address)).to.equal(rewardAmountAAVE)
+
+        // Advance time till auction ended
+        await advanceTime(config.auctionLength.add(100).toString())
+
+        // Mock auction by minting the buy tokens (in this case RSR and RToken)
+        await rsr.connect(addr1).approve(gnosis.address, minBuyAmt)
+        await rToken.connect(addr1).approve(gnosis.address, minBuyAmtRToken)
+        await gnosis.placeBid(0, {
+          bidder: addr1.address,
+          sellAmount: sellAmtRToken,
+          buyAmount: minBuyAmtRToken,
+        })
+        await gnosis.placeBid(1, {
+          bidder: addr1.address,
+          sellAmount: sellAmt,
+          buyAmount: minBuyAmt,
+        })
+
+        // Settle RToken trades via Facade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rTokenTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Close auction in RToken Trader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rTokenTrader, 'TradeSettled')
+          .withArgs(anyValue, aaveToken.address, rToken.address, sellAmtRToken, minBuyAmtRToken)
+
+        // Now settle trade in RSR Trader
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        // Close auction in RSR Trader
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        )
+          .to.emit(rsrTrader, 'TradeSettled')
+          .withArgs(anyValue, aaveToken.address, rsr.address, sellAmt, minBuyAmt)
       })
 
-      // Check rewards collected - there are funds in the RTokenTrader now
-      expect(await aaveToken.balanceOf(rsrTrader.address)).to.equal(bn(0)) // moved to trade
-      expect(await aaveToken.balanceOf(rTokenTrader.address)).to.equal(rewardAmountAAVE)
+      it('Revenues - Should handle multiple assets with same reward token', async () => {
+        // Update Reward token for AToken to use same as CToken
+        const ATokenCollateralFactory = await ethers.getContractFactory('ATokenFiatCollateral')
+        const chainlinkFeed = <MockV3Aggregator>(
+          await (await ethers.getContractFactory('MockV3Aggregator')).deploy(8, bn('1e8'))
+        )
+
+        const newATokenCollateral: ATokenFiatCollateral = <ATokenFiatCollateral>(
+          await ATokenCollateralFactory.deploy(
+            {
+              priceTimeout: PRICE_TIMEOUT,
+              chainlinkFeed: chainlinkFeed.address,
+              oracleError: ORACLE_ERROR,
+              erc20: aToken.address,
+              maxTradeVolume: config.rTokenMaxTradeVolume,
+              oracleTimeout: await aTokenAsset.oracleTimeout(),
+              targetName: ethers.utils.formatBytes32String('USD'),
+              defaultThreshold: DEFAULT_THRESHOLD,
+              delayUntilDefault: await aTokenAsset.delayUntilDefault(),
+            },
+            REVENUE_HIDING
+          )
+        )
+        // Perform asset swap
+        await assetRegistry.connect(owner).swapRegistered(newATokenCollateral.address)
+
+        // Refresh basket
+        await basketHandler.connect(owner).refreshBasket()
+
+        const rewardAmount = bn('0.5e18')
+
+        // COMP Rewards for both tokens, in the RToken
+        await aToken.setAaveToken(compToken.address) // set it internally in our mock
+        await aToken.setRewards(backingManager.address, rewardAmount)
+        await compoundMock.setRewards(backingManager.address, rewardAmount)
+
+        // Via Facade get next call - will Claim and sweep rewards
+        const [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        await owner.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // Check status - rewards claimed for both collaterals
+        expect(await compToken.balanceOf(backingManager.address)).to.equal(rewardAmount.mul(2))
+      })
+
+      it('Revenues - Should claim rewards in Revenue Traders', async () => {
+        const rewardAmountAAVE = bn('0.5e18')
+
+        // AAVE Rewards - RSR Trader
+        await aToken.setRewards(rsrTrader.address, rewardAmountAAVE)
+
+        // Via Facade get next call - will claim rewards from Traders, via Facade
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(facadeAct.address)
+        expect(data).to.not.equal('0x')
+
+        // Claim rewards
+        await owner.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // Check rewards collected
+        expect(await aaveToken.balanceOf(rsrTrader.address)).to.equal(rewardAmountAAVE)
+        expect(await aaveToken.balanceOf(rTokenTrader.address)).to.equal(bn(0))
+
+        // Via Facade get next call - will create a trade from the RSR Trader trade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(rsrTrader.address)
+        expect(data).to.not.equal('0x')
+
+        await expect(
+          owner.sendTransaction({
+            to: addr,
+            data,
+          })
+        ).to.emit(rsrTrader, 'TradeStarted')
+
+        // AAVE Rewards - RToken Trader
+        await aToken.setRewards(rTokenTrader.address, rewardAmountAAVE)
+
+        // Via Facade get next call - will claim rewards from Traders, via Facade
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(facadeAct.address)
+        expect(data).to.not.equal('0x')
+
+        // Claim rewards
+        await owner.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // Check rewards collected - there are funds in the RTokenTrader now
+        expect(await aaveToken.balanceOf(rsrTrader.address)).to.equal(bn(0)) // moved to trade
+        expect(await aaveToken.balanceOf(rTokenTrader.address)).to.equal(rewardAmountAAVE)
+      })
+
+      it('Should not revert if f=1', async () => {
+        await distributor
+          .connect(owner)
+          .setDistribution(FURNACE_DEST, { rTokenDist: 0, rsrDist: 0 })
+        // Transfer free tokens to RTokenTrader
+        const hndAmt: BigNumber = bn('10e18')
+        await rToken.connect(addr1).transfer(rTokenTrader.address, hndAmt)
+
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
+
+        // RSR can be distributed with no issues - seed stRSR with half as much
+        await rsr.connect(addr1).transfer(backingManager.address, hndAmt)
+        await rsr.connect(addr1).transfer(stRSR.address, hndAmt.div(2))
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(hndAmt.div(2))
+        expect(await rsr.balanceOf(backingManager.address)).to.equal(hndAmt)
+        expect(await rsr.balanceOf(rsrTrader.address)).to.equal(0)
+
+        // Execute managetokens in Backing Manager
+        await addr1.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // RSR forwarded
+        expect(await rsr.balanceOf(stRSR.address)).to.equal(hndAmt.add(hndAmt.div(2)))
+        expect(await rsr.balanceOf(backingManager.address)).to.equal(0)
+        expect(await rsr.balanceOf(rsrTrader.address)).to.equal(0)
+      })
+
+      it('Should not revert if f=0', async () => {
+        await distributor.connect(owner).setDistribution(STRSR_DEST, { rTokenDist: 0, rsrDist: 0 })
+        // Transfer free tokens to RTokenTrader
+        const hndAmt: BigNumber = bn('10e18')
+        await rsr.connect(addr1).transfer(rsrTrader.address, hndAmt)
+
+        let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(ZERO_ADDRESS)
+        expect(data).to.equal('0x')
+
+        // RToken can be distributed with no issues
+        await rToken.connect(addr1).transfer(backingManager.address, hndAmt)
+        ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
+        expect(addr).to.equal(backingManager.address)
+        expect(data).to.not.equal('0x')
+
+        expect(await rToken.balanceOf(backingManager.address)).to.equal(hndAmt)
+        expect(await rToken.balanceOf(rTokenTrader.address)).to.equal(0)
+
+        // Execute managetokens in Backing Manager
+        await addr1.sendTransaction({
+          to: addr,
+          data,
+        })
+
+        // RToken forwarded
+        expect(await rToken.balanceOf(backingManager.address)).to.equal(0)
+        expect(await rToken.balanceOf(rTokenTrader.address)).to.equal(hndAmt)
+      })
     })
 
-    it('Should not revert if f=1', async () => {
-      await distributor.connect(owner).setDistribution(FURNACE_DEST, { rTokenDist: 0, rsrDist: 0 })
-      // Transfer free tokens to RTokenTrader
-      const hndAmt: BigNumber = bn('10e18')
-      await rToken.connect(addr1).transfer(rTokenTrader.address, hndAmt)
+    context('getRevenueAuctionERC20s/runRevenueAuctions', () => {
+      it('Revenues/Rewards', async () => {
+        const rewardAmountAAVE = bn('0.5e18')
+        const rewardAmountCOMP = bn('1e18')
 
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
+        // Setup AAVE + COMP rewards
+        await aToken.setRewards(backingManager.address, rewardAmountAAVE)
+        await compoundMock.setRewards(backingManager.address, rewardAmountCOMP)
+        await backingManager.claimRewards()
 
-      // RSR can be distributed with no issues - seed stRSR with half as much
-      await rsr.connect(addr1).transfer(backingManager.address, hndAmt)
-      await rsr.connect(addr1).transfer(stRSR.address, hndAmt.div(2))
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
+        // getRevenueAuctionERC20s should return reward token
+        const rTokenERC20s = await facadeAct.callStatic.getRevenueAuctionERC20s(
+          rTokenTrader.address
+        )
+        expect(rTokenERC20s.length).to.equal(2)
+        expect(rTokenERC20s[0]).to.equal(aaveToken.address)
+        expect(rTokenERC20s[1]).to.equal(compToken.address)
+        const rsrERC20s = await facadeAct.callStatic.getRevenueAuctionERC20s(rsrTrader.address)
+        expect(rsrERC20s.length).to.equal(2)
+        expect(rsrERC20s[0]).to.equal(aaveToken.address)
+        expect(rsrERC20s[1]).to.equal(compToken.address)
 
-      expect(await rsr.balanceOf(stRSR.address)).to.equal(hndAmt.div(2))
-      expect(await rsr.balanceOf(backingManager.address)).to.equal(hndAmt)
-      expect(await rsr.balanceOf(rsrTrader.address)).to.equal(0)
+        // Run revenue auctions for both traders
+        await facadeAct.runRevenueAuctions(rTokenTrader.address, [], rTokenERC20s)
+        await facadeAct.runRevenueAuctions(rsrTrader.address, [], rsrERC20s)
 
-      // Execute managetokens in Backing Manager
-      await addr1.sendTransaction({
-        to: addr,
-        data,
+        // Nothing should be settleable
+        expect((await facade.auctionsSettleable(rTokenTrader.address)).length).to.equal(0)
+        expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
+
+        // Advance time till auction ended
+        await advanceTime(config.auctionLength.add(100).toString())
+
+        // Now both should be settleable
+        const rTokenSettleable = await facade.auctionsSettleable(rTokenTrader.address)
+        expect(rTokenSettleable.length).to.equal(2)
+        expect(rTokenSettleable[0]).to.equal(aaveToken.address)
+        expect(rTokenSettleable[1]).to.equal(compToken.address)
+        const rsrSettleable = await facade.auctionsSettleable(rsrTrader.address)
+        expect(rsrSettleable.length).to.equal(2)
+        expect(rsrSettleable[0]).to.equal(aaveToken.address)
+        expect(rsrSettleable[1]).to.equal(compToken.address)
       })
-
-      // RSR forwarded
-      expect(await rsr.balanceOf(stRSR.address)).to.equal(hndAmt.add(hndAmt.div(2)))
-      expect(await rsr.balanceOf(backingManager.address)).to.equal(0)
-      expect(await rsr.balanceOf(rsrTrader.address)).to.equal(0)
-    })
-
-    it('Should not revert if f=0', async () => {
-      await distributor.connect(owner).setDistribution(STRSR_DEST, { rTokenDist: 0, rsrDist: 0 })
-      // Transfer free tokens to RTokenTrader
-      const hndAmt: BigNumber = bn('10e18')
-      await rsr.connect(addr1).transfer(rsrTrader.address, hndAmt)
-
-      let [addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(ZERO_ADDRESS)
-      expect(data).to.equal('0x')
-
-      // RToken can be distributed with no issues
-      await rToken.connect(addr1).transfer(backingManager.address, hndAmt)
-      ;[addr, data] = await facadeAct.callStatic.getActCalldata(rToken.address)
-      expect(addr).to.equal(backingManager.address)
-      expect(data).to.not.equal('0x')
-
-      expect(await rToken.balanceOf(backingManager.address)).to.equal(hndAmt)
-      expect(await rToken.balanceOf(rTokenTrader.address)).to.equal(0)
-
-      // Execute managetokens in Backing Manager
-      await addr1.sendTransaction({
-        to: addr,
-        data,
-      })
-
-      // RToken forwarded
-      expect(await rToken.balanceOf(backingManager.address)).to.equal(0)
-      expect(await rToken.balanceOf(rTokenTrader.address)).to.equal(hndAmt)
     })
   })
 


### PR DESCRIPTION
Proposed pattern of use:
1. `Run Recollateralization Auctions` button
  (i) First: call `FacadeRead.auctionsSettleable(backingManager)`. If return array contains an entry (it will never contain more than 1), then there is a settlement action to be taken on the backingManager. 
  (ii) Second (can be done in parallel): call `FacadeAct.canRunRecollateralizationAuctions(backingManager)`. If it returns true, then `backingManager.manageTokensSortedOrder([])` can be called productively.
  (iii) If both (i) and (ii) returned values, we'll need to package these up via a multicall. See: `backingManager.multicall()`. Otherwise, can call `settleTrade(erc20)` or `manageTokensSortedOrder([])` in isolation.

2. `Run RSR Revenue Auctions` button
  (i) First: call `FacadeRead.auctionsSettleable(rsrTrader)`. Save list of ERC20s
  (ii) Second (can be done in parallel): call `FacadeAct.getRevenueAuctionERC20s(rsrTrader)`. Save list of ERC20s
  (iii) If _either_ of the two ERC20 lists are non-empty, then `FacadeAct.runRevenueAuctions` can be called. No Multicall required here. 

(and the same would apply for the `Run RToken Revenue Auctions` button)

