### PR TITLE
Roles changes in FacadeWrite and protocol

### DIFF
--- a/common/configuration.ts
+++ b/common/configuration.ts
@@ -387,6 +387,14 @@ export interface IGovParams {
   timelockDelay: BigNumber
 }
 
+export interface IGovRoles {
+  owner: string
+  guardian: string
+  pausers: string[]
+  shortFreezers: string[]
+  longFreezers: string[]
+}
+
 // System constants
 export const MAX_TRADE_SLIPPAGE = BigNumber.from(10).pow(18)
 export const MAX_BACKING_BUFFER = BigNumber.from(10).pow(18)

--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -163,7 +163,8 @@ contract FacadeWrite is IFacadeWrite {
 
             // Setup Roles
             timelock.grantRole(timelock.PROPOSER_ROLE(), governance); // Gov only proposer
-            timelock.grantRole(timelock.CANCELLER_ROLE(), govRoles.guardian); // Guardian as canceller
+            // Set Guardian as canceller, if address(0) then no one can cancel
+            timelock.grantRole(timelock.CANCELLER_ROLE(), govRoles.guardian);
             timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0)); // Anyone as executor
             timelock.revokeRole(timelock.TIMELOCK_ADMIN_ROLE(), address(this)); // Revoke admin role
 

--- a/contracts/interfaces/IFacadeWrite.sol
+++ b/contracts/interfaces/IFacadeWrite.sol
@@ -64,6 +64,18 @@ struct GovernanceParams {
 }
 
 /**
+ * @title GovernanceRoles
+ * @notice The set of roles required (owner, guardian, pausers, and freezers)
+ */
+struct GovernanceRoles {
+    address owner;
+    address guardian;
+    address[] pausers;
+    address[] shortFreezers;
+    address[] longFreezers;
+}
+
+/**
  * @title IFacadeWrite
  * @notice A UX-friendly layer for interactin with the protocol
  */
@@ -89,8 +101,6 @@ interface IFacadeWrite {
         bool deployGovernance,
         bool unfreeze,
         GovernanceParams calldata govParams,
-        address owner,
-        address guardian,
-        address pauser
+        GovernanceRoles calldata govRoles
     ) external returns (address);
 }

--- a/contracts/mixins/Auth.sol
+++ b/contracts/mixins/Auth.sol
@@ -21,8 +21,7 @@ abstract contract Auth is AccessControlUpgradeable, IAuth {
      *                    and rewards payout
      *  - Issuance Paused: disallow issuance
      *
-     * Typically freezing thaws on its own in a predetemined number of blocks.
-     *   However, OWNER can also freeze forever.
+     * Typically freezing thaws on its own in a predetermined number of blocks.
      */
 
     /// The rest of the contract uses the shorthand; these declarations are here for getters
@@ -55,9 +54,8 @@ abstract contract Auth is AccessControlUpgradeable, IAuth {
     // - 0 < shortFreeze_ <= MAX_SHORT_FREEZE
     // - 0 < longFreeze_ <= MAX_LONG_FREEZE
     // effects:
-    // - caller has all roles
+    // - caller has only the OWNER role
     // - OWNER is the admin role for all roles
-    // - longFreezes[caller] == LONG_FREEZE_CHARGES
     // - shortFreeze' == shortFreeze_
     // - longFreeze' == longFreeze_
     // questions: (what do I know about the values of paused and unfreezeAt?)
@@ -75,12 +73,7 @@ abstract contract Auth is AccessControlUpgradeable, IAuth {
         _setRoleAdmin(LONG_FREEZER, OWNER);
         _setRoleAdmin(PAUSER, OWNER);
 
-        address msgSender = _msgSender();
-        _grantRole(OWNER, msgSender);
-        _grantRole(SHORT_FREEZER, msgSender);
-        _grantRole(LONG_FREEZER, msgSender);
-        _grantRole(PAUSER, msgSender);
-        longFreezes[msgSender] = LONG_FREEZE_CHARGES;
+        _grantRole(OWNER, _msgSender());
 
         setShortFreeze(shortFreeze_);
         setLongFreeze(longFreeze_);

--- a/contracts/mixins/Auth.sol
+++ b/contracts/mixins/Auth.sol
@@ -22,6 +22,7 @@ abstract contract Auth is AccessControlUpgradeable, IAuth {
      *  - Issuance Paused: disallow issuance
      *
      * Typically freezing thaws on its own in a predetermined number of blocks.
+     *   However, OWNER can freeze forever and unfreeze.
      */
 
     /// The rest of the contract uses the shorthand; these declarations are here for getters

--- a/contracts/p0/Deployer.sol
+++ b/contracts/p0/Deployer.sol
@@ -145,13 +145,7 @@ contract DeployerP0 is IDeployer, Versioned {
 
         // Transfer Ownership
         main.grantRole(OWNER, owner);
-        main.grantRole(SHORT_FREEZER, owner);
-        main.grantRole(LONG_FREEZER, owner);
-        main.grantRole(PAUSER, owner);
         main.renounceRole(OWNER, address(this));
-        main.renounceRole(SHORT_FREEZER, address(this));
-        main.renounceRole(LONG_FREEZER, address(this));
-        main.renounceRole(PAUSER, address(this));
 
         emit RTokenCreated(main, components.rToken, components.stRSR, owner, version());
         return (address(components.rToken));

--- a/contracts/p1/Deployer.sol
+++ b/contracts/p1/Deployer.sol
@@ -98,7 +98,7 @@ contract DeployerP1 is IDeployer, Versioned {
     //   Deploy a proxy for Main and every component of Main
     //   Call init() on Main and every component of Main, using `params` for needed parameters
     //     While doing this, init assetRegistry with this.rsrAsset and a new rTokenAsset
-    //   Set up Auth so that `owner` holds all roles and no one else has any
+    //   Set up Auth so that `owner` holds the OWNER role and no one else has any
     function deploy(
         string memory name,
         string memory symbol,
@@ -234,13 +234,7 @@ contract DeployerP1 is IDeployer, Versioned {
 
         // Transfer Ownership
         main.grantRole(OWNER, owner);
-        main.grantRole(SHORT_FREEZER, owner);
-        main.grantRole(LONG_FREEZER, owner);
-        main.grantRole(PAUSER, owner);
         main.renounceRole(OWNER, address(this));
-        main.renounceRole(SHORT_FREEZER, address(this));
-        main.renounceRole(LONG_FREEZER, address(this));
-        main.renounceRole(PAUSER, address(this));
 
         emit RTokenCreated(main, components.rToken, components.stRSR, owner, version());
         return (address(components.rToken));

--- a/scripts/deployment/phase3-rtoken/2_deploy_governance.ts
+++ b/scripts/deployment/phase3-rtoken/2_deploy_governance.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import hre, { ethers } from 'hardhat'
 
 import { getChainId, isValidContract } from '../../../common/blockchain-utils'
-import { IGovParams, networkConfig } from '../../../common/configuration'
+import { IGovParams, IGovRoles, networkConfig } from '../../../common/configuration'
 import { ZERO_ADDRESS } from '../../../common/constants'
 import { expectInReceipt } from '../../../common/events'
 import { getRTokenConfig, RTOKEN_NAME } from './rTokenConfig'
@@ -74,15 +74,21 @@ async function main() {
   }
 
   // Setup Governance in RToken
+  const govRoles: IGovRoles = {
+    owner: ZERO_ADDRESS,
+    guardian: ZERO_ADDRESS,
+    pausers: [],
+    shortFreezers: [],
+    longFreezers: [],
+  }
+
   const receipt = await (
     await facadeWrite.connect(deployerUser).setupGovernance(
       rToken.address,
       true, // deploy governance
       chainId != '1', // unpause if not mainnet
       govParams,
-      ZERO_ADDRESS,
-      ZERO_ADDRESS,
-      ZERO_ADDRESS // no other pauser
+      govRoles
     )
   ).wait()
 

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -7,6 +7,7 @@ import { cloneDeep } from 'lodash'
 import {
   IConfig,
   IGovParams,
+  IGovRoles,
   IRevenueShare,
   IRTokenConfig,
   IRTokenSetup,
@@ -67,6 +68,7 @@ describe('FacadeWrite contract', () => {
   let owner: SignerWithAddress
   let addr1: SignerWithAddress
   let addr2: SignerWithAddress
+  let addr3: SignerWithAddress
   let beneficiary1: SignerWithAddress
   let beneficiary2: SignerWithAddress
 
@@ -122,12 +124,14 @@ describe('FacadeWrite contract', () => {
   let rTokenConfig: IRTokenConfig
   let rTokenSetup: IRTokenSetup
   let govParams: IGovParams
+  let govRoles: IGovRoles
 
   let revShare1: IRevenueShare
   let revShare2: IRevenueShare
 
   beforeEach(async () => {
-    ;[deployerUser, owner, addr1, addr2, beneficiary1, beneficiary2] = await ethers.getSigners()
+    ;[deployerUser, owner, addr1, addr2, addr3, beneficiary1, beneficiary2] =
+      await ethers.getSigners()
 
     // Deploy fixture
     ;({ rsr, compToken, compAsset, basket, config, facade, facadeTest, deployer } =
@@ -194,6 +198,15 @@ describe('FacadeWrite contract', () => {
       proposalThresholdAsMicroPercent: bn(1e6), // 1%
       quorumPercent: bn(4), // 4%
       timelockDelay: bn(60 * 60 * 24), // 1 day
+    }
+
+    // Set initial governance roles
+    govRoles = {
+      owner: owner.address,
+      guardian: ZERO_ADDRESS,
+      pausers: [],
+      shortFreezers: [],
+      longFreezers: [],
     }
   })
 
@@ -367,9 +380,9 @@ describe('FacadeWrite contract', () => {
         expect(await main.hasRole(PAUSER, deployerUser.address)).to.equal(false)
 
         expect(await main.hasRole(OWNER, facadeWrite.address)).to.equal(true)
-        expect(await main.hasRole(SHORT_FREEZER, facadeWrite.address)).to.equal(true)
-        expect(await main.hasRole(LONG_FREEZER, facadeWrite.address)).to.equal(true)
-        expect(await main.hasRole(PAUSER, facadeWrite.address)).to.equal(true)
+        expect(await main.hasRole(SHORT_FREEZER, facadeWrite.address)).to.equal(false)
+        expect(await main.hasRole(LONG_FREEZER, facadeWrite.address)).to.equal(false)
+        expect(await main.hasRole(PAUSER, facadeWrite.address)).to.equal(false)
         expect(await main.frozen()).to.equal(false)
         expect(await main.tradingPaused()).to.equal(true)
         expect(await main.tradingPausedOrFrozen()).to.equal(true)
@@ -458,15 +471,7 @@ describe('FacadeWrite contract', () => {
         await expect(
           facadeWrite
             .connect(addr1)
-            .setupGovernance(
-              rToken.address,
-              false,
-              false,
-              govParams,
-              owner.address,
-              ZERO_ADDRESS,
-              ZERO_ADDRESS
-            )
+            .setupGovernance(rToken.address, false, false, govParams, govRoles)
         ).to.be.revertedWith('not initial deployer')
       })
 
@@ -474,29 +479,16 @@ describe('FacadeWrite contract', () => {
         await expect(
           facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              true,
-              false,
-              govParams,
-              owner.address,
-              ZERO_ADDRESS,
-              ZERO_ADDRESS
-            )
+            .setupGovernance(rToken.address, true, false, govParams, govRoles)
         ).to.be.revertedWith('owner should be empty')
 
-        await expect(
+        // Remove owner
+        const noOwnerGovRoles = { ...govRoles }
+        noOwnerGovRoles.owner = ZERO_ADDRESS
+        govRoles.owner = await expect(
           facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              false,
-              false,
-              govParams,
-              ZERO_ADDRESS,
-              ZERO_ADDRESS,
-              ZERO_ADDRESS
-            )
+            .setupGovernance(rToken.address, false, false, govParams, noOwnerGovRoles)
         ).to.be.revertedWith('owner not defined')
       })
     })
@@ -504,23 +496,18 @@ describe('FacadeWrite contract', () => {
     describe('Phase 2 - Complete Setup', () => {
       context('Without deploying Governance - Paused', function () {
         beforeEach(async () => {
+          // Setup pauser
+          const newGovRoles = { ...govRoles }
+          newGovRoles.pausers.push(addr1.address)
+
           await facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              false,
-              false,
-              govParams,
-              owner.address,
-              ZERO_ADDRESS,
-              ZERO_ADDRESS
-            )
+            .setupGovernance(rToken.address, false, false, govParams, newGovRoles)
         })
 
         it('Should register Basket correctly', async () => {
-          // Unpause
-          await main.connect(owner).unpauseTrading()
-          await main.connect(owner).unpauseIssuance()
+          await main.connect(addr1).unpauseTrading()
+          await main.connect(addr1).unpauseIssuance()
 
           // Basket
           expect(await basketHandler.fullyCollateralized()).to.equal(true)
@@ -583,9 +570,15 @@ describe('FacadeWrite contract', () => {
 
         it('Should setup roles correctly', async () => {
           expect(await main.hasRole(OWNER, owner.address)).to.equal(true)
-          expect(await main.hasRole(SHORT_FREEZER, owner.address)).to.equal(true)
-          expect(await main.hasRole(LONG_FREEZER, owner.address)).to.equal(true)
-          expect(await main.hasRole(PAUSER, owner.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, owner.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, owner.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, owner.address)).to.equal(false)
+
+          // Pauser
+          expect(await main.hasRole(OWNER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, addr1.address)).to.equal(true)
 
           expect(await main.hasRole(OWNER, facadeWrite.address)).to.equal(false)
           expect(await main.hasRole(SHORT_FREEZER, facadeWrite.address)).to.equal(false)
@@ -608,50 +601,47 @@ describe('FacadeWrite contract', () => {
           await expect(
             facadeWrite
               .connect(deployerUser)
-              .setupGovernance(
-                rToken.address,
-                false,
-                false,
-                govParams,
-                owner.address,
-                ZERO_ADDRESS,
-                ZERO_ADDRESS
-              )
+              .setupGovernance(rToken.address, false, false, govParams, govRoles)
           ).to.be.revertedWith('ownership already transferred')
         })
       })
 
       context('Without deploying Governance - Unpaused', function () {
         beforeEach(async () => {
+          // Setup guardian, pauser, and freezers
+          const newGovRoles = { ...govRoles }
+          newGovRoles.guardian = addr1.address
+          newGovRoles.pausers.push(addr2.address)
+          newGovRoles.shortFreezers.push(addr2.address)
+          newGovRoles.longFreezers.push(owner.address) // make owner freezer
+          newGovRoles.longFreezers.push(addr3.address) // add another long freezer
+
           // Deploy RToken via FacadeWrite
           await facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              false,
-              true,
-              govParams,
-              owner.address,
-              addr1.address,
-              addr2.address
-            )
+            .setupGovernance(rToken.address, false, true, govParams, newGovRoles)
         })
 
         it('Should setup owner, freezer and pauser correctly', async () => {
           expect(await main.hasRole(OWNER, owner.address)).to.equal(true)
-          expect(await main.hasRole(SHORT_FREEZER, owner.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, owner.address)).to.equal(false)
           expect(await main.hasRole(LONG_FREEZER, owner.address)).to.equal(true)
-          expect(await main.hasRole(PAUSER, owner.address)).to.equal(true)
+          expect(await main.hasRole(PAUSER, owner.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, addr1.address)).to.equal(false)
-          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(true)
-          expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(true)
-          expect(await main.hasRole(PAUSER, addr1.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, addr1.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, addr2.address)).to.equal(false)
-          expect(await main.hasRole(SHORT_FREEZER, addr2.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr2.address)).to.equal(true)
           expect(await main.hasRole(LONG_FREEZER, addr2.address)).to.equal(false)
           expect(await main.hasRole(PAUSER, addr2.address)).to.equal(true)
+
+          expect(await main.hasRole(OWNER, addr3.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr3.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, addr3.address)).to.equal(true)
+          expect(await main.hasRole(PAUSER, addr3.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, facadeWrite.address)).to.equal(false)
           expect(await main.hasRole(SHORT_FREEZER, facadeWrite.address)).to.equal(false)
@@ -673,19 +663,20 @@ describe('FacadeWrite contract', () => {
 
       context('Deploying Governance - Paused', function () {
         beforeEach(async () => {
+          // Setup guardian
+          const newGovRoles = { ...govRoles }
+          newGovRoles.owner = ZERO_ADDRESS
+          newGovRoles.guardian = addr1.address
+          newGovRoles.pausers.push(addr1.address)
+          newGovRoles.pausers.push(addr2.address)
+          newGovRoles.shortFreezers.push(addr2.address)
+          newGovRoles.shortFreezers.push(addr3.address)
+
           // Deploy RToken via FacadeWrite
           const receipt = await (
             await facadeWrite
               .connect(deployerUser)
-              .setupGovernance(
-                rToken.address,
-                true,
-                false,
-                govParams,
-                ZERO_ADDRESS,
-                addr1.address,
-                ZERO_ADDRESS
-              )
+              .setupGovernance(rToken.address, true, false, govParams, newGovRoles)
           ).wait()
 
           // Get Governor and Timelock
@@ -699,19 +690,24 @@ describe('FacadeWrite contract', () => {
 
         it('Should setup owner, freezer and pauser correctly', async () => {
           expect(await main.hasRole(OWNER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(SHORT_FREEZER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(LONG_FREEZER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(PAUSER, timelock.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, timelock.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, timelock.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, timelock.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, addr1.address)).to.equal(false)
-          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(true)
-          expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(false)
           expect(await main.hasRole(PAUSER, addr1.address)).to.equal(true)
 
           expect(await main.hasRole(OWNER, addr2.address)).to.equal(false)
-          expect(await main.hasRole(SHORT_FREEZER, addr2.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr2.address)).to.equal(true)
           expect(await main.hasRole(LONG_FREEZER, addr2.address)).to.equal(false)
-          expect(await main.hasRole(PAUSER, addr2.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, addr2.address)).to.equal(true)
+
+          expect(await main.hasRole(OWNER, addr3.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr3.address)).to.equal(true)
+          expect(await main.hasRole(LONG_FREEZER, addr3.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, addr3.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, facadeWrite.address)).to.equal(false)
           expect(await main.hasRole(SHORT_FREEZER, facadeWrite.address)).to.equal(false)
@@ -751,18 +747,21 @@ describe('FacadeWrite contract', () => {
 
       context('Deploying Governance - Unpaused', function () {
         beforeEach(async () => {
+          // Remove owner
+          const newGovRoles = { ...govRoles }
+          newGovRoles.owner = ZERO_ADDRESS
+          newGovRoles.pausers.push(addr1.address)
+          newGovRoles.shortFreezers.push(addr1.address)
+
+          // Should handle Zero addresses
+          newGovRoles.pausers.push(ZERO_ADDRESS)
+          newGovRoles.shortFreezers.push(ZERO_ADDRESS)
+          newGovRoles.longFreezers.push(ZERO_ADDRESS)
+
           const receipt = await (
             await facadeWrite
               .connect(deployerUser)
-              .setupGovernance(
-                rToken.address,
-                true,
-                true,
-                govParams,
-                ZERO_ADDRESS,
-                ZERO_ADDRESS,
-                ZERO_ADDRESS
-              )
+              .setupGovernance(rToken.address, true, true, govParams, newGovRoles)
           ).wait()
 
           // Get Governor and Timelock
@@ -776,14 +775,14 @@ describe('FacadeWrite contract', () => {
 
         it('Should setup owner, freezer and pauser correctly', async () => {
           expect(await main.hasRole(OWNER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(SHORT_FREEZER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(LONG_FREEZER, timelock.address)).to.equal(true)
-          expect(await main.hasRole(PAUSER, timelock.address)).to.equal(true)
+          expect(await main.hasRole(SHORT_FREEZER, timelock.address)).to.equal(false)
+          expect(await main.hasRole(LONG_FREEZER, timelock.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, timelock.address)).to.equal(false)
 
           expect(await main.hasRole(OWNER, addr1.address)).to.equal(false)
-          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(SHORT_FREEZER, addr1.address)).to.equal(true)
           expect(await main.hasRole(LONG_FREEZER, addr1.address)).to.equal(false)
-          expect(await main.hasRole(PAUSER, addr1.address)).to.equal(false)
+          expect(await main.hasRole(PAUSER, addr1.address)).to.equal(true)
 
           expect(await main.hasRole(OWNER, addr2.address)).to.equal(false)
           expect(await main.hasRole(SHORT_FREEZER, addr2.address)).to.equal(false)
@@ -817,36 +816,29 @@ describe('FacadeWrite contract', () => {
       })
 
       it('Phase 2 - Without governance', async () => {
+        const newGovRoles = { ...govRoles }
+        newGovRoles.guardian = addr1.address
+        newGovRoles.pausers.push(addr2.address)
+
         // Deploy RToken via FacadeWrite
         await snapshotGasCost(
           await facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              false,
-              false,
-              govParams,
-              owner.address,
-              addr1.address,
-              addr2.address
-            )
+            .setupGovernance(rToken.address, false, false, govParams, newGovRoles)
         )
       })
 
       it('Phase 2 - Deploy governance', async () => {
+        const newGovRoles = { ...govRoles }
+        newGovRoles.owner = ZERO_ADDRESS
+        newGovRoles.guardian = addr1.address
+        newGovRoles.pausers.push(addr2.address)
+
         // Deploy RToken via FacadeWrite
         await snapshotGasCost(
           await facadeWrite
             .connect(deployerUser)
-            .setupGovernance(
-              rToken.address,
-              true,
-              true,
-              govParams,
-              ZERO_ADDRESS,
-              addr1.address,
-              addr2.address
-            )
+            .setupGovernance(rToken.address, true, true, govParams, newGovRoles)
         )
       })
     })

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -5,7 +5,7 @@ import { getChainId } from '../common/blockchain-utils'
 import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../common/configuration'
 import { expectInReceipt } from '../common/events'
 import { bn, fp } from '../common/numbers'
-import { CollateralStatus } from '../common/constants'
+import { CollateralStatus, PAUSER, LONG_FREEZER, SHORT_FREEZER } from '../common/constants'
 import {
   Asset,
   AssetRegistryP1,
@@ -661,6 +661,11 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
 
   // Charge throttle
   await setNextBlockTimestamp(Number(await getLatestBlockTimestamp()) + 3600)
+
+  // Set Owner as Pauser/Freezer for tests
+  await main.connect(owner).grantRole(PAUSER, owner.address)
+  await main.connect(owner).grantRole(SHORT_FREEZER, owner.address)
+  await main.connect(owner).grantRole(LONG_FREEZER, owner.address)
 
   return {
     rsr,

--- a/test/integration/EasyAuction.test.ts
+++ b/test/integration/EasyAuction.test.ts
@@ -23,6 +23,7 @@ import {
   MAX_UINT192,
   MAX_UINT256,
   ONE_ADDRESS,
+  PAUSER,
 } from '../../common/constants'
 import { advanceTime, getLatestBlockTimestamp } from '../utils/time'
 import { expectTrade, getAuctionId, getTrade } from '../utils/trades'
@@ -770,8 +771,11 @@ describeFork(`Gnosis EasyAuction Mainnet Forking - P${IMPLEMENTATION}`, function
         1,
         1
       )
+      // Set pauser and unpause
+      await main.connect(owner).grantRole(PAUSER, owner.address)
       await main.connect(owner).unpauseTrading()
       await main.connect(owner).unpauseIssuance()
+
       await broker.init(main.address, easyAuction.address, ONE_ADDRESS, config.auctionLength)
       const sellTok = await ERC20Factory.deploy('Sell Token', 'SELL', sellTokDecimals)
       const buyTok = await ERC20Factory.deploy('Buy Token', 'BUY', buyTokDecimals)

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -2,6 +2,7 @@ import { BigNumber, ContractFactory } from 'ethers'
 import hre, { ethers } from 'hardhat'
 import { getChainId } from '../../common/blockchain-utils'
 import { IConfig, IImplementations, IRevenueShare, networkConfig } from '../../common/configuration'
+import { PAUSER, SHORT_FREEZER, LONG_FREEZER } from '../../common/constants'
 import { expectInReceipt } from '../../common/events'
 import { advanceTime } from '../utils/time'
 import { bn, fp } from '../../common/numbers'
@@ -847,6 +848,11 @@ export const defaultFixture: Fixture<DefaultFixture> = async function (): Promis
   for (let i = 0; i < basket.length; i++) {
     await backingManager.grantRTokenAllowance(await basket[i].erc20())
   }
+
+  // Set Owner as Pauser/Freezer for tests
+  await main.connect(owner).grantRole(PAUSER, owner.address)
+  await main.connect(owner).grantRole(SHORT_FREEZER, owner.address)
+  await main.connect(owner).grantRole(LONG_FREEZER, owner.address)
 
   return {
     rsr,

--- a/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/compoundv2/CTokenFiatCollateral.test.ts
@@ -10,6 +10,7 @@ import forkBlockNumber from '../../../integration/fork-block-numbers'
 import {
   IConfig,
   IGovParams,
+  IGovRoles,
   IRevenueShare,
   IRTokenConfig,
   IRTokenSetup,
@@ -97,6 +98,7 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
   let facadeTest: FacadeTest
   let facadeWrite: FacadeWrite
   let govParams: IGovParams
+  let govRoles: IGovRoles
 
   // RToken Configuration
   const dist: IRevenueShare = {
@@ -251,15 +253,22 @@ describeFork(`CTokenFiatCollateral - Mainnet Forking P${IMPLEMENTATION}`, functi
       await ethers.getContractAt('RTokenAsset', await assetRegistry.toAsset(rToken.address))
     )
 
+    // Set initial governance roles
+    govRoles = {
+      owner: owner.address,
+      guardian: ZERO_ADDRESS,
+      pausers: [],
+      shortFreezers: [],
+      longFreezers: [],
+    }
+
     // Setup owner and unpause
     await facadeWrite.connect(owner).setupGovernance(
       rToken.address,
       false, // do not deploy governance
       true, // unpaused
       govParams, // mock values, not relevant
-      owner.address, // owner
-      ZERO_ADDRESS, // no guardian
-      ZERO_ADDRESS // no pauser
+      govRoles
     )
 
     // Setup mock chainlink feed for some of the tests (so we can change the value)


### PR DESCRIPTION
* Only grant `OWNER` role to RToken creator. `PAUSER`, `SHORT_FREEZER`, `LONG_FREEZER` have to be done explicitly. Impacts FacadeWrite, Deployer and Auth.
* Allows pausing multiple `pausers`, `shortFreezers`, and `longFreezers` via FacadeWrite.
* Adapts tests and scripts.