### PR TITLE
Feat/warmup period

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -3,6 +3,7 @@
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": "error",
+    "max-states-count": ["warn", 20],
     "max-line-length": ["error", 100],
     "func-param-name-mixedcase": "error",
     "modifier-name-mixedcase": "error",

--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -315,6 +315,7 @@ export interface IConfig {
   longFreeze: BigNumber
   rewardRatio: BigNumber
   unstakingDelay: BigNumber
+  warmupPeriod: BigNumber
   tradingDelay: BigNumber
   auctionLength: BigNumber
   backingBuffer: BigNumber
@@ -400,6 +401,7 @@ export const MAX_THROTTLE_PCT_RATE = BigNumber.from(10).pow(18)
 // Timestamps
 export const MAX_ORACLE_TIMEOUT = BigNumber.from(2).pow(48).sub(1)
 export const MAX_TRADING_DELAY = 31536000 // 1 year
+export const MAX_WARMUP_PERIOD = 31536000 // 1 year
 export const MAX_AUCTION_LENGTH = 604800 // 1 week
 export const MAX_UNSTAKING_DELAY = 31536000 // 1 year
 export const MAX_DELAY_UNTIL_DEFAULT = 1209600 // 2 weeks

--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -401,6 +401,7 @@ export const MAX_THROTTLE_PCT_RATE = BigNumber.from(10).pow(18)
 // Timestamps
 export const MAX_ORACLE_TIMEOUT = BigNumber.from(2).pow(48).sub(1)
 export const MAX_TRADING_DELAY = 31536000 // 1 year
+export const MIN_WARMUP_PERIOD = 60 // 1 minute
 export const MAX_WARMUP_PERIOD = 31536000 // 1 year
 export const MAX_AUCTION_LENGTH = 604800 // 1 week
 export const MAX_UNSTAKING_DELAY = 31536000 // 1 year

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -17,7 +17,14 @@ import "./ITrading.sol";
  *   vast majority of cases we expect the the O(n^2) function to be acceptable.
  */
 interface IBackingManager is IComponent, ITrading {
+    /// Emitted when the trading delay is changed
+    /// @param oldVal The old trading delay
+    /// @param newVal The new trading delay
     event TradingDelaySet(uint48 indexed oldVal, uint48 indexed newVal);
+
+    /// Emitted when the backing buffer is changed
+    /// @param oldVal The old backing buffer
+    /// @param newVal The new backing buffer
     event BackingBufferSet(uint192 indexed oldVal, uint192 indexed newVal);
 
     // Initialization

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -82,14 +82,15 @@ interface IBasketHandler is IComponent {
     /// @custom:interaction
     function refreshBasket() external;
 
+    /// Track the basket status changes
+    /// @custom:refresher
+    function trackStatus() external;
+
     /// @return If the BackingManager has sufficient collateral to redeem the entire RToken supply
     function fullyCollateralized() external view returns (bool);
 
     /// @return status The worst CollateralStatus of all collateral in the basket
     function status() external view returns (CollateralStatus status);
-
-    /// Track the basket status changes
-    function trackStatus() external;
 
     /// @return If the basket is ready to issue and trade
     function isReady() external view returns (bool);

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -38,8 +38,21 @@ interface IBasketHandler is IComponent {
     /// @param erc20s The set of backup collateral tokens
     event BackupConfigSet(bytes32 indexed targetName, uint256 indexed max, IERC20[] erc20s);
 
+    /// Emitted when the warmup period is changed
+    /// @param oldVal The old warmup period
+    /// @param newVal The new warmup period
+    event WarmupPeriodSet(uint48 indexed oldVal, uint48 indexed newVal);
+
+    /// Emitted when the status of a basket has changed
+    /// @param oldStatus The previous basket status
+    /// @param newStatus The new basket status
+    event BasketStatusChanged(
+        CollateralStatus indexed oldStatus,
+        CollateralStatus indexed newStatus
+    );
+
     // Initialization
-    function init(IMain main_) external;
+    function init(IMain main_, uint48 warmupPeriod_) external;
 
     /// Set the prime basket
     /// @param erc20s The collateral tokens for the new prime basket
@@ -74,6 +87,13 @@ interface IBasketHandler is IComponent {
 
     /// @return status The worst CollateralStatus of all collateral in the basket
     function status() external view returns (CollateralStatus status);
+
+    /// Track the basket status changes
+    /// @custom:protected
+    function trackStatus() external;
+
+    /// @return If the basket is ready to issue and trade
+    function isReady() external view returns (bool);
 
     /// @param erc20 The ERC20 token contract for the asset
     /// @return {tok/BU} The whole token quantity of token in the reference basket
@@ -119,4 +139,10 @@ interface IBasketHandler is IComponent {
 
     /// @return The current basket nonce, regardless of status
     function nonce() external view returns (uint48);
+}
+
+interface TestIBasketHandler is IBasketHandler {
+    function warmupPeriod() external view returns (uint48);
+
+    function setWarmupPeriod(uint48 val) external;
 }

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -89,7 +89,6 @@ interface IBasketHandler is IComponent {
     function status() external view returns (CollateralStatus status);
 
     /// Track the basket status changes
-    /// @custom:protected
     function trackStatus() external;
 
     /// @return If the basket is ready to issue and trade

--- a/contracts/interfaces/IDeployer.sol
+++ b/contracts/interfaces/IDeployer.sol
@@ -35,6 +35,9 @@ struct DeploymentParams {
     // === StRSR ===
     uint48 unstakingDelay; // {s} the "thawing time" of staked RSR before withdrawal
     //
+    // === BasketHandler ===
+    uint48 warmupPeriod; // {s} how long to wait until issuance/trading after regaining SOUND
+    //
     // === BackingManager ===
     uint48 tradingDelay; // {s} how long to wait until starting auctions after switching basket
     uint48 auctionLength; // {s} the length of an auction

--- a/contracts/p0/AssetRegistry.sol
+++ b/contracts/p0/AssetRegistry.sol
@@ -27,13 +27,16 @@ contract AssetRegistryP0 is ComponentP0, IAssetRegistry {
         }
     }
 
-    /// Force updates in all collateral assets
+    /// Force updates in all collateral assets. Tracks basket status.
     /// @custom:refresher
     function refresh() public {
         // It's a waste of gas to require notPausedOrFrozen because assets can be updated directly
         for (uint256 i = 0; i < _erc20s.length(); i++) {
             assets[IERC20(_erc20s.at(i))].refresh();
         }
+
+        IBasketHandler basketHandler = main.basketHandler();
+        basketHandler.trackStatus();
     }
 
     /// Forbids registering a different asset for an ERC20 that is already registered

--- a/contracts/p0/AssetRegistry.sol
+++ b/contracts/p0/AssetRegistry.sol
@@ -27,7 +27,7 @@ contract AssetRegistryP0 is ComponentP0, IAssetRegistry {
         }
     }
 
-    /// Force updates in all collateral assets. Tracks basket status.
+    /// Force updates in all collateral assets. Track basket status.
     /// @custom:refresher
     function refresh() public {
         // It's a waste of gas to require notPausedOrFrozen because assets can be updated directly

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -72,8 +72,8 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
 
         if (tradesOpen > 0) return;
 
-        // Do not trade when not SOUND
-        require(main.basketHandler().status() == CollateralStatus.SOUND, "basket not sound");
+        // Ensure basket is ready, SOUND and not in warmup period
+        require(main.basketHandler().isReady(), "basket not ready");
 
         uint48 basketTimestamp = main.basketHandler().timestamp();
         if (block.timestamp < basketTimestamp + tradingDelay) return;

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -76,7 +76,7 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
         require(main.basketHandler().isReady(), "basket not ready");
 
         uint48 basketTimestamp = main.basketHandler().timestamp();
-        if (block.timestamp < basketTimestamp + tradingDelay) return;
+        require(block.timestamp >= basketTimestamp + tradingDelay, "trading delayed");
 
         BasketRange memory basketsHeld = main.basketHandler().basketsHeldBy(address(this));
 

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -709,11 +709,4 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             return false;
         }
     }
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[47] private __gap;
 }

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -136,8 +136,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
     // basket status changes, mainly set when `trackStatus()` is called
     // used to enforce warmup period, after regaining SOUND
-    CollateralStatus private lastStatus;
     uint48 private lastStatusTimestamp;
+    CollateralStatus private lastStatus;
 
     // ==== Invariants ====
     // basket is a valid Basket:

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -109,6 +109,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using FixLib for uint192;
 
+    uint48 public constant MIN_WARMUP_PERIOD = 60; // {s} 1 minute
     uint48 public constant MAX_WARMUP_PERIOD = 31536000; // {s} 1 year
     uint192 public constant MAX_TARGET_AMT = 1e3 * FIX_ONE; // {target/BU} max basket weight
 
@@ -491,7 +492,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
     /// @custom:governance
     function setWarmupPeriod(uint48 val) public governance {
-        require(val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
+        require(val >= MIN_WARMUP_PERIOD && val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
         emit WarmupPeriodSet(warmupPeriod, val);
         warmupPeriod = val;
     }

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -199,6 +199,18 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         trackStatus();
     }
 
+    /// Track basket status changes if they ocurred
+    // effects: lastStatus' = status(), and lastStatusTimestamp' = current timestamp
+    /// @custom:refresher
+    function trackStatus() public {
+        CollateralStatus currentStatus = status();
+        if (currentStatus != lastStatus) {
+            emit BasketStatusChanged(lastStatus, currentStatus);
+            lastStatus = currentStatus;
+            lastStatusTimestamp = uint48(block.timestamp);
+        }
+    }
+
     /// Set the prime basket in the basket configuration, in terms of erc20s and target amounts
     /// @param erc20s The collateral for the new prime basket
     /// @param targetAmts The target amounts (in) {target/BU} for the new prime basket
@@ -295,17 +307,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         for (uint256 i = 0; i < size; ++i) {
             CollateralStatus s = main.assetRegistry().toColl(basket.erc20s[i]).status();
             if (s.worseThan(status_)) status_ = s;
-        }
-    }
-
-    /// Track basket status changes if they ocurred
-    // effects: lastStatus' = status(), and lastStatusTimestamp' = current timestamp
-    function trackStatus() public {
-        CollateralStatus currentStatus = status();
-        if (currentStatus != lastStatus) {
-            emit BasketStatusChanged(lastStatus, currentStatus);
-            lastStatus = currentStatus;
-            lastStatusTimestamp = uint48(block.timestamp);
         }
     }
 

--- a/contracts/p0/Deployer.sol
+++ b/contracts/p0/Deployer.sol
@@ -93,7 +93,7 @@ contract DeployerP0 is IDeployer, Versioned {
         );
 
         // Init Basket Handler
-        main.basketHandler().init(main);
+        main.basketHandler().init(main, params.warmupPeriod);
 
         // Init Revenue Traders
         main.rsrTrader().init(main, rsr, params.maxTradeSlippage, params.minTradeVolume);

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -101,8 +101,9 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         // Call collective state keepers.
         main.poke();
 
+        // Ensure basket is ready, SOUND and not in warmup period
         IBasketHandler basketHandler = main.basketHandler();
-        require(basketHandler.status() == CollateralStatus.SOUND, "basket unsound");
+        require(basketHandler.isReady(), "basket not ready");
 
         // Revert if issuance exceeds either supply throttle
         issuanceThrottle.useAvailable(totalSupply(), int256(amount)); // reverts on over-issuance

--- a/contracts/p1/AssetRegistry.sol
+++ b/contracts/p1/AssetRegistry.sol
@@ -46,13 +46,17 @@ contract AssetRegistryP1 is ComponentP1, IAssetRegistry {
 
     /// Update the state of all assets
     /// @custom:refresher
-    // actions: calls refresh(c) for c in keys(assets) when c.isCollateral()
+    // actions:
+    //   calls refresh(c) for c in keys(assets) when c.isCollateral()
+    //   tracks basket status on basketHandler
     function refresh() public {
         // It's a waste of gas to require notPausedOrFrozen because assets can be updated directly
         uint256 length = _erc20s.length();
         for (uint256 i = 0; i < length; ++i) {
             assets[IERC20(_erc20s.at(i))].refresh();
         }
+
+        basketHandler.trackStatus();
     }
 
     /// Register `asset`

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -107,8 +107,9 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         assetRegistry.refresh();
 
         if (tradesOpen > 0) return;
-        // Only trade when all the collateral assets in the basket are SOUND
-        require(basketHandler.status() == CollateralStatus.SOUND, "basket not sound");
+
+        // Ensure basket is ready, SOUND and not in warmup period
+        require(basketHandler.isReady(), "basket not ready");
 
         uint48 basketTimestamp = basketHandler.timestamp();
         if (block.timestamp < basketTimestamp + tradingDelay) return;

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -112,7 +112,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         require(basketHandler.isReady(), "basket not ready");
 
         uint48 basketTimestamp = basketHandler.timestamp();
-        if (block.timestamp < basketTimestamp + tradingDelay) return;
+        require(block.timestamp >= basketTimestamp + tradingDelay, "trading delayed");
 
         BasketRange memory basketsHeld = basketHandler.basketsHeldBy(address(this));
         uint192 basketsNeeded = rToken.basketsNeeded(); // {BU}

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -115,6 +115,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     using FixLib for uint192;
 
     uint192 public constant MAX_TARGET_AMT = 1e3 * FIX_ONE; // {target/BU} max basket weight
+    uint48 public constant MAX_WARMUP_PERIOD = 31536000; // {s} 1 year
 
     // Peer components
     IAssetRegistry private assetRegistry;
@@ -138,6 +139,19 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     // and everything except redemption should be paused.
     bool private disabled;
 
+    // These are effectively local variables of _switchBasket.
+    // Nothing should use their values from previous transactions.
+    EnumerableSet.Bytes32Set private _targetNames;
+    Basket private _newBasket; // Always empty
+
+    // Warmup Period
+    uint48 public warmupPeriod; // {s} how long to wait until issuance/trading after regaining SOUND
+
+    // basket status changes, mainly set when `trackStatus()` is called
+    // used to enforce warmup period, after regaining SOUND
+    CollateralStatus private lastStatus;
+    uint48 private lastStatusTimestamp;
+
     // ==== Invariants ====
     // basket is a valid Basket:
     //   basket.erc20s is a valid collateral array and basket.erc20s == keys(basket.refAmts)
@@ -148,7 +162,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     // if basket.erc20s is empty then disabled == true
 
     // BasketHandler.init() just leaves the BasketHandler state zeroed
-    function init(IMain main_) external initializer {
+    function init(IMain main_, uint48 warmupPeriod_) external initializer {
         __Component_init(main_);
 
         assetRegistry = main_.assetRegistry();
@@ -156,6 +170,12 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         rsr = main_.rsr();
         rToken = main_.rToken();
         stRSR = main_.stRSR();
+
+        setWarmupPeriod(warmupPeriod_);
+
+        // Set last status to DISABLED (default)
+        lastStatus = CollateralStatus.DISABLED;
+        lastStatusTimestamp = uint48(block.timestamp);
 
         disabled = true;
     }
@@ -192,6 +212,8 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             "basket unrefreshable"
         );
         _switchBasket();
+
+        trackStatus();
     }
 
     /// Set the prime basket in the basket configuration, in terms of erc20s and target amounts
@@ -291,6 +313,24 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             CollateralStatus s = assetRegistry.toColl(basket.erc20s[i]).status();
             if (s.worseThan(status_)) status_ = s;
         }
+    }
+
+    /// Track basket status changes if they ocurred
+    // effects: lastStatus' = status(), and lastStatusTimestamp' = current timestamp
+    function trackStatus() public {
+        CollateralStatus currentStatus = status();
+        if (currentStatus != lastStatus) {
+            emit BasketStatusChanged(lastStatus, currentStatus);
+            lastStatus = currentStatus;
+            lastStatusTimestamp = uint48(block.timestamp);
+        }
+    }
+
+    /// @return Whether the basket is ready to issue and trade
+    function isReady() external view returns (bool) {
+        return
+            status() == CollateralStatus.SOUND &&
+            (block.timestamp >= lastStatusTimestamp + warmupPeriod);
     }
 
     /// @param erc20 The token contract to check for quantity for
@@ -481,6 +521,15 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         }
     }
 
+    // === Governance Setters ===
+
+    /// @custom:governance
+    function setWarmupPeriod(uint48 val) public governance {
+        require(val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
+        emit WarmupPeriodSet(warmupPeriod, val);
+        warmupPeriod = val;
+    }
+
     // === Private ===
 
     /* _switchBasket computes basket' from three inputs:
@@ -537,11 +586,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
          nonce' = nonce + 1
          timestamp' = now
     */
-
-    // These are effectively local variables of _switchBasket.
-    // Nothing should use their values from previous transactions.
-    EnumerableSet.Bytes32Set private _targetNames;
-    Basket private _newBasket; // Always empty
 
     /// Select and save the next basket, based on the BasketConfig and Collateral statuses
     /// (The mutator that actually does all the work in this contract.)
@@ -764,5 +808,5 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[42] private __gap;
+    uint256[41] private __gap;
 }

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -149,8 +149,8 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
     // basket status changes, mainly set when `trackStatus()` is called
     // used to enforce warmup period, after regaining SOUND
-    CollateralStatus private lastStatus;
     uint48 private lastStatusTimestamp;
+    CollateralStatus private lastStatus;
 
     // ==== Invariants ====
     // basket is a valid Basket:

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -115,6 +115,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     using FixLib for uint192;
 
     uint192 public constant MAX_TARGET_AMT = 1e3 * FIX_ONE; // {target/BU} max basket weight
+    uint48 public constant MIN_WARMUP_PERIOD = 60; // {s} 1 minute
     uint48 public constant MAX_WARMUP_PERIOD = 31536000; // {s} 1 year
 
     // Peer components
@@ -525,7 +526,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
     /// @custom:governance
     function setWarmupPeriod(uint48 val) public governance {
-        require(val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
+        require(val >= MIN_WARMUP_PERIOD && val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
         emit WarmupPeriodSet(warmupPeriod, val);
         warmupPeriod = val;
     }

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -217,6 +217,18 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         trackStatus();
     }
 
+    /// Track basket status changes if they ocurred
+    // effects: lastStatus' = status(), and lastStatusTimestamp' = current timestamp
+    /// @custom:refresher
+    function trackStatus() public {
+        CollateralStatus currentStatus = status();
+        if (currentStatus != lastStatus) {
+            emit BasketStatusChanged(lastStatus, currentStatus);
+            lastStatus = currentStatus;
+            lastStatusTimestamp = uint48(block.timestamp);
+        }
+    }
+
     /// Set the prime basket in the basket configuration, in terms of erc20s and target amounts
     /// @param erc20s The collateral for the new prime basket
     /// @param targetAmts The target amounts (in) {target/BU} for the new prime basket
@@ -313,17 +325,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         for (uint256 i = 0; i < size; ++i) {
             CollateralStatus s = assetRegistry.toColl(basket.erc20s[i]).status();
             if (s.worseThan(status_)) status_ = s;
-        }
-    }
-
-    /// Track basket status changes if they ocurred
-    // effects: lastStatus' = status(), and lastStatusTimestamp' = current timestamp
-    function trackStatus() public {
-        CollateralStatus currentStatus = status();
-        if (currentStatus != lastStatus) {
-            emit BasketStatusChanged(lastStatus, currentStatus);
-            lastStatus = currentStatus;
-            lastStatusTimestamp = uint48(block.timestamp);
         }
     }
 

--- a/contracts/p1/Deployer.sol
+++ b/contracts/p1/Deployer.sol
@@ -182,7 +182,7 @@ contract DeployerP1 is IDeployer, Versioned {
         );
 
         // Init Basket Handler
-        components.basketHandler.init(main);
+        components.basketHandler.init(main, params.warmupPeriod);
 
         // Init Revenue Traders
         components.rsrTrader.init(main, rsr, params.maxTradeSlippage, params.minTradeVolume);

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -129,8 +129,8 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
         // == Checks-effects block ==
         address issuer = _msgSender(); // OK to save: it can't be changed in reentrant runs
 
-        // Ensure SOUND basket
-        require(basketHandler.status() == CollateralStatus.SOUND, "basket unsound");
+        // Ensure basket is ready, SOUND and not in warmup period
+        require(basketHandler.isReady(), "basket not ready");
 
         furnace.melt();
         uint256 supply = totalSupply();

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -207,6 +207,15 @@ The trading delay is how many seconds should pass after the basket has been chan
 Default value: `7200` = 2 hours
 Mainnet reasonable range: 0 to 604800
 
+### `warmupPeriod`
+
+Dimension: `{seconds}`
+
+The warmup period is how many seconds should pass after the basket regained the SOUND status before an RToken can be issued and/or a trade can be opened.
+
+Default value: `900` = 15 minutes
+Mainnet reasonable range: 0 to 604800
+
 ### `auctionLength`
 
 Dimension: `{seconds}`

--- a/test/Deployer.test.ts
+++ b/test/Deployer.test.ts
@@ -12,9 +12,9 @@ import {
   FacadeRead,
   GnosisMock,
   IAssetRegistry,
-  IBasketHandler,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDeployer,
   TestIDistributor,
@@ -58,7 +58,7 @@ describe(`DeployerP${IMPLEMENTATION} contract #fast`, () => {
   let main: TestIMain
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let distributor: TestIDistributor
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader

--- a/test/FacadeAct.test.ts
+++ b/test/FacadeAct.test.ts
@@ -26,11 +26,11 @@ import {
   FiatCollateral,
   GnosisMock,
   IAssetRegistry,
-  IBasketHandler,
   InvalidATokenFiatCollateralMock,
   MockV3Aggregator,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIDistributor,
   TestIRevenueTrader,
   TestIRToken,
@@ -93,7 +93,7 @@ describe('FacadeAct contract', () => {
   // Main
   let rToken: TestIRToken
   let stRSR: TestIStRSR
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let distributor: TestIDistributor

--- a/test/FacadeMonitor.ts
+++ b/test/FacadeMonitor.ts
@@ -23,9 +23,9 @@ import {
   FacadeAct,
   FiatCollateral,
   GnosisMock,
-  IBasketHandler,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIDistributor,
   TestIRevenueTrader,
   TestIRToken,
@@ -71,7 +71,7 @@ describe('FacadeMonitor Contract', () => {
 
   // Main
   let rToken: TestIRToken
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let backingManager: TestIBackingManager
   let distributor: TestIDistributor
   let gnosis: GnosisMock

--- a/test/FacadeRead.test.ts
+++ b/test/FacadeRead.test.ts
@@ -14,7 +14,7 @@ import {
   MockV3Aggregator,
   StaticATokenMock,
   StRSRP1,
-  IBasketHandler,
+  TestIBasketHandler,
   TestIMain,
   TestIStRSR,
   TestIRToken,
@@ -59,7 +59,7 @@ describe('FacadeRead contract', () => {
   let rToken: TestIRToken
   let main: TestIMain
   let stRSR: TestIStRSR
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   // RSR
   let rsrAsset: Asset

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -30,7 +30,6 @@ import {
   CTokenFiatCollateral,
   CTokenMock,
   ERC20Mock,
-  IBasketHandler,
   FacadeRead,
   FacadeTest,
   FacadeWrite,
@@ -39,6 +38,7 @@ import {
   IAssetRegistry,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDeployer,
   TestIDistributor,
@@ -109,7 +109,7 @@ describe('FacadeWrite contract', () => {
   let main: TestIMain
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let broker: TestIBroker
   let distributor: TestIDistributor
   let furnace: TestIFurnace
@@ -301,8 +301,8 @@ describe('FacadeWrite contract', () => {
       backingManager = <TestIBackingManager>(
         await ethers.getContractAt('TestIBackingManager', await main.backingManager())
       )
-      basketHandler = <IBasketHandler>(
-        await ethers.getContractAt('IBasketHandler', await main.basketHandler())
+      basketHandler = <TestIBasketHandler>(
+        await ethers.getContractAt('TestIBasketHandler', await main.basketHandler())
       )
 
       broker = <TestIBroker>await ethers.getContractAt('TestIBroker', await main.broker())

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1830,7 +1830,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
     })
 
-    it.skip('Should handle full collateral deregistration and disable the basket', async () => {
+    it('Should handle full collateral deregistration and disable the basket', async () => {
       // Check status
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await basketHandler.quantity(token1.address)).to.equal(basketsNeededAmts[1])

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_BACKING_BUFFER,
   MAX_TARGET_AMT,
   MAX_MIN_TRADE_VOLUME,
+  MIN_WARMUP_PERIOD,
   MAX_WARMUP_PERIOD,
   IComponents,
 } from '../common/configuration'
@@ -900,6 +901,11 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
 
       // Check value was updated
       expect(await basketHandler.warmupPeriod()).to.equal(newValue)
+
+      // Cannot update with value < min
+      await expect(
+        basketHandler.connect(owner).setWarmupPeriod(MIN_WARMUP_PERIOD - 1)
+      ).to.be.revertedWith('invalid warmupPeriod')
 
       // Cannot update with value > max
       await expect(

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -24,11 +24,11 @@ import {
   FacadeTest,
   FiatCollateral,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIFurnace,
   TestIMain,
   TestIRToken,
@@ -94,7 +94,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
   let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let furnace: TestIFurnace
 
   beforeEach(async () => {
@@ -332,7 +332,7 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await Promise.all(tokens.map((t) => t.connect(addr1).approve(rToken.address, issueAmount)))
 
       // Try to issue
-      await expect(rToken.connect(addr1).issue(issueAmount)).to.be.revertedWith('basket unsound')
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.be.revertedWith('basket not ready')
 
       // Check values
       expect(await rToken.totalSupply()).to.equal(bn(0))
@@ -606,6 +606,81 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
       // Set automine to true again
       await hre.network.provider.send('evm_setAutomine', [true])
+    })
+
+    it('Should apply warmup period on issuance', async function () {
+      const issueAmount: BigNumber = bn('10e18')
+      const warmupPeriod = bn('259200') // 3 days
+
+      // Set warmup period
+      await basketHandler.connect(owner).setWarmupPeriod(warmupPeriod)
+
+      // Start issuance
+      await Promise.all(tokens.map((t) => t.connect(addr1).approve(rToken.address, issueAmount)))
+
+      // Try to issue
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.be.revertedWith('basket not ready')
+
+      // Check values
+      expect(await rToken.totalSupply()).to.equal(bn(0))
+
+      // Move past warmup period
+      await advanceTime(warmupPeriod.toString())
+
+      // Try to issue
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.not.be.reverted
+
+      // Check values - rTokens issued
+      expect(await rToken.totalSupply()).to.equal(issueAmount)
+    })
+
+    it('Should use warmup period on issuance after regaining SOUND', async function () {
+      const issueAmount: BigNumber = bn('10e18')
+      const warmupPeriod = bn('259200') // 3 days
+
+      // Set warmup period and move time forward
+      await basketHandler.connect(owner).setWarmupPeriod(warmupPeriod)
+      await advanceTime(warmupPeriod.toString())
+
+      // Set collateral and basket status to IFFY to prevent issuance
+      await setOraclePrice(collateral1.address, bn('0.5e8'))
+      await assetRegistry.refresh()
+
+      // Collateral and basket in IFFY
+      expect(await collateral1.status()).to.equal(CollateralStatus.IFFY)
+      expect(await basketHandler.status()).to.equal(CollateralStatus.IFFY)
+
+      // Start issuance
+      await Promise.all(tokens.map((t) => t.connect(addr1).approve(rToken.address, issueAmount)))
+
+      // Try to issue, reverts because basket is not SOUND
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.be.revertedWith('basket not ready')
+
+      // Check values
+      expect(await rToken.totalSupply()).to.equal(bn(0))
+
+      // Set collateral and basket status to SOUND again
+      await setOraclePrice(collateral1.address, bn('1e8'))
+      await collateral1.refresh()
+
+      // Collateral and basket in SOUND
+      expect(await collateral1.status()).to.equal(CollateralStatus.SOUND)
+      expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+
+      // Need to track status in BH to record timestamp on when SOUND was regained
+      await basketHandler.trackStatus()
+
+      // Try to issuem still cannot issue due to warmup period
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.be.revertedWith('basket not ready')
+
+      // Move past warmup period
+      await advanceTime(warmupPeriod.toString())
+
+      // Should be able to issue now
+      await expect(rToken.connect(addr1).issue(issueAmount)).to.not.be.reverted
+
+      // Check values - rTokens issued
+      expect(await rToken.totalSupply()).to.equal(issueAmount)
     })
 
     it('Should handle issuance throttle correctly', async function () {

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -947,10 +947,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         const sellAmt: BigNumber = await token0.balanceOf(backingManager.address)
         const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
 
-        // Attempt to trigger before trading delay - will not open auction
-        await expect(facadeTest.runAuctionsForAllTraders(rToken.address)).to.not.emit(
-          backingManager,
-          'TradeStarted'
+        // Attempt to trigger before trading delay - Should revert
+        await expect(facadeTest.runAuctionsForAllTraders(rToken.address)).to.be.revertedWith(
+          'trading delayed'
         )
 
         // Advance time post trading delay

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -641,6 +641,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         await basketHandler.connect(owner).setPrimeBasket(initialTokens, [fp('0.5'), fp('0.5')])
         await basketHandler.connect(owner).refreshBasket()
 
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
+
         // Set initial values
         initialQuotes = [bn('0.5e18'), bn('0.5e6')]
         initialQuantities = initialQuotes.map((q) => {
@@ -1115,6 +1118,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         await expect(basketHandler.connect(owner).refreshBasket())
           .to.emit(basketHandler, 'BasketSet')
           .withArgs(3, [token1.address], [fp('1')], false)
+
+        // Advance time post warmup period - temporary IFFY->SOUND
+        await advanceTime(Number(config.warmupPeriod) + 1)
 
         // Check state remains SOUND
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -2009,6 +2015,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         await basketHandler.refreshBasket()
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
 
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
+
         // Check initial state
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.fullyCollateralized()).to.equal(true)
@@ -2036,6 +2045,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
 
         // Confirm default and trigger basket switch
         await basketHandler.refreshBasket()
+
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
 
         // Check new state after basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -2356,6 +2368,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         await assetRegistry.refresh()
         await basketHandler.refreshBasket()
 
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
+
         // Check new state after basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
@@ -2553,6 +2568,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           .to.emit(basketHandler, 'BasketSet')
           .withArgs(3, newTokens, newRefAmounts, false)
 
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
+
         // Check new state after basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
@@ -2728,6 +2746,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         // Confirm default and trigger basket switch
         await assetRegistry.refresh()
         await basketHandler.refreshBasket()
+
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
 
         // Running auctions will trigger recollateralization - All balance can be redeemed
         const sellAmt: BigNumber = await token0.balanceOf(backingManager.address)
@@ -3179,6 +3200,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           .to.emit(basketHandler, 'BasketSet')
           .withArgs(2, newTokens, newRefAmounts, false)
 
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
+
         // Check state - After basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
@@ -3412,6 +3436,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
         await expect(basketHandler.refreshBasket())
           .to.emit(basketHandler, 'BasketSet')
           .withArgs(2, newTokens, newRefAmounts, false)
+
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
 
         // Check state - After basket switch
         expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
@@ -4110,6 +4137,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           await backingManager.maxTradeSlippage(),
           config.minTradeVolume.mul((await assetRegistry.erc20s()).length)
         )
+
+        // Advance time post warmup period - SOUND just regained
+        await advanceTime(Number(config.warmupPeriod) + 1)
 
         // Check quotes
         ;[, quotes] = await facade.connect(addr1).callStatic.issue(rToken.address, bn('1e18'))

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -24,12 +24,12 @@ import {
   FacadeTest,
   GnosisMock,
   IAssetRegistry,
-  IBasketHandler,
   InvalidATokenFiatCollateralMock,
   MockV3Aggregator,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDistributor,
   TestIFurnace,
@@ -108,7 +108,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
   let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let distributor: TestIDistributor
   let main: TestIMain
 

--- a/test/Upgradeability.test.ts
+++ b/test/Upgradeability.test.ts
@@ -24,7 +24,6 @@ import {
   GnosisMock,
   GnosisTrade,
   IAssetRegistry,
-  IBasketHandler,
   MainP1,
   MainP1V2,
   RevenueTraderP1,
@@ -35,6 +34,7 @@ import {
   StRSRP1Votes,
   StRSRP1VotesV2,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDistributor,
   TestIFurnace,
@@ -70,7 +70,7 @@ describeP1(`Upgradeability - P${IMPLEMENTATION}`, () => {
   let main: TestIMain
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let distributor: TestIDistributor
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
@@ -237,7 +237,7 @@ describeP1(`Upgradeability - P${IMPLEMENTATION}`, () => {
     it('Should deploy valid implementation - BasketHandler', async () => {
       const newBasketHandler: BasketHandlerP1 = <BasketHandlerP1>await upgrades.deployProxy(
         BasketHandlerFactory,
-        [main.address],
+        [main.address, config.warmupPeriod],
         {
           initializer: 'init',
           kind: 'uups',

--- a/test/ZTradingExtremes.test.ts
+++ b/test/ZTradingExtremes.test.ts
@@ -18,9 +18,9 @@ import {
   GnosisMock,
   GnosisTrade,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIDistributor,
   TestIStRSR,
   TestIRevenueTrader,
@@ -71,7 +71,7 @@ describeExtreme(`Trading Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, 
   let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let distributor: TestIDistributor
 
   let ERC20Mock: ContractFactory

--- a/test/ZTradingExtremes.test.ts
+++ b/test/ZTradingExtremes.test.ts
@@ -641,7 +641,7 @@ describeExtreme(`Trading Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, 
       )
       await basketHandler.connect(owner).refreshBasket()
 
-      // Insure with RSR
+      // Over-collateralize with RSR
       await rsr.connect(owner).mint(addr1.address, fp('1e29'))
       await rsr.connect(addr1).approve(stRSR.address, fp('1e29'))
       await stRSR.connect(addr1).stake(fp('1e29'))
@@ -661,6 +661,10 @@ describeExtreme(`Trading Extreme Values (${SLOW ? 'slow mode' : 'fast mode'})`, 
       }
 
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await runRecollateralizationAuctions(basketSize)
     }
 

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -13,11 +13,11 @@ import {
   ERC20Mock,
   ERC1271Mock,
   FacadeRead,
-  IBasketHandler,
   StRSRP0,
   StRSRP1Votes,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIMain,
   TestIRToken,
   TestIStRSR,
@@ -66,7 +66,7 @@ describeExtreme(`StRSRP${IMPLEMENTATION} contract`, () => {
   // Main
   let main: TestIMain
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rToken: TestIRToken
   let facade: FacadeRead
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -410,7 +410,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
-    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
+    warmupPeriod: bn('60'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -30,7 +30,6 @@ import {
   GnosisMock,
   GnosisTrade,
   IAssetRegistry,
-  IBasketHandler,
   MainP1,
   MockV3Aggregator,
   RevenueTraderP1,
@@ -40,6 +39,7 @@ import {
   StaticATokenMock,
   StRSRP1Votes,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDeployer,
   TestIDistributor,
@@ -369,7 +369,7 @@ export interface DefaultFixture extends RSRAndCompAaveAndCollateralAndModuleFixt
   main: TestIMain
   assetRegistry: IAssetRegistry
   backingManager: TestIBackingManager
-  basketHandler: IBasketHandler
+  basketHandler: TestIBasketHandler
   distributor: TestIDistributor
   rsrAsset: Asset
   compAsset: Asset
@@ -410,6 +410,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
+    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%
@@ -565,8 +566,8 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   const backingManager: TestIBackingManager = <TestIBackingManager>(
     await ethers.getContractAt('TestIBackingManager', await main.backingManager())
   )
-  const basketHandler: IBasketHandler = <IBasketHandler>(
-    await ethers.getContractAt('IBasketHandler', await main.basketHandler())
+  const basketHandler: TestIBasketHandler = <TestIBasketHandler>(
+    await ethers.getContractAt('TestIBasketHandler', await main.basketHandler())
   )
   const distributor: TestIDistributor = <TestIDistributor>(
     await ethers.getContractAt('TestIDistributor', await main.distributor())

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -2,7 +2,13 @@ import { BigNumber, ContractFactory } from 'ethers'
 import { expect } from 'chai'
 import hre, { ethers } from 'hardhat'
 import { getChainId } from '../common/blockchain-utils'
-import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../common/configuration'
+import {
+  IConfig,
+  IImplementations,
+  IRevenueShare,
+  MIN_WARMUP_PERIOD,
+  networkConfig,
+} from '../common/configuration'
 import { expectInReceipt } from '../common/events'
 import { bn, fp } from '../common/numbers'
 import { CollateralStatus } from '../common/constants'
@@ -55,7 +61,7 @@ import {
   FacadeMonitor,
   ZeroDecimalMock,
 } from '../typechain'
-import { getLatestBlockTimestamp, setNextBlockTimestamp } from './utils/time'
+import { advanceTime, getLatestBlockTimestamp, setNextBlockTimestamp } from './utils/time'
 import { useEnv } from '#/utils/env'
 
 export enum Implementation {
@@ -650,6 +656,9 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   // Set non-empty basket
   await basketHandler.connect(owner).setPrimeBasket(basketERC20s, basketsNeededAmts)
   await basketHandler.connect(owner).refreshBasket()
+
+  // Advance time post warmup period
+  await advanceTime(MIN_WARMUP_PERIOD + 1)
 
   // Set up allowances
   for (let i = 0; i < basket.length; i++) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -2,13 +2,7 @@ import { BigNumber, ContractFactory } from 'ethers'
 import { expect } from 'chai'
 import hre, { ethers } from 'hardhat'
 import { getChainId } from '../common/blockchain-utils'
-import {
-  IConfig,
-  IImplementations,
-  IRevenueShare,
-  MIN_WARMUP_PERIOD,
-  networkConfig,
-} from '../common/configuration'
+import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../common/configuration'
 import { expectInReceipt } from '../common/events'
 import { bn, fp } from '../common/numbers'
 import { CollateralStatus } from '../common/constants'
@@ -658,7 +652,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   await basketHandler.connect(owner).refreshBasket()
 
   // Advance time post warmup period
-  await advanceTime(MIN_WARMUP_PERIOD + 1)
+  await advanceTime(Number(config.warmupPeriod) + 1)
 
   // Set up allowances
   for (let i = 0; i < basket.length; i++) {

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -1661,7 +1661,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(await basketHandler.timestamp()).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
-      await expectPrice(basketHandler.address, fp('1'), ORACLE_ERROR, true, bn('1e12'))
+      await expectPrice(basketHandler.address, fp('1'), ORACLE_ERROR, true, bn('1e5'))
 
       // Check RToken price
       const issueAmount: BigNumber = bn('10000e18')

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -1661,7 +1661,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
       expect(await basketHandler.timestamp()).to.be.gt(bn(0))
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
       expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
-      await expectPrice(basketHandler.address, fp('1'), ORACLE_ERROR, true, bn('1e8'))
+      await expectPrice(basketHandler.address, fp('1'), ORACLE_ERROR, true, bn('1e12'))
 
       // Check RToken price
       const issueAmount: BigNumber = bn('10000e18')

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -37,12 +37,12 @@ import {
   IAToken,
   IERC20,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   NonFiatCollateral,
   RTokenAsset,
   StaticATokenLM,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIMain,
   TestIRToken,
   USDCMock,
@@ -153,7 +153,7 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
   let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let config: IConfig
 
   // Factories

--- a/test/integration/EasyAuction.test.ts
+++ b/test/integration/EasyAuction.test.ts
@@ -569,6 +569,9 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       expect(await collateral0.status()).to.equal(CollateralStatus.DISABLED)
       expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
 
+      // Advance warmup period
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       // Should launch auction for token1
       await expect(backingManager.manageTokens([])).to.emit(backingManager, 'TradeStarted')
 
@@ -663,6 +666,9 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
       await collateral0.refresh()
       await advanceTime((await collateral0.delayUntilDefault()).toString())
       await basketHandler.refreshBasket()
+
+      // Advance warmup period
+      await advanceTime(Number(config.warmupPeriod) + 1)
 
       // Should launch auction for token1
       await expect(backingManager.manageTokens([])).to.emit(backingManager, 'TradeStarted')

--- a/test/integration/EasyAuction.test.ts
+++ b/test/integration/EasyAuction.test.ts
@@ -38,9 +38,9 @@ import {
   FacadeTest,
   FiatCollateral,
   IAssetRegistry,
-  IBasketHandler,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIRToken,
   TestIStRSR,
@@ -65,7 +65,7 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
   let rToken: TestIRToken
   let broker: TestIBroker
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let facadeTest: FacadeTest
   let assetRegistry: IAssetRegistry
 

--- a/test/integration/StaticATokenLM.test.ts
+++ b/test/integration/StaticATokenLM.test.ts
@@ -168,7 +168,9 @@ const getContext = async ({
   staticATokenSupply: await staticAToken.totalSupply(),
 })
 
-describe('StaticATokenLM: aToken wrapper with static balances and liquidity mining', () => {
+const describeFork = useEnv('FORK') ? describe : describe.skip
+
+describeFork('StaticATokenLM: aToken wrapper with static balances and liquidity mining', () => {
   let user1: SignerWithAddress
   let user2: SignerWithAddress
   let userSigner: providers.JsonRpcSigner

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -1,13 +1,7 @@
 import { BigNumber, ContractFactory } from 'ethers'
 import hre, { ethers } from 'hardhat'
 import { getChainId } from '../../common/blockchain-utils'
-import {
-  IConfig,
-  IImplementations,
-  IRevenueShare,
-  MIN_WARMUP_PERIOD,
-  networkConfig,
-} from '../../common/configuration'
+import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../../common/configuration'
 import { expectInReceipt } from '../../common/events'
 import { advanceTime } from '../utils/time'
 import { bn, fp } from '../../common/numbers'
@@ -847,7 +841,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   await basketHandler.connect(owner).refreshBasket()
 
   // Advance time post warmup period
-  await advanceTime(MIN_WARMUP_PERIOD + 1)
+  await advanceTime(Number(config.warmupPeriod) + 1)
 
   // Set up allowances
   for (let i = 0; i < basket.length; i++) {

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -1,8 +1,15 @@
 import { BigNumber, ContractFactory } from 'ethers'
 import hre, { ethers } from 'hardhat'
 import { getChainId } from '../../common/blockchain-utils'
-import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../../common/configuration'
+import {
+  IConfig,
+  IImplementations,
+  IRevenueShare,
+  MIN_WARMUP_PERIOD,
+  networkConfig,
+} from '../../common/configuration'
 import { expectInReceipt } from '../../common/events'
+import { advanceTime } from '../utils/time'
 import { bn, fp } from '../../common/numbers'
 import {
   AaveLendingPoolMock,
@@ -838,6 +845,9 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   // Set non-empty basket
   await basketHandler.connect(owner).setPrimeBasket(basketERC20s, basketsNeededAmts)
   await basketHandler.connect(owner).refreshBasket()
+
+  // Advance time post warmup period
+  await advanceTime(MIN_WARMUP_PERIOD + 1)
 
   // Set up allowances
   for (let i = 0; i < basket.length; i++) {

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -30,7 +30,6 @@ import {
   FurnaceP1,
   GnosisTrade,
   IAssetRegistry,
-  IBasketHandler,
   IERC20Metadata,
   MainP1,
   NonFiatCollateral,
@@ -41,6 +40,7 @@ import {
   StaticATokenLM,
   StRSRP1Votes,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIBroker,
   TestIDeployer,
   TestIDistributor,
@@ -570,7 +570,7 @@ interface DefaultFixture extends RSRAndCompAaveAndCollateralAndModuleFixture {
   main: TestIMain
   assetRegistry: IAssetRegistry
   backingManager: TestIBackingManager
-  basketHandler: IBasketHandler
+  basketHandler: TestIBasketHandler
   distributor: TestIDistributor
   rsrAsset: Asset
   compAsset: Asset
@@ -614,6 +614,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
+    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%
@@ -758,8 +759,8 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   const backingManager: TestIBackingManager = <TestIBackingManager>(
     await ethers.getContractAt('TestIBackingManager', await main.backingManager())
   )
-  const basketHandler: IBasketHandler = <IBasketHandler>(
-    await ethers.getContractAt('IBasketHandler', await main.basketHandler())
+  const basketHandler: TestIBasketHandler = <TestIBasketHandler>(
+    await ethers.getContractAt('TestIBasketHandler', await main.basketHandler())
   )
   const distributor: TestIDistributor = <TestIDistributor>(
     await ethers.getContractAt('TestIDistributor', await main.distributor())

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -614,7 +614,7 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
-    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
+    warmupPeriod: bn('60'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%

--- a/test/plugins/Asset.test.ts
+++ b/test/plugins/Asset.test.ts
@@ -22,12 +22,12 @@ import {
   ERC20Mock,
   FiatCollateral,
   IAssetRegistry,
-  IBasketHandler,
   InvalidFiatCollateral,
   InvalidMockV3Aggregator,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIRToken,
   USDCMock,
   UnpricedAssetMock,
@@ -74,7 +74,7 @@ describe('Assets contracts #fast', () => {
   let wallet: Wallet
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   // Factory
   let AssetFactory: ContractFactory

--- a/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
@@ -111,6 +111,7 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
+    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%

--- a/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
@@ -111,7 +111,7 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
     longFreeze: bn('2592000'), // 30 days
     rewardRatio: bn('1069671574938'), // approx. half life of 90 days
     unstakingDelay: bn('1209600'), // 2 weeks
-    warmupPeriod: bn('0'), // (the delay _after_ SOUND was regained)
+    warmupPeriod: bn('60'), // (the delay _after_ SOUND was regained)
     tradingDelay: bn('0'), // (the delay _after_ default has been confirmed)
     auctionLength: bn('900'), // 15 minutes
     backingBuffer: fp('0.0001'), // 0.01%

--- a/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
@@ -36,11 +36,11 @@ import {
   FacadeTest,
   FacadeWrite,
   IAssetRegistry,
-  IBasketHandler,
   InvalidMockV3Aggregator,
   MockV3Aggregator,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIDeployer,
   TestIMain,
   TestIRToken,
@@ -90,7 +90,7 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
   let rTokenAsset: RTokenAsset
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   let deployer: TestIDeployer
   let facade: FacadeRead
@@ -242,8 +242,8 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
     backingManager = <TestIBackingManager>(
       await ethers.getContractAt('TestIBackingManager', await main.backingManager())
     )
-    basketHandler = <IBasketHandler>(
-      await ethers.getContractAt('IBasketHandler', await main.basketHandler())
+    basketHandler = <TestIBasketHandler>(
+      await ethers.getContractAt('TestIBasketHandler', await main.basketHandler())
     )
     rToken = <TestIRToken>await ethers.getContractAt('TestIRToken', await main.rToken())
     rTokenAsset = <RTokenAsset>(

--- a/test/scenario/BadCollateralPlugin.test.ts
+++ b/test/scenario/BadCollateralPlugin.test.ts
@@ -11,11 +11,11 @@ import {
   BadCollateralPlugin,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRToken,
 } from '../../typechain'
@@ -60,7 +60,7 @@ describe(`Bad Collateral Plugin - P${IMPLEMENTATION}`, () => {
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   beforeEach(async () => {
     ;[owner, addr1, addr2] = await ethers.getSigners()

--- a/test/scenario/BadERC20.test.ts
+++ b/test/scenario/BadERC20.test.ts
@@ -244,7 +244,7 @@ describe(`Bad ERC20 - P${IMPLEMENTATION}`, () => {
       await furnace.melt()
     })
 
-    it.only('should be able to unregister and use RSR to recollateralize', async () => {
+    it('should be able to unregister and use RSR to recollateralize', async () => {
       await assetRegistry.connect(owner).unregister(collateral0.address)
       expect(await assetRegistry.isRegistered(collateral0.address)).to.equal(false)
       await expect(basketHandler.refreshBasket())

--- a/test/scenario/BadERC20.test.ts
+++ b/test/scenario/BadERC20.test.ts
@@ -10,10 +10,10 @@ import {
   BadERC20,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIFurnace,
   TestIStRSR,
   TestIRevenueTrader,
@@ -62,7 +62,7 @@ describe(`Bad ERC20 - P${IMPLEMENTATION}`, () => {
   let backingManager: TestIBackingManager
   let rTokenTrader: TestIRevenueTrader
   let rsrTrader: TestIRevenueTrader
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   // Computes the minBuyAmt for a sellAmt at two prices
   // sellPrice + buyPrice should not be the low and high estimates, but rather the oracle prices

--- a/test/scenario/BadERC20.test.ts
+++ b/test/scenario/BadERC20.test.ts
@@ -244,12 +244,16 @@ describe(`Bad ERC20 - P${IMPLEMENTATION}`, () => {
       await furnace.melt()
     })
 
-    it('should be able to unregister and use RSR to recollateralize', async () => {
+    it.only('should be able to unregister and use RSR to recollateralize', async () => {
       await assetRegistry.connect(owner).unregister(collateral0.address)
       expect(await assetRegistry.isRegistered(collateral0.address)).to.equal(false)
       await expect(basketHandler.refreshBasket())
         .to.emit(basketHandler, 'BasketSet')
         .withArgs(3, [backupToken.address], [fp('1')], false)
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([])).to.emit(backingManager, 'TradeStarted')
 
       // Should be trading RSR for backup token
@@ -310,6 +314,10 @@ describe(`Bad ERC20 - P${IMPLEMENTATION}`, () => {
       await expect(basketHandler.refreshBasket())
         .to.emit(basketHandler, 'BasketSet')
         .withArgs(3, [backupToken.address], [fp('1')], false)
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([])).to.be.revertedWith('censored')
 
       // Should work now
@@ -352,6 +360,10 @@ describe(`Bad ERC20 - P${IMPLEMENTATION}`, () => {
       await expect(basketHandler.refreshBasket())
         .to.emit(basketHandler, 'BasketSet')
         .withArgs(3, [backupToken.address], [fp('1')], false)
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([])).to.emit(backingManager, 'TradeStarted')
 
       // Should be trading RSR for backup token

--- a/test/scenario/ComplexBasket.test.ts
+++ b/test/scenario/ComplexBasket.test.ts
@@ -393,6 +393,9 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     await basketHandler.setPrimeBasket(primeBasketERC20s, targetAmts)
     await basketHandler.connect(owner).refreshBasket()
 
+    // Advance time post warmup period
+    await advanceTime(Number(config.warmupPeriod) + 1)
+
     // Mint and approve initial balances
     const backing: string[] = await facade.basketTokens(rToken.address)
     await prepareBacking(backing)

--- a/test/scenario/ComplexBasket.test.ts
+++ b/test/scenario/ComplexBasket.test.ts
@@ -15,11 +15,11 @@ import {
   FacadeTest,
   GnosisMock,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIRevenueTrader,
   TestIRToken,
   WETH9,
@@ -100,7 +100,7 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
   let rToken: TestIRToken
   let stRSR: TestIStRSR
   let assetRegistry: IAssetRegistry
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let facade: FacadeRead
   let facadeTest: FacadeTest
   let backingManager: TestIBackingManager

--- a/test/scenario/ComplexBasket.test.ts
+++ b/test/scenario/ComplexBasket.test.ts
@@ -1324,6 +1324,9 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
     // Ensure valid basket
     await basketHandler.refreshBasket()
 
+    // Advance time post warmup period
+    await advanceTime(Number(config.warmupPeriod) + 1)
+
     const [, newQuotes] = await facade.connect(addr1).callStatic.issue(rToken.address, issueAmount)
     const newExpectedTkn4: BigNumber = issueAmount
       .mul(targetAmts[4].add(targetAmts[5]))
@@ -1548,6 +1551,9 @@ describe(`Complex Basket - P${IMPLEMENTATION}`, () => {
 
     // Ensure valid basket
     await basketHandler.refreshBasket()
+
+    // Advance time post warmup period
+    await advanceTime(Number(config.warmupPeriod) + 1)
 
     const [, newQuotes] = await facade.connect(addr1).callStatic.issue(rToken.address, issueAmount)
     const newExpectedTkn6: BigNumber = issueAmount

--- a/test/scenario/EURT.test.ts
+++ b/test/scenario/EURT.test.ts
@@ -11,11 +11,11 @@ import {
   ERC20Mock,
   EURFiatCollateral,
   IAssetRegistry,
-  IBasketHandler,
   IFacadeTest,
   MockV3Aggregator,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -61,7 +61,7 @@ describe(`EUR fiatcoins (eg EURT) - P${IMPLEMENTATION}`, () => {
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
   let facadeTest: IFacadeTest

--- a/test/scenario/MaxBasketSize.test.ts
+++ b/test/scenario/MaxBasketSize.test.ts
@@ -16,11 +16,11 @@ import {
   FacadeTest,
   FiatCollateral,
   IAssetRegistry,
-  IBasketHandler,
   TestIStRSR,
   MockV3Aggregator,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIRToken,
 } from '../../typechain'
 import { advanceTime, getLatestBlockTimestamp } from '../utils/time'
@@ -65,7 +65,7 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
   let rsr: ERC20Mock
   let stRSR: TestIStRSR
   let assetRegistry: IAssetRegistry
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let facade: FacadeRead
   let facadeTest: FacadeTest
   let backingManager: TestIBackingManager

--- a/test/scenario/MaxBasketSize.test.ts
+++ b/test/scenario/MaxBasketSize.test.ts
@@ -386,6 +386,9 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
         await basketHandler.refreshBasket()
       }
 
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       // Check new basket
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       const newBacking: string[] = await facade.basketTokens(rToken.address)

--- a/test/scenario/MaxBasketSize.test.ts
+++ b/test/scenario/MaxBasketSize.test.ts
@@ -510,6 +510,9 @@ describe(`Max Basket Size - P${IMPLEMENTATION}`, () => {
         await basketHandler.refreshBasket()
       }
 
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       // Check new basket
       expect(await basketHandler.fullyCollateralized()).to.equal(false)
       const newBacking: string[] = await facade.basketTokens(rToken.address)

--- a/test/scenario/NontrivialPeg.test.ts
+++ b/test/scenario/NontrivialPeg.test.ts
@@ -10,11 +10,11 @@ import { expectEvents } from '../../common/events'
 import {
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   FiatCollateral,
   MockV3Aggregator,
   RTokenAsset,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRToken,
 } from '../../typechain'
@@ -56,7 +56,7 @@ describe(`The peg (target/ref) should be arbitrary - P${IMPLEMENTATION}`, () => 
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
 
   beforeEach(async () => {
     ;[owner, addr1, addr2] = await ethers.getSigners()

--- a/test/scenario/RevenueHiding.test.ts
+++ b/test/scenario/RevenueHiding.test.ts
@@ -12,9 +12,9 @@ import {
   ComptrollerMock,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   SelfReferentialCollateral,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -59,7 +59,7 @@ describe(`RevenueHiding basket collateral (/w CTokenFiatCollateral) - P${IMPLEME
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
 

--- a/test/scenario/RevenueHiding.test.ts
+++ b/test/scenario/RevenueHiding.test.ts
@@ -19,6 +19,7 @@ import {
   TestIRevenueTrader,
   TestIRToken,
 } from '../../typechain'
+import { advanceTime } from '../utils/time'
 import { getTrade } from '../utils/trades'
 import {
   Collateral,
@@ -137,6 +138,9 @@ describe(`RevenueHiding basket collateral (/w CTokenFiatCollateral) - P${IMPLEME
       .connect(owner)
       .setBackupConfig(await ethers.utils.formatBytes32String('USD'), 1, [dai.address])
     await basketHandler.refreshBasket()
+
+    // Advance time post warmup period - SOUND just regained
+    await advanceTime(Number(config.warmupPeriod) + 1)
 
     await backingManager.grantRTokenAllowance(cDAI.address)
     await backingManager.grantRTokenAllowance(dai.address)

--- a/test/scenario/SetProtocol.test.ts
+++ b/test/scenario/SetProtocol.test.ts
@@ -11,10 +11,10 @@ import { expectEvents } from '../../common/events'
 import {
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   MockV3Aggregator,
   SelfReferentialCollateral,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -56,7 +56,7 @@ describe(`Linear combination of self-referential collateral - P${IMPLEMENTATION}
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
 

--- a/test/scenario/WBTC.test.ts
+++ b/test/scenario/WBTC.test.ts
@@ -10,12 +10,12 @@ import { CollateralStatus } from '../../common/constants'
 import {
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   IFacadeTest,
   MockV3Aggregator,
   NonFiatCollateral,
   StaticATokenMock,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -63,7 +63,7 @@ describe(`Non-fiat collateral (eg WBTC) - P${IMPLEMENTATION}`, () => {
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
   let facadeTest: IFacadeTest

--- a/test/scenario/WBTC.test.ts
+++ b/test/scenario/WBTC.test.ts
@@ -196,6 +196,10 @@ describe(`Non-fiat collateral (eg WBTC) - P${IMPLEMENTATION}`, () => {
     it('should change basket around wbtc', async () => {
       await token0.setExchangeRate(fp('0.99')) // default
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([token0.address, wbtc.address])).to.emit(
         backingManager,
         'TradeStarted'

--- a/test/scenario/WETH.test.ts
+++ b/test/scenario/WETH.test.ts
@@ -21,6 +21,7 @@ import {
   WETH9,
 } from '../../typechain'
 import { setOraclePrice } from '../utils/oracles'
+import { advanceTime } from '../utils/time'
 import { getTrade } from '../utils/trades'
 import {
   Collateral,
@@ -191,6 +192,10 @@ describe(`Self-referential collateral (eg ETH via WETH) - P${IMPLEMENTATION}`, (
     it('should change basket around WETH', async () => {
       await token0.setExchangeRate(fp('0.99')) // default
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([token0.address, weth.address])).to.emit(
         backingManager,
         'TradeStarted'

--- a/test/scenario/WETH.test.ts
+++ b/test/scenario/WETH.test.ts
@@ -11,10 +11,10 @@ import {
   SelfReferentialCollateral,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   IFacadeTest,
   MockV3Aggregator,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -58,7 +58,7 @@ describe(`Self-referential collateral (eg ETH via WETH) - P${IMPLEMENTATION}`, (
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
   let facadeTest: IFacadeTest

--- a/test/scenario/cETH.test.ts
+++ b/test/scenario/cETH.test.ts
@@ -12,11 +12,11 @@ import {
   ComptrollerMock,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   IFacadeTest,
   MockV3Aggregator,
   SelfReferentialCollateral,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -66,7 +66,7 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
   let facadeTest: IFacadeTest

--- a/test/scenario/cETH.test.ts
+++ b/test/scenario/cETH.test.ts
@@ -22,6 +22,7 @@ import {
   TestIRToken,
   WETH9,
 } from '../../typechain'
+import { advanceTime } from '../utils/time'
 import { getTrade } from '../utils/trades'
 import { setOraclePrice } from '../utils/oracles'
 import {
@@ -226,6 +227,10 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
     it('should change basket around cETH', async () => {
       await token0.setExchangeRate(fp('0.99')) // default
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([token0.address, cETH.address])).to.emit(
         backingManager,
         'TradeStarted'
@@ -301,6 +306,9 @@ describe(`CToken of self-referential collateral (eg cETH) - P${IMPLEMENTATION}`,
       await cETHCollateral.refresh()
       await cETH.setExchangeRate(fp('0.99'))
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
 
       // Should swap WETH in for cETH
       const [tokens] = await basketHandler.quote(fp('1'), 2)

--- a/test/scenario/cWBTC.test.ts
+++ b/test/scenario/cWBTC.test.ts
@@ -13,11 +13,11 @@ import {
   ComptrollerMock,
   ERC20Mock,
   IAssetRegistry,
-  IBasketHandler,
   IFacadeTest,
   MockV3Aggregator,
   SelfReferentialCollateral,
   TestIBackingManager,
+  TestIBasketHandler,
   TestIStRSR,
   TestIRevenueTrader,
   TestIRToken,
@@ -70,7 +70,7 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
   let rToken: TestIRToken
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
-  let basketHandler: IBasketHandler
+  let basketHandler: TestIBasketHandler
   let rsrTrader: TestIRevenueTrader
   let rTokenTrader: TestIRevenueTrader
   let facadeTest: IFacadeTest

--- a/test/scenario/cWBTC.test.ts
+++ b/test/scenario/cWBTC.test.ts
@@ -239,6 +239,10 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
     it('should change basket around cWBTC', async () => {
       await token0.setExchangeRate(fp('0.99')) // default
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
+
       await expect(backingManager.manageTokens([token0.address, cWBTC.address])).to.emit(
         backingManager,
         'TradeStarted'
@@ -330,6 +334,9 @@ describe(`CToken of non-fiat collateral (eg cWBTC) - P${IMPLEMENTATION}`, () => 
       await assetRegistry.refresh()
       await cWBTC.setExchangeRate(fp('0.99'))
       await basketHandler.refreshBasket()
+
+      // Advance time post warmup period - SOUND just regained
+      await advanceTime(Number(config.warmupPeriod) + 1)
 
       // Should swap WBTC in for cWBTC
       const [tokens] = await basketHandler.quote(fp('1'), 2)


### PR DESCRIPTION
* Add warmup period logic 
* Adapt contracts and tests
* Adds minWarmup period and adapts prior tests.
* Revert on trading delay
* Adds 2 non-related minor things:  
   - Comments in `IBackingManger` that were missing
   - `describeFork` in StaticAToken which should only run on Fork (this was not being enforced).

Notes:
 - Because now we have to use `TestIBasketHandler` and not `IBasketHandler` a lot of tests files just have this simple change. It is now more consistent with all the other components.
 - The new variables are added to the end to prevent stepping on previous storage Slots.  The 3 variables are being packed in one slot, so we only need to decrease `gap` by 1.
 