### PR TITLE
tweaks for better upgrade checking

### DIFF
--- a/scripts/deployment/phase1-common/2_deploy_implementations.ts
+++ b/scripts/deployment/phase1-common/2_deploy_implementations.ts
@@ -190,7 +190,7 @@ async function main() {
   if (!upgrade) {
     backingMgrImplAddr = await upgrades.deployImplementation(BackingMgrImplFactory, {
       kind: 'uups',
-      unsafeAllow: ['external-library-linking'],
+      unsafeAllow: ['external-library-linking', 'delegatecall'],
     })
   } else {
     backingMgrImplAddr = await upgrades.prepareUpgrade(
@@ -198,7 +198,7 @@ async function main() {
       BackingMgrImplFactory,
       {
         kind: 'uups',
-        unsafeAllow: ['external-library-linking'],
+        unsafeAllow: ['external-library-linking', 'delegatecall'],
       }
     )
   }
@@ -340,6 +340,7 @@ async function main() {
   if (!upgrade) {
     rsrTraderImplAddr = await upgrades.deployImplementation(RevTraderImplFactory, {
       kind: 'uups',
+      unsafeAllow: ['delegatecall'],
     })
     rTokenTraderImplAddr = rsrTraderImplAddr // Both equal in initial deployment
   } else {
@@ -349,6 +350,7 @@ async function main() {
       RevTraderImplFactory,
       {
         kind: 'uups',
+        unsafeAllow: ['delegatecall'],
       }
     )
 
@@ -363,6 +365,7 @@ async function main() {
         RevTraderImplFactory,
         {
           kind: 'uups',
+          unsafeAllow: ['delegatecall'],
         }
       )
     } else {

--- a/tasks/upgrades/utils.ts
+++ b/tasks/upgrades/utils.ts
@@ -18,13 +18,14 @@ export const validateDeployments = async (
   }
 
   // Check basket lib defined
-  if (!deployments.basketLib) {
-    throw new Error(
-      `Missing deployed BasketLib for version ${version} in network ${hre.network.name}`
-    )
-  } else if (!(await isValidContract(hre, deployments.basketLib))) {
-    throw new Error(`BasketLib contract not found in network ${hre.network.name}`)
-  }
+  // Only enable after 3.0.0 for future releases
+  //   if (!deployments.basketLib) {
+  //     throw new Error(
+  //       `Missing deployed BasketLib for version ${version} in network ${hre.network.name}`
+  //     )
+  //   } else if (!(await isValidContract(hre, deployments.basketLib))) {
+  //     throw new Error(`BasketLib contract not found in network ${hre.network.name}`)
+  //   }
 
   // Check Main implementation is defined
   if (!deployments.implementations.main) {

--- a/tasks/upgrades/validate-upgrade.ts
+++ b/tasks/upgrades/validate-upgrade.ts
@@ -83,12 +83,14 @@ task('validate-upgrade', 'Validates if upgrade to new version is safe')
       deployments.implementations.components.rsrTrader,
       'RevenueTraderP1',
       undefined,
+      undefined,
       ['delegatecall']
     )
     await validateUpgrade(
       hre,
       deployments.implementations.components.rTokenTrader,
       'RevenueTraderP1',
+      undefined,
       undefined,
       ['delegatecall']
     )


### PR DESCRIPTION
* Restore allows for delegate calls
* Skip validation of `basketLib` in `validate-upgrade` which only makes sense for versions > 3.0.0 but not for the initial run.

Note: Opened an issue with OZ to undertand by some of the external libs are detected but not all. This does not impact the main use of the plugin which is storage layouts, which seem to work really nice. Checked 3.0.0 is OK.