### PR TITLE
give collateral plugins 3 oracles by default.

### DIFF
--- a/contracts/plugins/assets/EURFiatCollateral.sol
+++ b/contracts/plugins/assets/EURFiatCollateral.sol
@@ -14,21 +14,14 @@ contract EURFiatCollateral is FiatCollateral {
     using FixLib for uint192;
     using OracleLib for AggregatorV3Interface;
 
-    AggregatorV3Interface public immutable targetUnitChainlinkFeed; // {UoA/target}
-    uint48 public immutable targetUnitOracleTimeout; // {s}
-
     /// @param config.chainlinkFeed Feed units:{UoA/ref}
-    /// @param targetUnitChainlinkFeed_ Feed units: {UoA/target}
-    /// @param targetUnitOracleTimeout_ {s} oracle timeout to use for targetUnitChainlinkFeed
+    /// @param config.chainlinkFeedAlt1 Feed units: {UoA/target}
+    /// @param config.chainlinkFeedAlt1Timeout {s} oracle timeout to use for chainlinkFeedAlt1
     constructor(
-        CollateralConfig memory config,
-        AggregatorV3Interface targetUnitChainlinkFeed_,
-        uint48 targetUnitOracleTimeout_
+        CollateralConfig memory config
     ) FiatCollateral(config) {
-        require(address(targetUnitChainlinkFeed_) != address(0), "missing targetUnit feed");
-        require(targetUnitOracleTimeout_ > 0, "targetUnitOracleTimeout zero");
-        targetUnitChainlinkFeed = targetUnitChainlinkFeed_;
-        targetUnitOracleTimeout = targetUnitOracleTimeout_;
+        require(address(config.chainlinkFeedAlt1) != address(0), "missing targetUnit feed");
+        require(config.chainlinkFeedAlt1Timeout > 0, "chainlinkFeedAlt1Timeout zero");
     }
 
     /// Can revert, used by other contract functions in order to catch errors
@@ -48,7 +41,7 @@ contract EURFiatCollateral is FiatCollateral {
         uint192 refPrice = chainlinkFeed.price(oracleTimeout); // {UoA/ref}
 
         // {UoA/target}
-        uint192 pricePerTarget = targetUnitChainlinkFeed.price(targetUnitOracleTimeout);
+        uint192 pricePerTarget = chainlinkFeedAlt1.price(chainlinkFeedAlt1Timeout);
 
         // div-by-zero later
         if (pricePerTarget == 0) {

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -20,6 +20,10 @@ struct CollateralConfig {
     uint192 defaultThreshold; // {1} A value like 0.05 that represents a deviation tolerance
     // set defaultThreshold to zero to create SelfReferentialCollateral
     uint48 delayUntilDefault; // {s} The number of seconds an oracle can mulfunction
+    AggregatorV3Interface chainlinkFeedAlt1; // additional chainlink feed (could be 0x0)
+    uint48 chainlinkFeedAlt1Timeout; // {s}
+    AggregatorV3Interface chainlinkFeedAlt2; // additional chainlink feed (could be 0x0)
+    uint48 chainlinkFeedAlt2Timeout; // {s}
 }
 
 /**
@@ -58,6 +62,14 @@ contract FiatCollateral is ICollateral, Asset {
 
     uint192 public immutable pegTop; // {target/ref} The top of the peg
 
+    AggregatorV3Interface public immutable chainlinkFeedAlt1; // 1st additional chainlink feed
+
+    uint48 public immutable chainlinkFeedAlt1Timeout; // {s}
+
+    AggregatorV3Interface public immutable chainlinkFeedAlt2; // 2nd additional chainlink feed
+
+    uint48 public immutable chainlinkFeedAlt2Timeout; // {s}
+
     /// @param config.chainlinkFeed Feed units: {UoA/ref}
     constructor(CollateralConfig memory config)
         Asset(
@@ -77,6 +89,11 @@ contract FiatCollateral is ICollateral, Asset {
 
         targetName = config.targetName;
         delayUntilDefault = config.delayUntilDefault;
+
+        chainlinkFeedAlt1 = config.chainlinkFeedAlt1;
+        chainlinkFeedAlt1Timeout = config.chainlinkFeedAlt1Timeout;
+        chainlinkFeedAlt2 = config.chainlinkFeedAlt2;
+        chainlinkFeedAlt2Timeout = config.chainlinkFeedAlt2Timeout;
 
         // Cache constants
         uint192 peg = targetPerRef(); // {target/ref}

--- a/contracts/plugins/assets/NonFiatCollateral.sol
+++ b/contracts/plugins/assets/NonFiatCollateral.sol
@@ -14,21 +14,14 @@ contract NonFiatCollateral is FiatCollateral {
     using FixLib for uint192;
     using OracleLib for AggregatorV3Interface;
 
-    AggregatorV3Interface public immutable targetUnitChainlinkFeed; // {UoA/target}
-    uint48 public immutable targetUnitOracleTimeout; // {s}
-
     /// @param config.chainlinkFeed Feed units: {target/ref}
-    /// @param targetUnitChainlinkFeed_ Feed units: {UoA/target}
-    /// @param targetUnitOracleTimeout_ {s} oracle timeout to use for targetUnitChainlinkFeed
+    /// @param config.chainlinkFeedAlt1 Feed units: {UoA/target}
+    /// @param config.chainlinkFeedAlt1Timeout {s} oracle timeout to use for chainlinkFeedAlt1
     constructor(
-        CollateralConfig memory config,
-        AggregatorV3Interface targetUnitChainlinkFeed_,
-        uint48 targetUnitOracleTimeout_
+        CollateralConfig memory config
     ) FiatCollateral(config) {
-        require(address(targetUnitChainlinkFeed_) != address(0), "missing targetUnit feed");
-        require(targetUnitOracleTimeout_ > 0, "targetUnitOracleTimeout zero");
-        targetUnitChainlinkFeed = targetUnitChainlinkFeed_;
-        targetUnitOracleTimeout = targetUnitOracleTimeout_;
+        require(address(config.chainlinkFeedAlt1) != address(0), "missing targetUnit feed");
+        require(config.chainlinkFeedAlt1Timeout > 0, "chainlinkFeedAlt1Timeout zero");
     }
 
     /// Can revert, used by other contract functions in order to catch errors
@@ -48,7 +41,7 @@ contract NonFiatCollateral is FiatCollateral {
         pegPrice = chainlinkFeed.price(oracleTimeout); // {target/ref}
 
         // {UoA/target}
-        uint192 pricePerTarget = targetUnitChainlinkFeed.price(targetUnitOracleTimeout);
+        uint192 pricePerTarget = chainlinkFeedAlt1.price(chainlinkFeedAlt1Timeout);
 
         // Assumption: {ref/tok} = 1; inherit from `AppreciatingFiatCollateral` if need appreciation
         // {UoA/tok} = {UoA/target} * {ref/tok} * {target/ref} (1)

--- a/contracts/plugins/assets/compoundv2/CTokenNonFiatCollateral.sol
+++ b/contracts/plugins/assets/compoundv2/CTokenNonFiatCollateral.sol
@@ -15,25 +15,16 @@ contract CTokenNonFiatCollateral is CTokenFiatCollateral {
     using FixLib for uint192;
     using OracleLib for AggregatorV3Interface;
 
-    AggregatorV3Interface public immutable targetUnitChainlinkFeed; // {UoA/target}
-    uint48 public immutable targetUnitOracleTimeout; // {s}
-
     /// @param config.chainlinkFeed Feed units: {target/ref}
-    /// @param targetUnitChainlinkFeed_ Feed units: {UoA/target}
-    /// @param targetUnitOracleTimeout_ {s} oracle timeout to use for targetUnitChainlinkFeed
     /// @param revenueHiding {1} A value like 1e-6 that represents the maximum refPerTok to hide
     /// @param comptroller_ The CompoundFinance Comptroller
     constructor(
         CollateralConfig memory config,
-        AggregatorV3Interface targetUnitChainlinkFeed_,
-        uint48 targetUnitOracleTimeout_,
         uint192 revenueHiding,
         IComptroller comptroller_
     ) CTokenFiatCollateral(config, revenueHiding, comptroller_) {
-        require(address(targetUnitChainlinkFeed_) != address(0), "missing targetUnit feed");
-        require(targetUnitOracleTimeout_ > 0, "targetUnitOracleTimeout zero");
-        targetUnitChainlinkFeed = targetUnitChainlinkFeed_;
-        targetUnitOracleTimeout = targetUnitOracleTimeout_;
+        require(address(config.chainlinkFeedAlt1) != address(0), "missing targetUnit feed");
+        require(config.chainlinkFeedAlt1Timeout > 0, "chainlinkFeedAlt1Timeout zero");
     }
 
     /// Can revert, used by other contract functions in order to catch errors
@@ -53,7 +44,7 @@ contract CTokenNonFiatCollateral is CTokenFiatCollateral {
         pegPrice = chainlinkFeed.price(oracleTimeout); // {target/ref}
 
         // {UoA/target}
-        uint192 pricePerTarget = targetUnitChainlinkFeed.price(targetUnitOracleTimeout);
+        uint192 pricePerTarget = chainlinkFeedAlt1.price(chainlinkFeedAlt1Timeout);
 
         // {UoA/tok} = {UoA/target} * {target/ref} * {ref/tok}
         uint192 pLow = pricePerTarget.mul(pegPrice).mul(refPerTok());

--- a/contracts/plugins/assets/rocket-eth/RethCollateral.sol
+++ b/contracts/plugins/assets/rocket-eth/RethCollateral.sol
@@ -19,19 +19,12 @@ contract RethCollateral is AppreciatingFiatCollateral {
     using OracleLib for AggregatorV3Interface;
     using FixLib for uint192;
 
-    AggregatorV3Interface public immutable refPerTokChainlinkFeed;
-    uint48 public immutable refPerTokChainlinkTimeout;
-
     constructor(
         CollateralConfig memory config,
-        uint192 revenueHiding,
-        AggregatorV3Interface _refPerTokChainlinkFeed,
-        uint48 _refPerTokChainlinkTimeout
+        uint192 revenueHiding
     ) AppreciatingFiatCollateral(config, revenueHiding) {
-        require(address(_refPerTokChainlinkFeed) != address(0), "missing refPerTok feed");
-        require(_refPerTokChainlinkTimeout != 0, "refPerTokChainlinkTimeout zero");
-        refPerTokChainlinkFeed = _refPerTokChainlinkFeed;
-        refPerTokChainlinkTimeout = _refPerTokChainlinkTimeout;
+        require(address(config.chainlinkFeedAlt1) != address(0), "missing refPerTok feed");
+        require(config.chainlinkFeedAlt1Timeout != 0, "chainlinkFeedAlt1Timeout zero");
     }
 
     /// Can revert, used by other contract functions in order to catch errors
@@ -54,7 +47,7 @@ contract RethCollateral is AppreciatingFiatCollateral {
         uint192 p = chainlinkFeed.price(oracleTimeout); // target==ref :: {UoA/target} == {UoA/ref}
 
         // {ref/tok}
-        uint192 refPerTok = refPerTokChainlinkFeed.price(refPerTokChainlinkTimeout);
+        uint192 refPerTok = chainlinkFeedAlt1.price(chainlinkFeedAlt1Timeout);
 
         // {UoA/tok} = {UoA/ref} * {ref/tok}
         uint192 pHigh = p.mul(refPerTok);


### PR DESCRIPTION
This pr adds the concept of 2 additional oracles to ALL collaterals that inherit FiatCollateral.

The reason for this is to allow for testing (namely, integration scripts and fork testing scripts like the WIP upgrade-checker.ts) to programmatically push any and all oracles forward so that collaterals do not become `DISABLED` when the timestamp of the chain gets pushed forward to do things like pass governance proposals or realize revenue.