### PR TITLE
store erc20s in deployment file

### DIFF
--- a/scripts/deployment/common.ts
+++ b/scripts/deployment/common.ts
@@ -27,6 +27,7 @@ export interface IDeployments {
 export interface IAssetCollDeployments {
   assets: ITokens
   collateral: ITokens & IPlugins
+  erc20s: ITokens & IPlugins
 }
 
 export interface IRTokenDeployments {

--- a/scripts/deployment/phase2-assets/0_setup_deployments.ts
+++ b/scripts/deployment/phase2-assets/0_setup_deployments.ts
@@ -37,6 +37,7 @@ async function main() {
   const deployments: IAssetCollDeployments = {
     assets: {},
     collateral: {},
+    erc20s: {},
   }
   fs.writeFileSync(deploymentFilename, JSON.stringify(deployments, null, 2))
 

--- a/scripts/deployment/phase2-assets/1_deploy_assets.ts
+++ b/scripts/deployment/phase2-assets/1_deploy_assets.ts
@@ -48,6 +48,7 @@ async function main() {
   await (<Asset>await ethers.getContractAt('Asset', stkAAVEAsset)).refresh()
 
   assetCollDeployments.assets.stkAAVE = stkAAVEAsset
+  assetCollDeployments.erc20s.stkAAVE = networkConfig[chainId].tokens.stkAAVE
   deployedAssets.push(stkAAVEAsset.toString())
 
   /********  Deploy Comp Asset **************************/
@@ -62,6 +63,7 @@ async function main() {
   await (<Asset>await ethers.getContractAt('Asset', compAsset)).refresh()
 
   assetCollDeployments.assets.COMP = compAsset
+  assetCollDeployments.erc20s.COMP = networkConfig[chainId].tokens.COMP
   deployedAssets.push(compAsset.toString())
 
   /**************************************************************/

--- a/scripts/deployment/phase2-assets/2_deploy_collateral.ts
+++ b/scripts/deployment/phase2-assets/2_deploy_collateral.ts
@@ -59,6 +59,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.DAI = daiCollateral
+  assetCollDeployments.erc20s.DAI = networkConfig[chainId].tokens.DAI
   deployedCollateral.push(daiCollateral.toString())
 
   /********  Deploy Fiat Collateral - USDC  **************************/
@@ -80,6 +81,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.USDC = usdcCollateral
+  assetCollDeployments.erc20s.USDC = networkConfig[chainId].tokens.USDC
   deployedCollateral.push(usdcCollateral.toString())
 
   /********  Deploy Fiat Collateral - USDT  **************************/
@@ -101,6 +103,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.USDT = usdtCollateral
+  assetCollDeployments.erc20s.USDT = networkConfig[chainId].tokens.USDT
   deployedCollateral.push(usdtCollateral.toString())
 
   /********  Deploy Fiat Collateral - USDP  **************************/
@@ -122,6 +125,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.USDP = usdpCollateral
+  assetCollDeployments.erc20s.USDP = networkConfig[chainId].tokens.USDP
   deployedCollateral.push(usdpCollateral.toString())
 
   /********  Deploy Fiat Collateral - TUSD  **************************/
@@ -141,6 +145,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.TUSD = tusdCollateral
+  assetCollDeployments.erc20s.TUSD = networkConfig[chainId].tokens.TUSD
   deployedCollateral.push(tusdCollateral.toString())
 
   /********  Deploy Fiat Collateral - BUSD  **************************/
@@ -162,6 +167,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.BUSD = busdCollateral
+  assetCollDeployments.erc20s.BUSD = networkConfig[chainId].tokens.BUSD
   deployedCollateral.push(busdCollateral.toString())
 
   /********  Deploy AToken Fiat Collateral - aDAI  **************************/
@@ -205,6 +211,7 @@ async function main() {
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
 
   assetCollDeployments.collateral.aDAI = aDaiCollateral
+  assetCollDeployments.erc20s.aDAI = adaiStaticToken.address
   deployedCollateral.push(aDaiCollateral.toString())
 
   /********  Deploy AToken Fiat Collateral - aUSDC  **************************/
@@ -246,6 +253,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.aUSDC = aUsdcCollateral
+  assetCollDeployments.erc20s.aUSDC = ausdcStaticToken.address
   deployedCollateral.push(aUsdcCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -289,6 +297,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.aUSDT = aUsdtCollateral
+  assetCollDeployments.erc20s.aUSDT = ausdtStaticToken.address
   deployedCollateral.push(aUsdtCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -331,6 +340,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.aBUSD = aBusdCollateral
+  assetCollDeployments.erc20s.aBUSD = abusdStaticToken.address
   deployedCollateral.push(aBusdCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -374,6 +384,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.aUSDP = aUsdpCollateral
+  assetCollDeployments.erc20s.aUSDP = ausdpStaticToken.address
   deployedCollateral.push(aUsdpCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -399,13 +410,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', cDaiCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cDAI = cDaiCollateral
+  assetCollDeployments.erc20s.cDAI = cDaiVault.address
   deployedCollateral.push(cDaiCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -430,13 +442,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', cUsdcCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cUSDC = cUsdcCollateral
+  assetCollDeployments.erc20s.cUSDC = cUsdcVault.address
   deployedCollateral.push(cUsdcCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -461,13 +474,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', cUsdtCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cUSDT = cUsdtCollateral
+  assetCollDeployments.erc20s.cUSDT = cUsdtVault.address
   deployedCollateral.push(cUsdtCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -492,13 +506,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.02').toString(), // 2%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', cUsdpCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cUSDP = cUsdpCollateral
+  assetCollDeployments.erc20s.cUSDP = cUsdpVault.address
   deployedCollateral.push(cUsdpCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -529,13 +544,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('BTC'),
     defaultThreshold: fp('0.01').add(combinedBTCWBTCError).toString(), // ~3.5%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', cWBTCCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cWBTC = cWBTCCollateral
+  assetCollDeployments.erc20s.cWBTC = cWBTCVault.address
   deployedCollateral.push(cWBTCCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -566,6 +582,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.cETH = cETHCollateral
+  assetCollDeployments.erc20s.cETH = cETHVault.address
   deployedCollateral.push(cETHCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -589,6 +606,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.WBTC = wBTCCollateral
+  assetCollDeployments.erc20s.WBTC = networkConfig[chainId].tokens.WBTC
   deployedCollateral.push(wBTCCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -609,6 +627,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.WETH = wETHCollateral
+  assetCollDeployments.erc20s.WETH = networkConfig[chainId].tokens.WETH
   deployedCollateral.push(wETHCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -634,6 +653,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.EURT = eurtCollateral
+  assetCollDeployments.erc20s.EURT = networkConfig[chainId].tokens.EURT
   deployedCollateral.push(eurtCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/2_deploy_collateral.ts
+++ b/scripts/deployment/phase2-assets/2_deploy_collateral.ts
@@ -400,6 +400,10 @@ async function main() {
     networkConfig[chainId].COMPTROLLER!
   )
 
+  await cDaiVault.deployed()
+
+  console.log(`Deployed Vault for cDAI on ${hre.network.name} (${chainId}): ${cDaiVault.address} `)
+
   const { collateral: cDaiCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
     priceTimeout: priceTimeout.toString(),
     priceFeed: networkConfig[chainId].chainlinkFeeds.DAI,
@@ -430,6 +434,12 @@ async function main() {
     `${await cUsdc.name()} Vault`,
     `${await cUsdc.symbol()}-VAULT`,
     networkConfig[chainId].COMPTROLLER!
+  )
+
+  await cUsdcVault.deployed()
+
+  console.log(
+    `Deployed Vault for cUSDC on ${hre.network.name} (${chainId}): ${cUsdcVault.address} `
   )
 
   const { collateral: cUsdcCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
@@ -464,6 +474,12 @@ async function main() {
     networkConfig[chainId].COMPTROLLER!
   )
 
+  await cUsdtVault.deployed()
+
+  console.log(
+    `Deployed Vault for cUSDT on ${hre.network.name} (${chainId}): ${cUsdtVault.address} `
+  )
+
   const { collateral: cUsdtCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
     priceTimeout: priceTimeout.toString(),
     priceFeed: networkConfig[chainId].chainlinkFeeds.USDT,
@@ -496,6 +512,12 @@ async function main() {
     networkConfig[chainId].COMPTROLLER!
   )
 
+  await cUsdpVault.deployed()
+
+  console.log(
+    `Deployed Vault for cUSDP on ${hre.network.name} (${chainId}): ${cUsdpVault.address} `
+  )
+
   const { collateral: cUsdpCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
     priceTimeout: priceTimeout.toString(),
     priceFeed: networkConfig[chainId].chainlinkFeeds.USDP,
@@ -526,6 +548,12 @@ async function main() {
     `${await cWBTC.name()} Vault`,
     `${await cWBTC.symbol()}-VAULT`,
     networkConfig[chainId].COMPTROLLER!
+  )
+
+  await cWBTCVault.deployed()
+
+  console.log(
+    `Deployed Vault for cWBTC on ${hre.network.name} (${chainId}): ${cWBTCVault.address} `
   )
 
   const wbtcOracleError = fp('0.02') // 2%
@@ -565,6 +593,10 @@ async function main() {
     `${await cETH.symbol()}-VAULT`,
     networkConfig[chainId].COMPTROLLER!
   )
+
+  await cETHVault.deployed()
+
+  console.log(`Deployed Vault for cETH on ${hre.network.name} (${chainId}): ${cETHVault.address} `)
 
   const { collateral: cETHCollateral } = await hre.run('deploy-ctoken-selfreferential-collateral', {
     priceTimeout: priceTimeout.toString(),

--- a/scripts/deployment/phase2-assets/assets/deploy_crv.ts
+++ b/scripts/deployment/phase2-assets/assets/deploy_crv.ts
@@ -48,6 +48,7 @@ async function main() {
   await (<Asset>await ethers.getContractAt('Asset', crvAsset)).refresh()
 
   assetCollDeployments.assets.CRV = crvAsset
+  assetCollDeployments.erc20s.CRV = networkConfig[chainId].tokens.CRV
   deployedAssets.push(crvAsset.toString())
 
   /**************************************************************/

--- a/scripts/deployment/phase2-assets/assets/deploy_cvx.ts
+++ b/scripts/deployment/phase2-assets/assets/deploy_cvx.ts
@@ -48,6 +48,7 @@ async function main() {
   await (<Asset>await ethers.getContractAt('Asset', cvxAsset)).refresh()
 
   assetCollDeployments.assets.CVX = cvxAsset
+  assetCollDeployments.erc20s.CVX = networkConfig[chainId].tokens.CVX
   deployedAssets.push(cvxAsset.toString())
 
   /**************************************************************/

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_rToken_metapool_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_rToken_metapool_plugin.ts
@@ -114,6 +114,7 @@ async function main() {
   )
 
   assetCollDeployments.collateral.cvxeUSDFRAXBP = collateral.address
+  assetCollDeployments.erc20s.cvxeUSDFRAXBP = wPool.address
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_rToken_metapool_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_rToken_metapool_plugin.ts
@@ -75,6 +75,10 @@ async function main() {
   await wPool.deployed()
   await (await wPool.initialize(eUSD_FRAX_BP_POOL_ID)).wait()
 
+  console.log(
+    `Deployed wrapper for Convex eUSD/FRAX Metapool on ${hre.network.name} (${chainId}): ${wPool.address} `
+  )
+
   const collateral = <CvxStableRTokenMetapoolCollateral>await CvxStableCollateralFactory.connect(
     deployer
   ).deploy(

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_metapool_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_metapool_plugin.ts
@@ -121,6 +121,7 @@ async function main() {
   )
 
   assetCollDeployments.collateral.cvxMIM3Pool = collateral.address
+  assetCollDeployments.erc20s.cvxMIM3Pool = wPool.address
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_metapool_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_metapool_plugin.ts
@@ -81,6 +81,10 @@ async function main() {
   await wPool.deployed()
   await (await wPool.initialize(MIM_THREE_POOL_POOL_ID)).wait()
 
+  console.log(
+    `Deployed wrapper for Convex Stable MIM/3Pool on ${hre.network.name} (${chainId}): ${wPool.address} `
+  )
+
   const collateral = <CvxStableMetapoolCollateral>await CvxStableCollateralFactory.connect(
     deployer
   ).deploy(
@@ -117,7 +121,7 @@ async function main() {
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   console.log(
-    `Deployed Convex RToken Metapool Collateral to ${hre.network.name} (${chainId}): ${collateral.address}`
+    `Deployed Convex Metapool Collateral to ${hre.network.name} (${chainId}): ${collateral.address}`
   )
 
   assetCollDeployments.collateral.cvxMIM3Pool = collateral.address

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_plugin.ts
@@ -111,6 +111,7 @@ async function main() {
   )
 
   assetCollDeployments.collateral.cvx3Pool = collateral.address
+  assetCollDeployments.erc20s.cvx3Pool = w3Pool.address
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_stable_plugin.ts
@@ -75,6 +75,10 @@ async function main() {
   await w3Pool.deployed()
   await (await w3Pool.initialize(THREE_POOL_CVX_POOL_ID)).wait()
 
+  console.log(
+    `Deployed wrapper for Convex Stable 3Pool on ${hre.network.name} (${chainId}): ${w3Pool.address} `
+  )
+
   const collateral = <CvxStableCollateral>await CvxStableCollateralFactory.connect(deployer).deploy(
     {
       erc20: w3Pool.address,

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_volatile_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_volatile_plugin.ts
@@ -78,6 +78,10 @@ async function main() {
   await w3Pool.deployed()
   await (await w3Pool.initialize(TRI_CRYPTO_CVX_POOL_ID)).wait()
 
+  console.log(
+    `Deployed wrapper for Convex Volatile TriCrypto on ${hre.network.name} (${chainId}): ${w3Pool.address} `
+  )
+
   const collateral = <CvxVolatileCollateral>await CvxVolatileCollateralFactory.connect(
     deployer
   ).deploy(

--- a/scripts/deployment/phase2-assets/collaterals/deploy_convex_volatile_plugin.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_convex_volatile_plugin.ts
@@ -120,6 +120,7 @@ async function main() {
   )
 
   assetCollDeployments.collateral.cvxTriCrypto = collateral.address
+  assetCollDeployments.erc20s.cvxTriCrypto = w3Pool.address
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_ctokenv3_usdc_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_ctokenv3_usdc_collateral.ts
@@ -51,6 +51,8 @@ async function main() {
   )
   await erc20.deployed()
 
+  console.log(`Deployed wrapper for cUSDCv3 on ${hre.network.name} (${chainId}): ${erc20.address} `)
+
   const CTokenV3Factory: ContractFactory = await hre.ethers.getContractFactory('CTokenV3Collateral')
 
   const collateral = <CTokenV3Collateral>await CTokenV3Factory.connect(deployer).deploy(

--- a/scripts/deployment/phase2-assets/collaterals/deploy_ctokenv3_usdc_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_ctokenv3_usdc_collateral.ts
@@ -75,6 +75,7 @@ async function main() {
   console.log(`Deployed CompoundV3 USDC to ${hre.network.name} (${chainId}): ${collateral.address}`)
 
   assetCollDeployments.collateral.cUSDCv3 = collateral.address
+  assetCollDeployments.erc20s.cUSDCv3 = erc20.address
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_flux_finance_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_flux_finance_collateral.ts
@@ -14,7 +14,6 @@ import {
 } from '../../common'
 import { priceTimeout, oracleTimeout, revenueHiding } from '../../utils'
 import { ICollateral } from '../../../../typechain'
-import { ZERO_ADDRESS } from '#/tasks/deployment/create-deployer-registry'
 
 async function main() {
   // ==== Read Configuration ====
@@ -62,13 +61,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   let collateral = <ICollateral>await ethers.getContractAt('ICollateral', fUsdcCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.fUSDC = fUsdcCollateral
+  assetCollDeployments.erc20s.fUSDC = fUsdcVault.address
   deployedCollateral.push(fUsdcCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -93,13 +93,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', fUsdtCollateral)
   await (await collateral.refresh()).wait()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.fUSDT = fUsdtCollateral
+  assetCollDeployments.erc20s.fUSDT = fUsdtVault.address
   deployedCollateral.push(fUsdtCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -124,13 +125,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.0125').toString(), // 1.25%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', fDaiCollateral)
   await collateral.refresh()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.fDAI = fDaiCollateral
+  assetCollDeployments.erc20s.fDAI = fDaiVault.address
   deployedCollateral.push(fDaiCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))
@@ -155,13 +157,14 @@ async function main() {
     targetName: hre.ethers.utils.formatBytes32String('USD'),
     defaultThreshold: fp('0.02').toString(), // 2%
     delayUntilDefault: bn('86400').toString(), // 24h
-    revenueHiding: revenueHiding.toString()
+    revenueHiding: revenueHiding.toString(),
   })
   collateral = <ICollateral>await ethers.getContractAt('ICollateral', fFRAXCollateral)
   await collateral.refresh()
   expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
   assetCollDeployments.collateral.fFRAX = fFRAXCollateral
+  assetCollDeployments.erc20s.fFRAX = fFraxVault.address
   deployedCollateral.push(fFRAXCollateral.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_flux_finance_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_flux_finance_collateral.ts
@@ -51,6 +51,12 @@ async function main() {
     networkConfig[chainId].COMPTROLLER!
   )
 
+  await fUsdcVault.deployed()
+
+  console.log(
+    `Deployed Vault for fUSDC on ${hre.network.name} (${chainId}): ${fUsdcVault.address} `
+  )
+
   const { collateral: fUsdcCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
     priceTimeout: priceTimeout.toString(),
     priceFeed: networkConfig[chainId].chainlinkFeeds.USDC,
@@ -81,6 +87,12 @@ async function main() {
     `${await fUsdt.name()} Vault`,
     `${await fUsdt.symbol()}-VAULT`,
     networkConfig[chainId].COMPTROLLER!
+  )
+
+  await fUsdtVault.deployed()
+
+  console.log(
+    `Deployed Vault for fUSDT on ${hre.network.name} (${chainId}): ${fUsdtVault.address} `
   )
 
   const { collateral: fUsdtCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
@@ -115,6 +127,10 @@ async function main() {
     networkConfig[chainId].COMPTROLLER!
   )
 
+  await fDaiVault.deployed()
+
+  console.log(`Deployed Vault for fDAI on ${hre.network.name} (${chainId}): ${fDaiVault.address} `)
+
   const { collateral: fDaiCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {
     priceTimeout: priceTimeout.toString(),
     priceFeed: networkConfig[chainId].chainlinkFeeds.DAI,
@@ -145,6 +161,12 @@ async function main() {
     `${await fFrax.name()} Vault`,
     `${await fFrax.symbol()}-VAULT`,
     networkConfig[chainId].COMPTROLLER!
+  )
+
+  await fFraxVault.deployed()
+
+  console.log(
+    `Deployed Vault for fFRAX on ${hre.network.name} (${chainId}): ${fFraxVault.address} `
   )
 
   const { collateral: fFRAXCollateral } = await hre.run('deploy-ctoken-fiat-collateral', {

--- a/scripts/deployment/phase2-assets/collaterals/deploy_lido_wsteth_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_lido_wsteth_collateral.ts
@@ -71,6 +71,7 @@ async function main() {
   console.log(`Deployed Lido wStETH to ${hre.network.name} (${chainId}): ${collateral.address}`)
 
   assetCollDeployments.collateral.wstETH = collateral.address
+  assetCollDeployments.erc20s.wstETH = networkConfig[chainId].tokens.wstETH
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))

--- a/scripts/deployment/phase2-assets/collaterals/deploy_rocket_pool_reth_collateral.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_rocket_pool_reth_collateral.ts
@@ -69,6 +69,7 @@ async function main() {
   console.log(`Deployed Rocketpool rETH to ${hre.network.name} (${chainId}): ${collateral.address}`)
 
   assetCollDeployments.collateral.rETH = collateral.address
+  assetCollDeployments.erc20s.rETH = networkConfig[chainId].tokens.rETH
   deployedCollateral.push(collateral.address.toString())
 
   fs.writeFileSync(assetCollDeploymentFilename, JSON.stringify(assetCollDeployments, null, 2))


### PR DESCRIPTION
* Stores `erc20s` addresses in the deployment files for all assets and collaterals.
* The address stored belongs to the main ERC20 used for that specific asset/collateral. This means it would be the wrapper tokens or vaults when they are applied.