### PR TITLE
expose StRSR.draftRSR/stakeRSR/totalDrafts

### DIFF
--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -465,6 +465,21 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
         return draftQueues[era_][account].length;
     }
 
+    /// @return {qDrafts} The amount of RSR currently being withdrawn
+    function getDraftRSR() external view returns (uint256) {
+        return draftRSR;
+    }
+
+    /// @return {qRSR} The amount of RSR currently being staked and earning rewards
+    function getStakeRSR() external view returns (uint256) {
+        return stakeRSR;
+    }
+
+    /// @return {qDrafts} The amount of StRSR currently being withdrawn
+    function getTotalDrafts() external view returns (uint256) {
+        return totalDrafts;
+    }
+
     // ==== Internal Functions ====
 
     /// Assign reward payouts to the staker pool

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -1029,6 +1029,26 @@ describeExtreme(`StRSRP${IMPLEMENTATION} contract`, () => {
         // Exchange rate remains steady
         expect(await stRSR.exchangeRate()).to.equal(fp('1'))
       })
+
+      describeP1('Should be able to view staking/withdrawal quantities', () => {
+        let stRSRP1: StRSRP1Votes
+
+        beforeEach(async () => {
+          stRSRP1 = await ethers.getContractAt('StRSRP1Votes', stRSR.address)
+        })
+
+        it('Should read draftRSR', async () => {
+          expect(await stRSRP1.getDraftRSR()).to.equal(amount1)
+        })
+
+        it('Should read stakeRSR', async () => {
+          expect(await stRSRP1.getStakeRSR()).to.equal(amount2.add(amount3))
+        })
+
+        it('Should read totalDrafts', async () => {
+          expect(await stRSRP1.getTotalDrafts()).to.equal(amount1)
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Turns out it's not possible to view the amount of RSR (or StRSR) being withdrawn. We definitely want to expose this. I've implemented it in a way that obviously safe and doesn't touch storage. `StRSRP1Votes` remains well under the contract limit. 

Closes #727