### PR TITLE
remove prime nonce

### DIFF
--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -20,16 +20,10 @@ struct BasketRange {
  */
 interface IBasketHandler is IComponent {
     /// Emitted when the prime basket is set
-    /// @param nonce {basketNonce} The first nonce under the prime basket; may not exist yet
     /// @param erc20s The collateral tokens for the prime basket
     /// @param targetAmts {target/BU} A list of quantities of target unit per basket unit
     /// @param targetNames Each collateral token's targetName
-    event PrimeBasketSet(
-        uint256 indexed nonce,
-        IERC20[] erc20s,
-        uint192[] targetAmts,
-        bytes32[] targetNames
-    );
+    event PrimeBasketSet(IERC20[] erc20s, uint192[] targetAmts, bytes32[] targetNames);
 
     /// Emitted when the reference basket is set
     /// @param nonce {basketNonce} The basket nonce

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -145,10 +145,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     uint48 private lastStatusTimestamp;
     CollateralStatus private lastStatus;
 
-    // Nonce of the first reference basket from the current history
-    // There can be 0 to any number of baskets with nonce >= primeNonce
-    uint48 public primeNonce; // {basketNonce}
-
     // A history of baskets by basket nonce; includes current basket
     mapping(uint48 => Basket) private basketHistory;
 
@@ -273,8 +269,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             config.targetNames[erc20s[i]] = names[i];
         }
 
-        primeNonce = nonce + 1; // set primeNonce to the next nonce
-        emit PrimeBasketSet(primeNonce, erc20s, targetAmts, names);
+        emit PrimeBasketSet(erc20s, targetAmts, names);
     }
 
     /// Set the backup configuration for some target name
@@ -458,8 +453,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         uint192[] memory portions,
         uint192 amount
     ) external view returns (address[] memory erc20s, uint256[] memory quantities) {
-        // directly after upgrade the primeNonce will be 0, which is not a valid value
-        require(primeNonce > 0, "primeNonce uninitialized");
         require(basketNonces.length == portions.length, "portions does not mirror basketNonces");
 
         IERC20[] memory erc20sAll = new IERC20[](main.assetRegistry().size());
@@ -469,10 +462,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
         // Calculate the linear combination basket
         for (uint48 i = 0; i < basketNonces.length; ++i) {
-            require(
-                basketNonces[i] >= primeNonce && basketNonces[i] <= nonce,
-                "invalid basketNonce"
-            ); // will always revert directly after setPrimeBasket()
+            require(basketNonces[i] <= nonce, "invalid basketNonce");
             Basket storage b = basketHistory[basketNonces[i]];
 
             // Add-in refAmts contribution from historical basket

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1888,7 +1888,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       // Set basket
       await expect(basketHandler.connect(owner).setPrimeBasket([token0.address], [fp('1')]))
         .to.emit(basketHandler, 'PrimeBasketSet')
-        .withArgs(2, [token0.address], [fp('1')], [ethers.utils.formatBytes32String('USD')])
+        .withArgs([token0.address], [fp('1')], [ethers.utils.formatBytes32String('USD')])
     })
 
     it('Should revert if target has been changed in asset registry', async () => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -1112,36 +1112,36 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         await expect(rToken.connect(addr1).redeem(bn(redeemAmount))).to.not.be.reverted
       })
 
-      it('Should revert while rebalancing after prime basket change', async function () {
+      it('Should behave correctly after basket change', async function () {
         // New prime basket
         await basketHandler.connect(owner).setPrimeBasket([token1.address], [fp('1')])
         expect(await basketHandler.fullyCollateralized()).to.equal(true) // ref basket hasn't changed
 
-        // Should still redeem through the main flow; not custom flow
-        await rToken.connect(addr1).redeem(1)
-        await expect(
-          rToken
-            .connect(addr1)
-            .redeemCustom(addr1.address, 1, [await basketHandler.nonce()], [fp('1')], [], [])
-        ).to.be.revertedWith('invalid basketNonce')
+        // Should be able to redeem through both main flow and custom flow
+        await rToken.connect(addr1).redeem(fp('1'))
+        await rToken
+          .connect(addr1)
+          .redeemCustom(addr1.address, fp('1'), [await basketHandler.nonce()], [fp('1')], [], [])
 
         // New reference basket
         await basketHandler.refreshBasket()
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
 
-        // Before the first auction is completed, BOTH redemption methods are bricked
+        // Custom redemption should not revert since there is collateral overlap
         await expect(rToken.connect(addr1).redeem(1)).to.be.revertedWith(
           'partial redemption; use redeemCustom'
         )
         const nonce = await basketHandler.nonce()
+        await rToken.connect(addr1).redeemCustom(addr1.address, fp('1'), [nonce], [fp('1')], [], [])
+
+        // Previous basket nonce should be redeemable
+        await rToken
+          .connect(addr1)
+          .redeemCustom(addr1.address, fp('1'), [nonce - 1], [fp('1')], [], [])
+
+        // Future basket nonce should not be redeemable
         await expect(
-          rToken.connect(addr1).redeemCustom(addr1.address, 1, [nonce], [fp('1')], [], [])
-        ).to.be.revertedWith('empty redemption')
-        await expect(
-          rToken.connect(addr1).redeemCustom(addr1.address, 1, [nonce - 1], [fp('1')], [], [])
-        ).to.be.revertedWith('invalid basketNonce')
-        await expect(
-          rToken.connect(addr1).redeemCustom(addr1.address, 1, [nonce + 1], [fp('1')], [], [])
+          rToken.connect(addr1).redeemCustom(addr1.address, fp('1'), [nonce + 1], [fp('1')], [], [])
         ).to.be.revertedWith('invalid basketNonce')
       })
 
@@ -1718,38 +1718,6 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
 
         // Check values
         expect(await rToken.totalSupply()).to.equal(issueAmount.div(2))
-      })
-
-      it('Should enforce primeNonce <-> reference nonce relationship #fast', async function () {
-        const portions = [fp('1')]
-        await expect(
-          rToken
-            .connect(addr1)
-            .redeemCustom(addr1.address, issueAmount.div(2), [2], portions, [], [])
-        ).to.be.revertedWith('invalid basketNonce')
-
-        // Bump primeNonce
-        await basketHandler.connect(owner).setPrimeBasket([token1.address], [fp('1')])
-
-        // Old basket is no longer redeemable
-        await expect(
-          rToken
-            .connect(addr1)
-            .redeemCustom(addr1.address, issueAmount.div(2), [1], portions, [], [])
-        ).to.be.revertedWith('invalid basketNonce')
-
-        // Nonce 2 still doesn't have a reference basket yet
-        await expect(
-          rToken
-            .connect(addr1)
-            .redeemCustom(addr1.address, issueAmount.div(2), [2], portions, [], [])
-        ).to.be.revertedWith('invalid basketNonce')
-
-        // Refresh reference basket
-        await basketHandler.connect(owner).refreshBasket()
-        await rToken
-          .connect(addr1)
-          .redeemCustom(addr1.address, issueAmount.div(2), [2], portions, [], [])
       })
 
       it('Should prorate redemption if basket is DISABLED from fallen refPerTok() #fast', async function () {


### PR DESCRIPTION
The primeNonce should have been deleted when we added `requireConstantConfigTargets()`

I checked the storage slots, and they are unchanged