### PR TITLE
StRSR: require basket ready

### DIFF
--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -192,7 +192,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
 
         IBasketHandler bh = main.basketHandler();
         require(bh.fullyCollateralized(), "RToken uncollateralized");
-        require(bh.status() == CollateralStatus.SOUND, "basket defaulted");
+        require(bh.isReady(), "basket not ready");
 
         Withdrawal[] storage queue = withdrawals[account];
         if (endId == 0) return;
@@ -223,7 +223,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
 
         // IBasketHandler bh = main.basketHandler();
         // require(bh.fullyCollateralized(), "RToken uncollateralized");
-        // require(bh.status() == CollateralStatus.SOUND, "basket defaulted");
+        // require(bh.isReady(), "basket not ready");
 
         Withdrawal[] storage queue = withdrawals[account];
         if (endId == 0) return;

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -302,7 +302,7 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
 
         // == Checks + Effects ==
         require(basketHandler.fullyCollateralized(), "RToken uncollateralized");
-        require(basketHandler.status() == CollateralStatus.SOUND, "basket defaulted");
+        require(basketHandler.isReady(), "basket not ready");
 
         uint256 firstId = firstRemainingDraft[draftEra][account];
         CumulativeDraft[] storage queue = draftQueues[draftEra][account];
@@ -340,7 +340,7 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
 
         // We specifically allow unstaking when under collateralized
         // require(basketHandler.fullyCollateralized(), "RToken uncollateralized");
-        // require(basketHandler.status() == CollateralStatus.SOUND, "basket defaulted");
+        // require(basketHandler.isReady(), "basket not ready");
 
         uint256 firstId = firstRemainingDraft[draftEra][account];
         CumulativeDraft[] storage queue = draftQueues[draftEra][account];

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -786,7 +786,7 @@ describeExtreme(`StRSRP${IMPLEMENTATION} contract`, () => {
 
         // Attempt to Withdraw
         await expect(stRSR.connect(addr1).withdraw(addr1.address, 1)).to.be.revertedWith(
-          'basket defaulted'
+          'basket not ready'
         )
 
         // Nothing completed
@@ -806,7 +806,7 @@ describeExtreme(`StRSRP${IMPLEMENTATION} contract`, () => {
 
         // Attempt to Withdraw
         await expect(stRSR.connect(addr1).withdraw(addr1.address, 1)).to.be.revertedWith(
-          'basket defaulted'
+          'basket not ready'
         )
       })
 


### PR DESCRIPTION
Similar to how we disallow RToken issuance during the basket warmup period we should also disallow StRSR withdrawals during the basket warmup period. Otherwise, it's possible a staker who has already initiated unstaking could benefit from the basket being SOUND even for just 1 block, which could potentially be manipulated. 