### PR TITLE
Fix upgrade annotation

### DIFF
--- a/contracts/mixins/Auth.sol
+++ b/contracts/mixins/Auth.sol
@@ -41,6 +41,7 @@ abstract contract Auth is AccessControlUpgradeable, IAuth {
 
     // === Pausing ===
 
+    /// @custom:oz-renamed-from paused
     bool public tradingPaused;
     bool public issuancePaused;
 


### PR DESCRIPTION
* Adds annotation required when renaming variables so the Upgrade Plugin does not mark it as a conflict.
* There is no issue here in `tradingPaused` inheriting the value from `paused`. its actually what we want as they are kind of equivalent.
* Checked the contract is Upgrade Safe after this.