### PR TITLE
Gas optimize rebalance

### DIFF
--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -146,11 +146,6 @@ interface IBasketHandler is IComponent {
     /// @return lotHigh {UoA/tok} The upper end of the lot price estimate
     function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh);
 
-    /// Returns both the price & lotPrice at once, for gas optimization
-    /// @return price_ {UoA/tok} The low and high price estimate of an RToken
-    /// @return lotPrice_ {UoA/tok} The low and high lotprice of an RToken
-    function prices() external view returns (Price memory price_, Price memory lotPrice_);
-
     /// @return timestamp The timestamp at which the basket was last set
     function timestamp() external view returns (uint48);
 

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -5,14 +5,13 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IComponent.sol";
 
 uint256 constant MAX_DISTRIBUTION = 1e4; // 10,000
-uint8 constant MAX_DESTINATIONS = 100;
 
 struct RevenueShare {
     uint16 rTokenDist; // {revShare} A value between [0, 10,000]
     uint16 rsrDist; // {revShare} A value between [0, 10,000]
 }
 
-/// Assumes no more than MAX_DESTINATIONS independent distributions.
+/// Assumes no more than 100 independent distributions.
 struct RevenueTotals {
     uint24 rTokenTotal; // {revShare}
     uint24 rsrTotal; // {revShare}

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -15,6 +15,9 @@ struct RevenueTotals {
     uint24 rsrTotal; // {revShare}
 }
 
+// The maximum value of rTokenTotal and rsrTotal; up to 1024 entries, each up to 10,000
+uint256 constant MAX_REVENUE_TOTALS = 1024 * 1e4;
+
 /**
  * @title IDistributor
  * @notice The Distributor Component maintains a revenue distribution table that dictates

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -4,19 +4,20 @@ pragma solidity 0.8.17;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IComponent.sol";
 
+uint256 constant MAX_DISTRIBUTION = 1e4; // 10,000
+uint8 constant MAX_DESTINATIONS = 100;
+
 struct RevenueShare {
     uint16 rTokenDist; // {revShare} A value between [0, 10,000]
     uint16 rsrDist; // {revShare} A value between [0, 10,000]
 }
 
-/// Assumes no more than 1024 independent distributions.
+/// Assumes no more than MAX_DESTINATIONS independent distributions.
+/// Each total can only be at most MAX_DISTRIBUTION * MAX_DESTINATIONS
 struct RevenueTotals {
     uint24 rTokenTotal; // {revShare}
     uint24 rsrTotal; // {revShare}
 }
-
-// The maximum value of rTokenTotal and rsrTotal; up to 1024 entries, each up to 10,000
-uint256 constant MAX_REVENUE_TOTALS = 1024 * 1e4;
 
 /**
  * @title IDistributor

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -13,7 +13,6 @@ struct RevenueShare {
 }
 
 /// Assumes no more than MAX_DESTINATIONS independent distributions.
-/// Each total can only be at most MAX_DISTRIBUTION * MAX_DESTINATIONS
 struct RevenueTotals {
     uint24 rTokenTotal; // {revShare}
     uint24 rsrTotal; // {revShare}

--- a/contracts/interfaces/IDistributor.sol
+++ b/contracts/interfaces/IDistributor.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IComponent.sol";
 
 uint256 constant MAX_DISTRIBUTION = 1e4; // 10,000
+uint8 constant MAX_DESTINATIONS = 100; // maximum number of RevenueShare destinations
 
 struct RevenueShare {
     uint16 rTokenDist; // {revShare} A value between [0, 10,000]

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -117,11 +117,13 @@ interface IRToken is IComponent, IERC20MetadataUpgradeable, IERC20PermitUpgradea
 
     /// Melt a quantity of RToken from the caller's account
     /// @param amount {qRTok} The amount to be melted
+    /// @custom:protected
     function melt(uint256 amount) external;
 
-    /// Giveup an amount of RToken from caller's account and scales basketsNeeded down
-    /// Callable only by backingManager
-    function giveup(uint256 amount) external;
+    /// Dissolve an amount of RToken from caller's account and scale basketsNeeded down
+    /// Callable only by BackingManager
+    /// @custom:protected
+    function dissolve(uint256 amount) external;
 
     /// Set the number of baskets needed directly, callable only by the BackingManager
     /// @param basketsNeeded {BU} The number of baskets to target

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -119,6 +119,10 @@ interface IRToken is IComponent, IERC20MetadataUpgradeable, IERC20PermitUpgradea
     /// @param amount {qRTok} The amount to be melted
     function melt(uint256 amount) external;
 
+    /// Giveup an amount of RToken from caller's account and scales basketsNeeded down
+    /// Callable only by backingManager
+    function giveup(uint256 amount) external;
+
     /// Set the number of baskets needed directly, callable only by the BackingManager
     /// @param basketsNeeded {BU} The number of baskets to target
     ///                      needed range: pretty interesting

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -91,6 +91,11 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
         );
         require(!main.basketHandler().fullyCollateralized(), "already collateralized");
 
+        // First giveup any held RToken balance (no token transfers required)
+        uint256 balance = main.rToken().balanceOf(address(this));
+        if (balance > 0) main.rToken().giveup(balance);
+        if (main.basketHandler().fullyCollateralized()) return; // return if now capitalized
+
         /*
          * Recollateralization
          *
@@ -201,6 +206,8 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
             }
         }
     }
+
+    // === Private ===
 
     /// Compromise on how many baskets are needed in order to recollateralize-by-accounting
     /// @param wholeBasketsHeld {BU} The number of full basket units held by the BackingManager

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -91,9 +91,10 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
         );
         require(!main.basketHandler().fullyCollateralized(), "already collateralized");
 
-        // First giveup any held RToken balance (no token transfers required)
+        // First dissolve any held RToken balance above Distributor-dust
+        // gas-optimization: 1 whole RToken must be worth 100 trillion dollars for this to skip $1
         uint256 balance = main.rToken().balanceOf(address(this));
-        if (balance > 0) main.rToken().giveup(balance);
+        if (balance >= MAX_DISTRIBUTION * MAX_DESTINATIONS) main.rToken().dissolve(balance);
         if (main.basketHandler().fullyCollateralized()) return; // return if now capitalized
 
         /*

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -368,53 +368,46 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     }
 
     /// Should not revert
-    /// @return {UoA/BU} The lower end of the price estimate
-    /// @return {UoA/BU} The upper end of the price estimate
+    /// @return low {UoA/BU} The lower end of the price estimate
+    /// @return high {UoA/BU} The upper end of the price estimate
     // returns sum(quantity(erc20) * price(erc20) for erc20 in basket.erc20s)
-    function price() external view returns (uint192, uint192) {
-        (Price memory p, ) = prices();
-        return (p.low, p.high);
+    function price() external view returns (uint192 low, uint192 high) {
+        return _price(false);
     }
 
     /// Should not revert
     /// lowLow should be nonzero when the asset might be worth selling
-    /// @return {UoA/BU} The lower end of the lot price estimate
-    /// @return {UoA/BU} The upper end of the lot price estimate
+    /// @return lotLow {UoA/BU} The lower end of the lot price estimate
+    /// @return lotHigh {UoA/BU} The upper end of the lot price estimate
     // returns sum(quantity(erc20) * lotPrice(erc20) for erc20 in basket.erc20s)
-    function lotPrice() external view returns (uint192, uint192) {
-        (, Price memory lotP) = prices();
-        return (lotP.low, lotP.high);
+    function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh) {
+        return _price(true);
     }
 
-    /// Returns both the price() & lotPrice() at once, for gas optimization
-    /// @return price_ {UoA/tok} The low and high price estimate of an RToken
-    /// @return lotPrice_ {UoA/tok} The low and high lotprice of an RToken
-    function prices() public view returns (Price memory price_, Price memory lotPrice_) {
+    /// Returns the price of a BU, using the lot prices if `useLotPrice` is true
+    /// @return low {UoA/BU} The lower end of the lot price estimate
+    /// @return high {UoA/BU} The upper end of the lot price estimate
+    function _price(bool useLotPrice) internal view returns (uint192 low, uint192 high) {
+        IAssetRegistry reg = main.assetRegistry();
+
         uint256 low256;
         uint256 high256;
-        uint256 lotLow256;
-        uint256 lotHigh256;
 
-        uint256 len = basket.erc20s.length;
-        for (uint256 i = 0; i < len; ++i) {
+        for (uint256 i = 0; i < basket.erc20s.length; i++) {
             uint192 qty = quantity(basket.erc20s[i]);
             if (qty == 0) continue;
 
-            IAsset asset = main.assetRegistry().toAsset(basket.erc20s[i]);
-            (uint192 lowP, uint192 highP) = asset.price();
-            (uint192 lotLowP, uint192 lotHighP) = asset.lotPrice();
+            (uint192 lowP, uint192 highP) = useLotPrice
+                ? reg.toAsset(basket.erc20s[i]).lotPrice()
+                : reg.toAsset(basket.erc20s[i]).price();
 
             low256 += qty.safeMul(lowP, RoundingMode.FLOOR);
             high256 += qty.safeMul(highP, RoundingMode.CEIL);
-            lotLow256 += qty.safeMul(lotLowP, RoundingMode.FLOOR);
-            lotHigh256 += qty.safeMul(lotHighP, RoundingMode.CEIL);
         }
 
         // safe downcast: FIX_MAX is type(uint192).max
-        price_.low = low256 >= FIX_MAX ? FIX_MAX : uint192(low256);
-        price_.high = high256 >= FIX_MAX ? FIX_MAX : uint192(high256);
-        lotPrice_.low = lotLow256 >= FIX_MAX ? FIX_MAX : uint192(lotLow256);
-        lotPrice_.high = lotHigh256 >= FIX_MAX ? FIX_MAX : uint192(lotHigh256);
+        low = low256 >= FIX_MAX ? FIX_MAX : uint192(low256);
+        high = high256 >= FIX_MAX ? FIX_MAX : uint192(high256);
     }
 
     /// Return the current issuance/redemption value of `amount` BUs

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -21,7 +21,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
 
     function init(IMain main_, RevenueShare memory dist) public initializer {
         __Component_init(main_);

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -94,8 +94,8 @@ contract DistributorP0 is ComponentP0, IDistributor {
         );
         if (dest == FURNACE) require(share.rsrDist == 0, "Furnace must get 0% of RSR");
         if (dest == ST_RSR) require(share.rTokenDist == 0, "StRSR must get 0% of RToken");
-        require(share.rsrDist <= 10000, "RSR distribution too high");
-        require(share.rTokenDist <= 10000, "RToken distribution too high");
+        require(share.rsrDist <= MAX_DISTRIBUTION, "RSR distribution too high");
+        require(share.rTokenDist <= MAX_DISTRIBUTION, "RToken distribution too high");
 
         if (share.rsrDist == 0 && share.rTokenDist == 0) {
             destinations.remove(dest);

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -21,7 +21,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS; // 100
 
     function init(IMain main_, RevenueShare memory dist) public initializer {
         __Component_init(main_);

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -21,7 +21,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS;
 
     function init(IMain main_, RevenueShare memory dist) public initializer {
         __Component_init(main_);

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -368,8 +368,6 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     /// @param amount {qRTok} The amount of RToken to be redeemed
     /// @param basketsRedeemed {BU} The number of baskets redeemed
     function _redeem(address account, uint256 amount) private returns (uint192 basketsRedeemed) {
-        if (amount == 0) return 0;
-
         // {BU} = {BU} * {qRTok} / {qRTok}
         basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
         assert(basketsRedeemed.lte(basketsNeeded));

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -273,11 +273,7 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     /// @param recipient The recipient of the newly minted RToken
     /// @param amount {qRTok} The amount to be minted
     /// @custom:protected
-    function mint(address recipient, uint256 amount)
-        external
-        notTradingPausedOrFrozen
-        exchangeRateIsValidAfter
-    {
+    function mint(address recipient, uint256 amount) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         _mint(recipient, amount);
     }
@@ -290,22 +286,18 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         emit Melted(amount);
     }
 
-    /// Giveup an amount of RToken from caller's account and scales basketsNeeded down
+    /// Dissolve an amount of RToken from caller's account and scale basketsNeeded down
     /// Callable only by backingManager
     /// @param amount {qRTok}
     /// @custom:protected
-    function giveup(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
+    function dissolve(uint256 amount) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         _redeem(_msgSender(), amount);
     }
 
     /// An affordance of last resort for Main in order to ensure re-capitalization
     /// @custom:protected
-    function setBasketsNeeded(uint192 basketsNeeded_)
-        external
-        notTradingPausedOrFrozen
-        exchangeRateIsValidAfter
-    {
+    function setBasketsNeeded(uint192 basketsNeeded_) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -273,14 +273,17 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     /// @param recipient The recipient of the newly minted RToken
     /// @param amount {qRTok} The amount to be minted
     /// @custom:protected
-    function mint(address recipient, uint256 amount) external exchangeRateIsValidAfter {
+    function mint(address recipient, uint256 amount)
+        external
+        notTradingPausedOrFrozen
+        exchangeRateIsValidAfter
+    {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         _mint(recipient, amount);
     }
 
     /// Melt a quantity of RToken from the caller's account, increasing the basket rate
     /// @param amount {qRTok} The amount to be melted
-    /// @custom:protected
     function melt(uint256 amount) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.furnace()), "furnace only");
         _burn(_msgSender(), amount);
@@ -291,14 +294,18 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     /// Callable only by backingManager
     /// @param amount {qRTok}
     /// @custom:protected
-    function dissolve(uint256 amount) external exchangeRateIsValidAfter {
+    function dissolve(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         _redeem(_msgSender(), amount);
     }
 
     /// An affordance of last resort for Main in order to ensure re-capitalization
     /// @custom:protected
-    function setBasketsNeeded(uint192 basketsNeeded_) external exchangeRateIsValidAfter {
+    function setBasketsNeeded(uint192 basketsNeeded_)
+        external
+        notTradingPausedOrFrozen
+        exchangeRateIsValidAfter
+    {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -280,6 +280,7 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
 
     /// Melt a quantity of RToken from the caller's account, increasing the basket rate
     /// @param amount {qRTok} The amount to be melted
+    /// @custom:protected
     function melt(uint256 amount) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.furnace()), "furnace only");
         _burn(_msgSender(), amount);

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -152,18 +152,14 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         issuanceThrottle.useAvailable(totalSupply(), -int256(amount));
         redemptionThrottle.useAvailable(totalSupply(), int256(amount)); // reverts on overuse
 
-        // {BU} = {BU} * {qRTok} / {qRTok}
-        uint192 basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply());
-        assert(basketsRedeemed.lte(basketsNeeded));
+        // {BU}
+        uint192 basketsRedeemed = _redeem(_msgSender(), amount);
         emit Redemption(_msgSender(), recipient, amount, basketsRedeemed);
 
         (address[] memory erc20s, uint256[] memory amounts) = main.basketHandler().quote(
             basketsRedeemed,
             FLOOR
         );
-
-        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(basketsRedeemed));
-        basketsNeeded = basketsNeeded.minus(basketsRedeemed);
 
         // ==== Send out balances ====
         for (uint256 i = 0; i < erc20s.length; i++) {
@@ -176,9 +172,6 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
                 );
             }
         }
-
-        // Accept and burn RToken, reverts if not enough balance
-        _burn(_msgSender(), amount);
     }
 
     /// Redeem RToken for a linear combination of historical baskets, to a particular recipient
@@ -212,9 +205,8 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         issuanceThrottle.useAvailable(totalSupply(), -int256(amount));
         redemptionThrottle.useAvailable(totalSupply(), int256(amount)); // reverts on overuse
 
-        // {BU} = {BU} * {qRTok} / {qRTok}
-        uint192 basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply());
-        assert(basketsRedeemed.lte(basketsNeeded));
+        // {BU}
+        uint192 basketsRedeemed = _redeem(_msgSender(), amount);
         emit Redemption(_msgSender(), recipient, amount, basketsRedeemed);
 
         // === Get basket redemption amounts ===
@@ -232,9 +224,6 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
             portions,
             basketsRedeemed
         );
-
-        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(basketsRedeemed));
-        basketsNeeded = basketsNeeded.minus(basketsRedeemed);
 
         // === Save initial recipient balances ===
 
@@ -269,9 +258,6 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
             if (allZero) revert("empty redemption");
         }
 
-        // Accept and burn RToken, reverts if not enough balance
-        _burn(_msgSender(), amount);
-
         // === Post-checks ===
 
         // Check post-balances
@@ -302,6 +288,15 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         require(_msgSender() == address(main.furnace()), "furnace only");
         _burn(_msgSender(), amount);
         emit Melted(amount);
+    }
+
+    /// Giveup an amount of RToken from caller's account and scales basketsNeeded down
+    /// Callable only by backingManager
+    /// @param amount {qRTok}
+    /// @custom:protected
+    function giveup(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
+        require(_msgSender() == address(main.backingManager()), "not backing manager");
+        _redeem(_msgSender(), amount);
     }
 
     /// An affordance of last resort for Main in order to ensure re-capitalization
@@ -367,6 +362,23 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     }
 
     // === Private ===
+
+    /// Redeem an amount of RToken from an account for basket units, without transferring tokens
+    /// @param account The address to redeem RTokens from
+    /// @param amount {qRTok} The amount of RToken to be redeemed
+    /// @param basketsRedeemed {BU} The number of baskets redeemed
+    function _redeem(address account, uint256 amount) private returns (uint192 basketsRedeemed) {
+        if (amount == 0) return 0;
+
+        // {BU} = {BU} * {qRTok} / {qRTok}
+        basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
+        assert(basketsRedeemed.lte(basketsNeeded));
+        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(basketsRedeemed));
+        basketsNeeded = basketsNeeded.minus(basketsRedeemed);
+
+        // Burn RToken from account; reverts if not enough balance
+        _burn(account, amount);
+    }
 
     /**
      * @dev Hook that is called before any transfer of tokens. This includes

--- a/contracts/p0/mixins/TradingLib.sol
+++ b/contracts/p0/mixins/TradingLib.sol
@@ -487,29 +487,6 @@ library TradingLibP0 {
             }
         }
 
-        // Use RToken if needed
-        if (address(trade.sell) == address(0) && address(trade.buy) != address(0)) {
-            IAsset rTokenAsset = IAsset(address(ctx.reg.toAsset(IERC20(address(ctx.rToken)))));
-            uint192 bal = rTokenAsset.bal(address(ctx.bm));
-
-            // Only price RToken if it is large enough to be worth it
-            // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
-            if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
-                // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
-                // This product is 1e6, so on a minTradeVolume of $1000 it would
-                // require 1 whole RToken to be worth 1 quadrillion dollars to be a mistake.
-                // So, it is a pretty safe heuristic to use to avoid looking up RToken price.
-
-                (uint192 low, uint192 high) = rTokenAsset.price(); // {UoA/tok}
-                (uint192 lotLow, ) = rTokenAsset.lotPrice(); // {UoA/tok}
-                if (high > 0 && isEnoughToSell(rTokenAsset, bal, lotLow, ctx.minTradeVolume)) {
-                    trade.sell = rTokenAsset;
-                    trade.sellAmount = bal;
-                    trade.sellPrice = low;
-                }
-            }
-        }
-
         // Use RSR if needed
         if (address(trade.sell) == address(0) && address(trade.buy) != address(0)) {
             IAsset rsrAsset = ctx.reg.toAsset(ctx.rsr);

--- a/contracts/p0/mixins/TradingLib.sol
+++ b/contracts/p0/mixins/TradingLib.sol
@@ -496,9 +496,9 @@ library TradingLibP0 {
             // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
             if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
                 // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
-                // MAX_REVENUE_TOTALS is about 1e7, so on a minTradeVolume of $1000 it would
-                // require 1 whole RToken to be worth 100 trillion dollars to be a mistake.
-                // So, it seems like a safe heuristic to use to avoid looking up RToken price.
+                // This product is 1e6, so on a minTradeVolume of $1000 it would
+                // require 1 whole RToken to be worth 1 quadrillion dollars to be a mistake.
+                // So, it is a pretty safe heuristic to use to avoid looking up RToken price.
 
                 (uint192 low, uint192 high) = rTokenAsset.price(); // {UoA/tok}
                 (uint192 lotLow, ) = rTokenAsset.lotPrice(); // {UoA/tok}

--- a/contracts/p0/mixins/TradingLib.sol
+++ b/contracts/p0/mixins/TradingLib.sol
@@ -493,7 +493,8 @@ library TradingLibP0 {
             uint192 bal = rTokenAsset.bal(address(ctx.bm));
 
             // Only price RToken if it is large enough to be worth it
-            if (bal > MAX_REVENUE_TOTALS) {
+            // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
+            if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
                 // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
                 // MAX_REVENUE_TOTALS is about 1e7, so on a minTradeVolume of $1000 it would
                 // require 1 whole RToken to be worth 100 trillion dollars to be a mistake.

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -124,6 +124,11 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         require(basketsHeld.bottom < rToken.basketsNeeded(), "already collateralized");
         // require(!basketHandler.fullyCollateralized())
 
+        // First giveup any held RToken balance (no token transfers required)
+        uint256 balance = main.rToken().balanceOf(address(this));
+        if (balance > 0) main.rToken().giveup(balance);
+        if (basketsHeld.bottom >= rToken.basketsNeeded()) return; // return if now capitalized
+
         /*
          * Recollateralization
          *
@@ -267,6 +272,8 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
 
         // It's okay if there is leftover dust for RToken or a surplus asset (not RSR)
     }
+
+    // === Private ===
 
     /// Compromise on how many baskets are needed in order to recollateralize-by-accounting
     /// @param basketsHeldBottom {BU} The number of full basket units held by the BackingManager

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -124,9 +124,10 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         require(basketsHeld.bottom < rToken.basketsNeeded(), "already collateralized");
         // require(!basketHandler.fullyCollateralized())
 
-        // First giveup any held RToken balance (no token transfers required)
+        // First dissolve any held RToken balance (above Distributor-dust)
+        // gas-optimization: 1 whole RToken must be worth 100 trillion dollars for this to skip $1
         uint256 balance = main.rToken().balanceOf(address(this));
-        if (balance > 0) main.rToken().giveup(balance);
+        if (balance >= MAX_DISTRIBUTION * MAX_DESTINATIONS) main.rToken().dissolve(balance);
         if (basketsHeld.bottom >= rToken.basketsNeeded()) return; // return if now capitalized
 
         /*

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -303,53 +303,45 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     }
 
     /// Should not revert
-    /// @return {UoA/BU} The lower end of the price estimate
-    /// @return {UoA/BU} The upper end of the price estimate
+    /// @return low {UoA/BU} The lower end of the price estimate
+    /// @return high {UoA/BU} The upper end of the price estimate
     // returns sum(quantity(erc20) * price(erc20) for erc20 in basket.erc20s)
-    function price() external view returns (uint192, uint192) {
-        (Price memory p, ) = prices();
-        return (p.low, p.high);
+    function price() external view returns (uint192 low, uint192 high) {
+        return _price(false);
     }
 
     /// Should not revert
     /// lowLow should be nonzero when the asset might be worth selling
-    /// @return {UoA/BU} The lower end of the lot price estimate
-    /// @return {UoA/BU} The upper end of the lot price estimate
+    /// @return lotLow {UoA/BU} The lower end of the lot price estimate
+    /// @return lotHigh {UoA/BU} The upper end of the lot price estimate
     // returns sum(quantity(erc20) * lotPrice(erc20) for erc20 in basket.erc20s)
-    function lotPrice() external view returns (uint192, uint192) {
-        (, Price memory lotP) = prices();
-        return (lotP.low, lotP.high);
+    function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh) {
+        return _price(true);
     }
 
-    /// Returns both the price() & lotPrice() at once, for gas optimization
-    /// @return price_ {UoA/tok} The low and high price estimate of an RToken
-    /// @return lotPrice_ {UoA/tok} The low and high lotprice of an RToken
-    function prices() public view returns (Price memory price_, Price memory lotPrice_) {
+    /// Returns the price of a BU, using the lot prices if `useLotPrice` is true
+    /// @return low {UoA/BU} The lower end of the price estimate
+    /// @return high {UoA/BU} The upper end of the price estimate
+    function _price(bool useLotPrice) internal view returns (uint192 low, uint192 high) {
         uint256 low256;
         uint256 high256;
-        uint256 lotLow256;
-        uint256 lotHigh256;
 
         uint256 len = basket.erc20s.length;
         for (uint256 i = 0; i < len; ++i) {
             uint192 qty = quantity(basket.erc20s[i]);
             if (qty == 0) continue;
 
-            IAsset asset = assetRegistry.toAsset(basket.erc20s[i]);
-            (uint192 lowP, uint192 highP) = asset.price();
-            (uint192 lotLowP, uint192 lotHighP) = asset.lotPrice();
+            (uint192 lowP, uint192 highP) = useLotPrice
+                ? assetRegistry.toAsset(basket.erc20s[i]).lotPrice()
+                : assetRegistry.toAsset(basket.erc20s[i]).price();
 
             low256 += qty.safeMul(lowP, RoundingMode.FLOOR);
             high256 += qty.safeMul(highP, RoundingMode.CEIL);
-            lotLow256 += qty.safeMul(lotLowP, RoundingMode.FLOOR);
-            lotHigh256 += qty.safeMul(lotHighP, RoundingMode.CEIL);
         }
 
         // safe downcast: FIX_MAX is type(uint192).max
-        price_.low = low256 >= FIX_MAX ? FIX_MAX : uint192(low256);
-        price_.high = high256 >= FIX_MAX ? FIX_MAX : uint192(high256);
-        lotPrice_.low = lotLow256 >= FIX_MAX ? FIX_MAX : uint192(lotLow256);
-        lotPrice_.high = lotHigh256 >= FIX_MAX ? FIX_MAX : uint192(lotHigh256);
+        low = low256 >= FIX_MAX ? FIX_MAX : uint192(low256);
+        high = high256 >= FIX_MAX ? FIX_MAX : uint192(high256);
     }
 
     /// Return the current issuance/redemption value of `amount` BUs

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -31,7 +31,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS;
 
     IERC20 private rsr;
     IERC20 private rToken;

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -31,7 +31,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
 
     IERC20 private rsr;
     IERC20 private rToken;

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -23,7 +23,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     // distribution[FURNACE].rsrDist == 0
     // distribution[ST_RSR].rTokenDist == 0
     // distribution has no more than MAX_DESTINATIONS_ALLOWED key-value entries
-    // all distribution-share values are <= 10000
+    // all distribution-share values are <= MAX_DISTRIBUTION
 
     // ==== destinations:
     // distribution[dest] != (0,0) if and only if dest in destinations
@@ -149,7 +149,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     // checks:
     //   distribution'[FURNACE].rsrDist == 0
     //   distribution'[ST_RSR].rTokenDist == 0
-    //   share.rsrDist <= 10000
+    //   share.rsrDist <= MAX_DISTRIBUTION
     //   size(destinations') <= MAX_DESTINATIONS_ALLOWED
     // effects:
     //   destinations' = destinations.add(dest)
@@ -162,8 +162,8 @@ contract DistributorP1 is ComponentP1, IDistributor {
         );
         if (dest == FURNACE) require(share.rsrDist == 0, "Furnace must get 0% of RSR");
         if (dest == ST_RSR) require(share.rTokenDist == 0, "StRSR must get 0% of RToken");
-        require(share.rsrDist <= 10000, "RSR distribution too high");
-        require(share.rTokenDist <= 10000, "RToken distribution too high");
+        require(share.rsrDist <= MAX_DISTRIBUTION, "RSR distribution too high");
+        require(share.rTokenDist <= MAX_DISTRIBUTION, "RToken distribution too high");
 
         if (share.rsrDist == 0 && share.rTokenDist == 0) {
             destinations.remove(dest);

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -31,7 +31,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     address public constant FURNACE = address(1);
     address public constant ST_RSR = address(2);
 
-    uint8 public constant MAX_DESTINATIONS_ALLOWED = 100;
+    uint8 public constant MAX_DESTINATIONS_ALLOWED = MAX_DESTINATIONS; // 100
 
     IERC20 private rsr;
     IERC20 private rToken;

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -503,8 +503,6 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
     /// @param amount {qRTok} The amount of RToken to be redeemed
     /// @param basketsRedeemed {BU} The number of baskets redeemed
     function _redeem(address account, uint256 amount) private returns (uint192 basketsRedeemed) {
-        if (amount == 0) return 0;
-
         // D18{BU} = D18{BU} * {qRTok} / {qRTok}
         basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded - basketsRedeemed);

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -401,6 +401,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
 
     /// Melt a quantity of RToken from the caller's account, increasing the basket rate
     /// @param amtRToken {qRTok} The amtRToken to be melted
+    /// @custom:protected
     // checks: not trading paused or frozen
     // effects:
     //   bal'[caller] = bal[caller] - amtRToken
@@ -410,8 +411,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
     //   `else` branch of `exchangeRateIsValidAfter` (ie. revert) shows as uncovered
     //   but it is fully covered for `melt` (limitations of coverage plugin)
     function melt(uint256 amtRToken) external exchangeRateIsValidAfter {
-        address caller = _msgSender();
-        require(caller == address(furnace) || caller == address(backingManager), "furnace only");
+        require(_msgSender() == address(furnace), "furnace only");
         _burn(_msgSender(), amtRToken);
         emit Melted(amtRToken);
     }

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -416,11 +416,11 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
         emit Melted(amtRToken);
     }
 
-    /// Giveup an amount of RToken from caller's account and scales basketsNeeded down
+    /// Dissolve an amount of RToken from caller's account and scale basketsNeeded down
     /// Callable only by backingManager
     /// @param amount {qRTok}
-    /// @custom:proctected
-    function giveup(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
+    /// @custom:protected
+    function dissolve(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
         require(_msgSender() == address(backingManager), "not backing manager");
         _redeem(_msgSender(), amount);
     }

--- a/contracts/p1/mixins/RecollateralizationLib.sol
+++ b/contracts/p1/mixins/RecollateralizationLib.sol
@@ -391,32 +391,6 @@ library RecollateralizationLibP1 {
             }
         }
 
-        // Use RToken if needed
-        if (address(trade.sell) == address(0) && address(trade.buy) != address(0)) {
-            IAsset rTokenAsset = ctx.ar.toAsset(IERC20(address(ctx.rToken)));
-            uint192 bal = rTokenAsset.bal(address(ctx.bm));
-
-            // Only price RToken if it is large enough to be worth it
-            // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
-            if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
-                // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
-                // This product is 1e6, so on a minTradeVolume of $1000 it would
-                // require 1 whole RToken to be worth 1 quadrillion dollars to be a mistake.
-                // So, it is a pretty safe heuristic to use to avoid looking up RToken price.
-
-                (uint192 low, uint192 high) = rTokenAsset.price(); // {UoA/tok}
-                (uint192 lotLow, ) = rTokenAsset.lotPrice(); // {UoA/tok}
-                if (
-                    high > 0 &&
-                    TradeLib.isEnoughToSell(rTokenAsset, bal, lotLow, ctx.minTradeVolume)
-                ) {
-                    trade.sell = rTokenAsset;
-                    trade.sellAmount = bal;
-                    trade.sellPrice = low;
-                }
-            }
-        }
-
         // Use RSR if needed
         if (address(trade.sell) == address(0) && address(trade.buy) != address(0)) {
             IAsset rsrAsset = ctx.ar.toAsset(ctx.rsr);

--- a/contracts/p1/mixins/RecollateralizationLib.sol
+++ b/contracts/p1/mixins/RecollateralizationLib.sol
@@ -20,6 +20,7 @@ struct TradingContext {
 
     // Components
     IBackingManager bm;
+    IBasketHandler bh;
     IAssetRegistry ar;
     IStRSR stRSR;
     IERC20 rsr;
@@ -27,14 +28,8 @@ struct TradingContext {
     // Gov Vars
     uint192 minTradeVolume; // {UoA}
     uint192 maxTradeSlippage; // {1}
-}
-
-// All the extra information nextTradePair() needs; necessary to stay under stack limit
-struct NextTradePairContext {
+    // Cached values
     uint192[] quantities; // {tok/BU} basket quantities
-    BasketRange range;
-    Price rTokenPrice;
-    Price rTokenLotPrice;
 }
 
 /**
@@ -66,48 +61,35 @@ library RecollateralizationLibP1 {
         view
         returns (bool doTrade, TradeRequest memory req)
     {
-        NextTradePairContext memory ntpCtx;
-
-        // === Prepare cached values ===
-
         IMain main = bm.main();
-        TradingContext memory ctx = TradingContext({
-            basketsHeld: basketsHeld,
-            bm: bm,
-            ar: main.assetRegistry(),
-            stRSR: main.stRSR(),
-            rsr: main.rsr(),
-            rToken: main.rToken(),
-            minTradeVolume: bm.minTradeVolume(),
-            maxTradeSlippage: bm.maxTradeSlippage()
-        });
-        Registry memory reg = ctx.ar.getRegistry();
 
-        // Calculate quantities up-front for re-use
-        IBasketHandler bh = main.basketHandler();
-        ntpCtx.quantities = new uint192[](reg.erc20s.length);
+        // === Prepare TradingContext cache ===
+        TradingContext memory ctx;
+
+        ctx.basketsHeld = basketsHeld;
+        ctx.bm = bm;
+        ctx.bh = main.basketHandler();
+        ctx.ar = main.assetRegistry();
+        ctx.stRSR = main.stRSR();
+        ctx.rsr = main.rsr();
+        ctx.rToken = main.rToken();
+        ctx.minTradeVolume = bm.minTradeVolume();
+        ctx.maxTradeSlippage = bm.maxTradeSlippage();
+
+        // Calculate quantities
+        Registry memory reg = ctx.ar.getRegistry();
+        ctx.quantities = new uint192[](reg.erc20s.length);
         for (uint256 i = 0; i < reg.erc20s.length; ++i) {
-            ntpCtx.quantities[i] = bh.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
+            ctx.quantities[i] = ctx.bh.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
         }
 
         // ============================
 
-        // Compute BU price
-        (Price memory buPrice, Price memory buLotPrice) = bh.prices();
-
         // Compute a target basket range for trading -  {BU}
-        ntpCtx.range = basketRange(ctx, reg, ntpCtx.quantities, buPrice);
-
-        // Compute RToken price
-        RTokenAsset rTokenAsset = RTokenAsset(address(ctx.ar.toAsset(IERC20(address(ctx.rToken)))));
-        (ntpCtx.rTokenPrice, ntpCtx.rTokenLotPrice) = rTokenAsset.prices(
-            ntpCtx.range,
-            buPrice,
-            buLotPrice
-        );
+        BasketRange memory range = basketRange(ctx, reg);
 
         // Select a pair to trade next, if one exists
-        TradeInfo memory trade = nextTradePair(ctx, reg, ntpCtx);
+        TradeInfo memory trade = nextTradePair(ctx, reg, range);
 
         // Don't trade if no pair is selected
         if (address(trade.sell) == address(0) || address(trade.buy) == address(0)) {
@@ -167,13 +149,13 @@ library RecollateralizationLibP1 {
     // - range.bottom = min(rToken.basketsNeeded, basketsHeld.bottom + least baskets purchaseable)
     //   where "least baskets purchaseable" involves trading at unfavorable prices,
     //   incurring maxTradeSlippage, and taking up to a minTradeVolume loss due to dust.
-    function basketRange(
-        TradingContext memory ctx,
-        Registry memory reg,
-        uint192[] memory quantities,
-        Price memory buPrice
-    ) internal view returns (BasketRange memory range) {
-        uint192 basketsNeeded = ctx.rToken.basketsNeeded();
+    function basketRange(TradingContext memory ctx, Registry memory reg)
+        internal
+        view
+        returns (BasketRange memory range)
+    {
+        (uint192 buPriceLow, uint192 buPriceHigh) = ctx.bh.price(); // {UoA/BU}
+        uint192 basketsNeeded = ctx.rToken.basketsNeeded(); // {BU}
 
         // Cap ctx.basketsHeld.top
         if (ctx.basketsHeld.top > basketsNeeded) {
@@ -207,7 +189,7 @@ library RecollateralizationLibP1 {
 
                 // Intentionally include value of IFFY/DISABLED collateral
                 if (
-                    quantities[i] == 0 &&
+                    ctx.quantities[i] == 0 &&
                     !TradeLib.isEnoughToSell(reg.assets[i], bal, lotLow, ctx.minTradeVolume)
                 ) continue;
             }
@@ -220,20 +202,20 @@ library RecollateralizationLibP1 {
             // if in surplus relative to ctx.basketsHeld.top: add-in surplus baskets
             {
                 // {tok} = {tok/BU} * {BU}
-                uint192 anchor = quantities[i].mul(ctx.basketsHeld.top, CEIL);
+                uint192 anchor = ctx.quantities[i].mul(ctx.basketsHeld.top, CEIL);
 
                 if (anchor > bal) {
                     // deficit: deduct optimistic estimate of baskets missing
 
                     // {BU} = {UoA/tok} * {tok} / {UoA/BU}
-                    deltaTop -= int256(uint256(low.mulDiv(anchor - bal, buPrice.high, FLOOR)));
+                    deltaTop -= int256(uint256(low.mulDiv(anchor - bal, buPriceHigh, FLOOR)));
                     // does not need underflow protection: using low price of asset
                 } else {
                     // surplus: add-in optimistic estimate of baskets purchaseable
 
                     // {BU} = {UoA/tok} * {tok} / {UoA/BU}
                     deltaTop += int256(
-                        uint256(ctx.bm.safeMulDivCeil(high, bal - anchor, buPrice.low))
+                        uint256(ctx.bm.safeMulDivCeil(high, bal - anchor, buPriceLow))
                     );
                     // needs overflow protection: using high price of asset which can be FIX_MAX
                 }
@@ -243,7 +225,7 @@ library RecollateralizationLibP1 {
             // add-in surplus baskets relative to ctx.basketsHeld.bottom
             {
                 // {tok} = {tok/BU} * {BU}
-                uint192 anchor = quantities[i].mul(ctx.basketsHeld.bottom, FLOOR);
+                uint192 anchor = ctx.quantities[i].mul(ctx.basketsHeld.bottom, FLOOR);
 
                 // (1) Sell tokens at low price
                 // {UoA} = {UoA/tok} * {tok}
@@ -261,11 +243,7 @@ library RecollateralizationLibP1 {
                 // (3) Buy BUs at their high price with the remaining value
                 // (4) Assume maximum slippage in trade
                 // {BU} = {UoA} * {1} / {UoA/BU}
-                range.bottom += val.mulDiv(
-                    FIX_ONE.minus(ctx.maxTradeSlippage),
-                    buPrice.high,
-                    FLOOR
-                );
+                range.bottom += val.mulDiv(FIX_ONE.minus(ctx.maxTradeSlippage), buPriceHigh, FLOOR);
             }
         }
 
@@ -334,7 +312,7 @@ library RecollateralizationLibP1 {
     function nextTradePair(
         TradingContext memory ctx,
         Registry memory reg,
-        NextTradePairContext memory ntpCtx
+        BasketRange memory range
     ) private view returns (TradeInfo memory trade) {
         MaxSurplusDeficit memory maxes;
         maxes.surplusStatus = CollateralStatus.IFFY; // least-desirable sell status
@@ -348,7 +326,7 @@ library RecollateralizationLibP1 {
 
             // {tok} = {BU} * {tok/BU}
             // needed(Top): token balance needed for range.top baskets: quantity(e) * range.top
-            uint192 needed = ntpCtx.range.top.mul(ntpCtx.quantities[i], CEIL); // {tok}
+            uint192 needed = range.top.mul(ctx.quantities[i], CEIL); // {tok}
 
             if (bal.gt(needed)) {
                 uint192 low; // {UoA/sellTok}
@@ -393,7 +371,7 @@ library RecollateralizationLibP1 {
                 }
             } else {
                 // needed(Bottom): token balance needed at bottom of the basket range
-                needed = ntpCtx.range.bottom.mul(ntpCtx.quantities[i], CEIL); // {buyTok};
+                needed = range.bottom.mul(ctx.quantities[i], CEIL); // {buyTok};
 
                 if (bal.lt(needed)) {
                     uint192 amtShort = needed.minus(bal); // {buyTok}
@@ -414,30 +392,24 @@ library RecollateralizationLibP1 {
             }
         }
 
-        // Special-case RToken
-        {
+        // Use RToken if needed
+        if (address(trade.sell) == address(0) && address(trade.buy) != address(0)) {
             RTokenAsset rTokenAsset = RTokenAsset(
                 address(ctx.ar.toAsset(IERC20(address(ctx.rToken))))
             );
             uint192 bal = rTokenAsset.bal(address(ctx.bm));
 
-            if (
-                ntpCtx.rTokenPrice.high > 0 &&
-                isBetterSurplus(
-                    maxes,
-                    CollateralStatus.SOUND,
-                    bal.mul(ntpCtx.rTokenLotPrice.low, FLOOR)
-                ) &&
-                TradeLib.isEnoughToSell(
-                    rTokenAsset,
-                    bal,
-                    ntpCtx.rTokenLotPrice.low,
-                    ctx.minTradeVolume
-                )
-            ) {
-                trade.sell = rTokenAsset;
-                trade.sellAmount = bal;
-                trade.sellPrice = ntpCtx.rTokenPrice.low;
+            if (bal > 0) {
+                (uint192 low, uint192 high) = rTokenAsset.price(); // {UoA/tok}
+                (uint192 lotLow, ) = rTokenAsset.lotPrice(); // {UoA/tok}
+                if (
+                    high > 0 &&
+                    TradeLib.isEnoughToSell(rTokenAsset, bal, lotLow, ctx.minTradeVolume)
+                ) {
+                    trade.sell = rTokenAsset;
+                    trade.sellAmount = bal;
+                    trade.sellPrice = low;
+                }
             }
         }
 

--- a/contracts/p1/mixins/RecollateralizationLib.sol
+++ b/contracts/p1/mixins/RecollateralizationLib.sol
@@ -400,9 +400,9 @@ library RecollateralizationLibP1 {
             // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
             if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
                 // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
-                // MAX_REVENUE_TOTALS is about 1e7, so on a minTradeVolume of $1000 it would
-                // require 1 whole RToken to be worth 100 trillion dollars to be a mistake.
-                // So, it seems like a safe heuristic to use to avoid looking up RToken price.
+                // This product is 1e6, so on a minTradeVolume of $1000 it would
+                // require 1 whole RToken to be worth 1 quadrillion dollars to be a mistake.
+                // So, it is a pretty safe heuristic to use to avoid looking up RToken price.
 
                 (uint192 low, uint192 high) = rTokenAsset.price(); // {UoA/tok}
                 (uint192 lotLow, ) = rTokenAsset.lotPrice(); // {UoA/tok}

--- a/contracts/p1/mixins/RecollateralizationLib.sol
+++ b/contracts/p1/mixins/RecollateralizationLib.sol
@@ -397,7 +397,8 @@ library RecollateralizationLibP1 {
             uint192 bal = rTokenAsset.bal(address(ctx.bm));
 
             // Only price RToken if it is large enough to be worth it
-            if (bal > MAX_REVENUE_TOTALS) {
+            // Heuristic: If the distributor would skip it, it's smaller than minTradeVolume
+            if (bal >= MAX_DISTRIBUTION * MAX_DESTINATIONS) {
                 // Context: The Distributor leaves small balances behind. It is a non-UoA measure.
                 // MAX_REVENUE_TOTALS is about 1e7, so on a minTradeVolume of $1000 it would
                 // require 1 whole RToken to be worth 100 trillion dollars to be a mistake.

--- a/contracts/plugins/assets/RTokenAsset.sol
+++ b/contracts/plugins/assets/RTokenAsset.sol
@@ -39,33 +39,6 @@ contract RTokenAsset is IAsset, VersionedAsset {
         maxTradeVolume = maxTradeVolume_;
     }
 
-    /// Calculates price() & lotPrice() in a gas-optimized way using a cached BasketRange
-    /// Used by RecollateralizationLib for efficient price calculation
-    /// @param buRange {BU} The top and bottom of the bu band; how many BUs we expect to hold
-    /// @param buPrice {UoA/BU} The low and high price estimate of a basket unit
-    /// @param buLotPrice {UoA/BU} The low and high lotprice of a basket unit
-    /// @return price_ {UoA/tok} The low and high price estimate of an RToken
-    /// @return lotPrice_ {UoA/tok} The low and high lotprice of an RToken
-    function prices(
-        BasketRange memory buRange,
-        Price memory buPrice,
-        Price memory buLotPrice
-    ) public view returns (Price memory price_, Price memory lotPrice_) {
-        // Here we take advantage of the fact that we know RToken has 18 decimals
-        // to convert between uint256 an uint192. Fits due to assumed max totalSupply.
-        uint192 supply = _safeWrap(IRToken(address(erc20)).totalSupply());
-
-        if (supply == 0) return (buPrice, buLotPrice);
-
-        // {UoA/tok} = {BU} * {UoA/BU} / {tok}
-        price_.low = buRange.bottom.mulDiv(buPrice.low, supply, FLOOR);
-        price_.high = buRange.top.mulDiv(buPrice.high, supply, CEIL);
-        lotPrice_.low = buRange.bottom.mulDiv(buLotPrice.low, supply, FLOOR);
-        lotPrice_.high = buRange.top.mulDiv(buLotPrice.high, supply, CEIL);
-        assert(price_.low <= price_.high);
-        assert(lotPrice_.low <= lotPrice_.high);
-    }
-
     /// Can revert, used by other contract functions in order to catch errors
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
@@ -159,9 +132,6 @@ contract RTokenAsset is IAsset, VersionedAsset {
 
     /// Computationally expensive basketRange calculation; used in price() & lotPrice()
     function basketRange() private view returns (BasketRange memory range) {
-        Price memory buPrice;
-        (buPrice.low, buPrice.high) = basketHandler.price(); // {UoA/BU}
-
         BasketRange memory basketsHeld = basketHandler.basketsHeldBy(address(backingManager));
         uint192 basketsNeeded = IRToken(address(erc20)).basketsNeeded(); // {BU}
 
@@ -176,26 +146,27 @@ contract RTokenAsset is IAsset, VersionedAsset {
             // should switch over to an asset with a price feed.
 
             IMain main = backingManager.main();
-            TradingContext memory ctx = TradingContext({
-                basketsHeld: basketsHeld,
-                bm: backingManager,
-                ar: main.assetRegistry(),
-                stRSR: main.stRSR(),
-                rsr: main.rsr(),
-                rToken: main.rToken(),
-                minTradeVolume: backingManager.minTradeVolume(),
-                maxTradeSlippage: backingManager.maxTradeSlippage()
-            });
-
             Registry memory reg = assetRegistry.getRegistry();
 
             uint192[] memory quantities = new uint192[](reg.erc20s.length);
             for (uint256 i = 0; i < reg.erc20s.length; ++i) {
                 quantities[i] = basketHandler.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
             }
+            TradingContext memory ctx = TradingContext({
+                basketsHeld: basketsHeld,
+                bm: backingManager,
+                bh: basketHandler,
+                ar: assetRegistry,
+                stRSR: main.stRSR(),
+                rsr: main.rsr(),
+                rToken: main.rToken(),
+                minTradeVolume: backingManager.minTradeVolume(),
+                maxTradeSlippage: backingManager.maxTradeSlippage(),
+                quantities: quantities
+            });
 
             // will exclude UoA value from RToken balances at BackingManager
-            range = RecollateralizationLibP1.basketRange(ctx, reg, quantities, buPrice);
+            range = RecollateralizationLibP1.basketRange(ctx, reg);
         }
     }
 }

--- a/contracts/plugins/assets/RTokenAsset.sol
+++ b/contracts/plugins/assets/RTokenAsset.sol
@@ -146,24 +146,24 @@ contract RTokenAsset is IAsset, VersionedAsset {
             // should switch over to an asset with a price feed.
 
             IMain main = backingManager.main();
-            Registry memory reg = assetRegistry.getRegistry();
+            TradingContext memory ctx;
 
-            uint192[] memory quantities = new uint192[](reg.erc20s.length);
+            ctx.basketsHeld = basketsHeld;
+            ctx.bm = backingManager;
+            ctx.bh = basketHandler;
+            ctx.ar = assetRegistry;
+            ctx.stRSR = main.stRSR();
+            ctx.rsr = main.rsr();
+            ctx.rToken = main.rToken();
+            ctx.minTradeVolume = backingManager.minTradeVolume();
+            ctx.maxTradeSlippage = backingManager.maxTradeSlippage();
+
+            // Calculate quantities
+            Registry memory reg = ctx.ar.getRegistry();
+            ctx.quantities = new uint192[](reg.erc20s.length);
             for (uint256 i = 0; i < reg.erc20s.length; ++i) {
-                quantities[i] = basketHandler.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
+                ctx.quantities[i] = ctx.bh.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
             }
-            TradingContext memory ctx = TradingContext({
-                basketsHeld: basketsHeld,
-                bm: backingManager,
-                bh: basketHandler,
-                ar: assetRegistry,
-                stRSR: main.stRSR(),
-                rsr: main.rsr(),
-                rToken: main.rToken(),
-                minTradeVolume: backingManager.minTradeVolume(),
-                maxTradeSlippage: backingManager.maxTradeSlippage(),
-                quantities: quantities
-            });
 
             // will exclude UoA value from RToken balances at BackingManager
             range = RecollateralizationLibP1.basketRange(ctx, reg);

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -2604,7 +2604,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect(highPrice).to.equal(MAX_UINT192)
     })
 
-    it('Should distinguish between price/lotPrice - prices()', async () => {
+    it('Should distinguish between price/lotPrice', async () => {
       // Set basket with single collateral
       await basketHandler.connect(owner).setPrimeBasket([token0.address], [fp('1')])
       await basketHandler.refreshBasket()
@@ -2613,13 +2613,14 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       const [low, high] = await collateral0.price()
       await setOraclePrice(collateral0.address, MAX_UINT256.div(2)) // oracle error
 
-      const [price, lotPrice] = await basketHandler.prices()
-      expect(price.low).to.equal(0)
-      expect(price.high).to.equal(MAX_UINT192)
-      expect(lotPrice.low).to.be.closeTo(low, low.div(bn('1e5'))) // small decay
-      expect(lotPrice.low).to.be.lt(low)
-      expect(lotPrice.high).to.be.closeTo(high, high.div(bn('1e5'))) // small decay
-      expect(lotPrice.high).to.be.lt(high)
+      const [lowPrice, highPrice] = await basketHandler.price()
+      const [lotLowPrice, lotHighPrice] = await basketHandler.lotPrice()
+      expect(lowPrice).to.equal(0)
+      expect(highPrice).to.equal(MAX_UINT192)
+      expect(lotLowPrice).to.be.closeTo(low, low.div(bn('1e5'))) // small decay
+      expect(lotLowPrice).to.be.lt(low)
+      expect(lotHighPrice).to.be.closeTo(high, high.div(bn('1e5'))) // small decay
+      expect(lotHighPrice).to.be.lt(high)
     })
 
     it('Should disable basket on asset deregistration + return quantities correctly', async () => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -190,6 +190,12 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
         await expect(rToken.connect(bmSigner).dissolve(fp('1'))).to.be.revertedWith(
           'frozen or trading paused'
         )
+
+        // Should have a different outcome if unfrozen
+        await main.connect(owner).unfreeze()
+        await expect(rToken.connect(bmSigner).dissolve(fp('1'))).to.not.be.revertedWith(
+          'frozen or trading paused'
+        )
       })
     })
 

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -172,6 +172,10 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
   })
 
   describe('Configuration #fast', () => {
+    it('Should allow to giveup RTokens only from BackingManager', async () => {
+      await expect(rToken.connect(owner).giveup(fp('1'))).to.be.revertedWith('not backing manager')
+    })
+
     it('Should allow to set basketsNeeded only from BackingManager', async () => {
       // Check initial status
       expect(await rToken.basketsNeeded()).to.equal(0)

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -2024,6 +2024,198 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmount)
         })
 
+        it('Should recollateralize correctly when switching basket - Using RToken for remainder', async () => {
+          // Send it all the RToken at the start -- should be ignored
+          await rToken.connect(addr1).transfer(backingManager.address, issueAmount)
+
+          // Set prime basket
+          await basketHandler.connect(owner).setPrimeBasket([token1.address], [fp('1')])
+
+          // Switch Basket
+          await expect(basketHandler.connect(owner).refreshBasket())
+            .to.emit(basketHandler, 'BasketSet')
+            .withArgs(3, [token1.address], [fp('1')], false)
+
+          // Check state remains SOUND
+          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+          expect(await basketHandler.fullyCollateralized()).to.equal(false)
+          expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+          expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
+          expect(await token1.balanceOf(backingManager.address)).to.equal(0)
+          expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+          // Check price in USD of the current RToken -- retains price because of
+          // over-collateralization
+          await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
+
+          // Trigger recollateralization
+          const sellAmt: BigNumber = await token0.balanceOf(backingManager.address)
+          const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
+
+          await expect(facadeTest.runAuctionsForAllTraders(rToken.address))
+            .to.emit(backingManager, 'TradeStarted')
+            .withArgs(
+              anyValue,
+              token0.address,
+              token1.address,
+              sellAmt,
+              toBNDecimals(minBuyAmt, 6).add(1)
+            )
+
+          let auctionTimestamp: number = await getLatestBlockTimestamp()
+
+          // Check auction registered
+          // Token0 -> Token1 Auction
+          await expectTrade(backingManager, {
+            sell: token0.address,
+            buy: token1.address,
+            endTime: auctionTimestamp + Number(config.batchAuctionLength),
+            externalId: bn('0'),
+          })
+
+          // Check state
+          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+          expect(await basketHandler.fullyCollateralized()).to.equal(false)
+          // Asset value is zero, everything was moved to the Market
+          expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
+          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
+          expect(await token1.balanceOf(backingManager.address)).to.equal(0)
+          expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+          // Check price in USD of the current RToken -- retains price because of
+          // over-collateralization
+          await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
+
+          // Check Gnosis
+          expect(await token0.balanceOf(gnosis.address)).to.equal(issueAmount)
+
+          // Perform Mock Bids for the new Token (addr1 has balance)
+          // Get fair price - minBuyAmt
+          await token1.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmt, 6).add(1))
+          await gnosis.placeBid(0, {
+            bidder: addr1.address,
+            sellAmount: sellAmt,
+            buyAmount: toBNDecimals(minBuyAmt, 6).add(1),
+          })
+
+          // Advance time till auction ended
+          await advanceTime(config.batchAuctionLength.add(100).toString())
+
+          // End current auction, should start a new one to sell a new revenue token instead of RSR
+          // About 3e18 Tokens left to buy - Sets Buy amount as independent value
+          const buyAmtBidRevToken: BigNumber = sellAmt.sub(minBuyAmt)
+
+          // Send the excess revenue tokens to backing manager - should be used instead of RSR
+          // Set price = $1 as expected
+          await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
+            {
+              contract: backingManager,
+              name: 'TradeSettled',
+              args: [
+                anyValue,
+                token0.address,
+                token1.address,
+                sellAmt,
+                toBNDecimals(minBuyAmt, 6).add(1),
+              ],
+              emitted: true,
+            },
+            {
+              contract: backingManager,
+              name: 'TradeStarted',
+              args: [
+                anyValue,
+                rToken.address,
+                token1.address,
+                anyValue,
+                toBNDecimals(buyAmtBidRevToken, 6).add(1),
+              ],
+              emitted: true,
+            },
+          ])
+
+          auctionTimestamp = await getLatestBlockTimestamp()
+
+          // RToken -> Token1 Auction
+          await expectTrade(backingManager, {
+            sell: rToken.address,
+            buy: token1.address,
+            endTime: auctionTimestamp + Number(config.batchAuctionLength),
+            externalId: bn('1'),
+          })
+
+          const t = await getTrade(backingManager, rToken.address)
+          const sellAmtRevToken = await t.initBal()
+          expect(toBNDecimals(buyAmtBidRevToken, 6).add(1)).to.equal(
+            toBNDecimals(await toMinBuyAmt(sellAmtRevToken, fp('1'), fp('1')), 6).add(1)
+          )
+
+          // Check state
+          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+          expect(await basketHandler.fullyCollateralized()).to.equal(false)
+          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
+          expect(await token1.balanceOf(backingManager.address)).to.equal(
+            toBNDecimals(minBuyAmt, 6).add(1)
+          )
+          expect(await rToken.balanceOf(backingManager.address)).to.equal(
+            issueAmount.sub(sellAmtRevToken)
+          )
+          expect(await rToken.totalSupply()).to.equal(issueAmount)
+
+          // Check Gnosis
+          expect(await rToken.balanceOf(gnosis.address)).to.equal(sellAmtRevToken)
+
+          // Perform Mock Bids for the new Token (addr1 has balance)
+          // Cover buyAmtBidRevToken which is all the amount required
+          await token1.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmtRevToken, 6))
+          await gnosis.placeBid(1, {
+            bidder: addr1.address,
+            sellAmount: sellAmtRevToken,
+            buyAmount: toBNDecimals(buyAmtBidRevToken, 6).add(1),
+          })
+
+          // Advance time till auction ended
+          await advanceTime(config.batchAuctionLength.add(100).toString())
+
+          // End current auction
+          await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
+            {
+              contract: backingManager,
+              name: 'TradeSettled',
+              args: [
+                anyValue,
+                rToken.address,
+                token1.address,
+                sellAmtRevToken,
+                toBNDecimals(buyAmtBidRevToken, 6).add(1),
+              ],
+              emitted: true,
+            },
+            {
+              contract: backingManager,
+              name: 'TradeStarted',
+              emitted: false,
+            },
+          ])
+
+          //  Check state - Order restablished
+          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
+          expect(await basketHandler.fullyCollateralized()).to.equal(true)
+          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
+          expect(await token1.balanceOf(backingManager.address)).to.equal(
+            toBNDecimals(issueAmount, 6).add(1)
+          )
+          expect(await rToken.balanceOf(backingManager.address)).to.be.closeTo(bn('0'), 100) // distributor leaves some
+          expect(await rToken.totalSupply()).to.be.closeTo(issueAmount, fp('0.000001')) // we have a bit more
+
+          // Check price in USD of the current RToken
+          await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
+
+          // Stakes unchanged
+          expect(await rsr.balanceOf(stRSR.address)).to.equal(stakeAmount)
+          expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmount)
+        })
+
         it('Should recollateralize correctly in case of default - Using RSR for remainder', async () => {
           // Register Collateral
           await assetRegistry.connect(owner).register(backupCollateral1.address)

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -2024,8 +2024,8 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmount)
         })
 
-        it('Should recollateralize correctly when switching basket - Using RToken for remainder', async () => {
-          // Send it all the RToken at the start -- should be ignored
+        it('Should dissolve held RToken to recapitalize, when possible', async () => {
+          // Send all RToken to BackingManager
           await rToken.connect(addr1).transfer(backingManager.address, issueAmount)
 
           // Set prime basket
@@ -2048,172 +2048,27 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           // over-collateralization
           await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
 
-          // Trigger recollateralization
-          const sellAmt: BigNumber = await token0.balanceOf(backingManager.address)
-          const minBuyAmt: BigNumber = await toMinBuyAmt(sellAmt, fp('1'), fp('1'))
-
-          await expect(facadeTest.runAuctionsForAllTraders(rToken.address))
-            .to.emit(backingManager, 'TradeStarted')
-            .withArgs(
-              anyValue,
-              token0.address,
-              token1.address,
-              sellAmt,
-              toBNDecimals(minBuyAmt, 6).add(1)
-            )
-
-          let auctionTimestamp: number = await getLatestBlockTimestamp()
-
-          // Check auction registered
-          // Token0 -> Token1 Auction
-          await expectTrade(backingManager, {
-            sell: token0.address,
-            buy: token1.address,
-            endTime: auctionTimestamp + Number(config.batchAuctionLength),
-            externalId: bn('0'),
-          })
-
-          // Check state
-          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
-          expect(await basketHandler.fullyCollateralized()).to.equal(false)
-          // Asset value is zero, everything was moved to the Market
-          expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(0)
-          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
-          expect(await token1.balanceOf(backingManager.address)).to.equal(0)
-          expect(await rToken.totalSupply()).to.equal(issueAmount)
-
-          // Check price in USD of the current RToken -- retains price because of
-          // over-collateralization
-          await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
-
-          // Check Gnosis
-          expect(await token0.balanceOf(gnosis.address)).to.equal(issueAmount)
-
-          // Perform Mock Bids for the new Token (addr1 has balance)
-          // Get fair price - minBuyAmt
-          await token1.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmt, 6).add(1))
-          await gnosis.placeBid(0, {
-            bidder: addr1.address,
-            sellAmount: sellAmt,
-            buyAmount: toBNDecimals(minBuyAmt, 6).add(1),
-          })
-
-          // Advance time till auction ended
-          await advanceTime(config.batchAuctionLength.add(100).toString())
-
-          // End current auction, should start a new one to sell a new revenue token instead of RSR
-          // About 3e18 Tokens left to buy - Sets Buy amount as independent value
-          const buyAmtBidRevToken: BigNumber = sellAmt.sub(minBuyAmt)
-
-          // Send the excess revenue tokens to backing manager - should be used instead of RSR
-          // Set price = $1 as expected
-          await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
-            {
-              contract: backingManager,
-              name: 'TradeSettled',
-              args: [
-                anyValue,
-                token0.address,
-                token1.address,
-                sellAmt,
-                toBNDecimals(minBuyAmt, 6).add(1),
-              ],
-              emitted: true,
-            },
-            {
-              contract: backingManager,
-              name: 'TradeStarted',
-              args: [
-                anyValue,
-                rToken.address,
-                token1.address,
-                anyValue,
-                toBNDecimals(buyAmtBidRevToken, 6).add(1),
-              ],
-              emitted: true,
-            },
-          ])
-
-          auctionTimestamp = await getLatestBlockTimestamp()
-
-          // RToken -> Token1 Auction
-          await expectTrade(backingManager, {
-            sell: rToken.address,
-            buy: token1.address,
-            endTime: auctionTimestamp + Number(config.batchAuctionLength),
-            externalId: bn('1'),
-          })
-
-          const t = await getTrade(backingManager, rToken.address)
-          const sellAmtRevToken = await t.initBal()
-          expect(toBNDecimals(buyAmtBidRevToken, 6).add(1)).to.equal(
-            toBNDecimals(await toMinBuyAmt(sellAmtRevToken, fp('1'), fp('1')), 6).add(1)
-          )
-
-          // Check state
-          expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
-          expect(await basketHandler.fullyCollateralized()).to.equal(false)
-          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
-          expect(await token1.balanceOf(backingManager.address)).to.equal(
-            toBNDecimals(minBuyAmt, 6).add(1)
-          )
-          expect(await rToken.balanceOf(backingManager.address)).to.equal(
-            issueAmount.sub(sellAmtRevToken)
-          )
-          expect(await rToken.totalSupply()).to.equal(issueAmount)
-
-          // Check Gnosis
-          expect(await rToken.balanceOf(gnosis.address)).to.equal(sellAmtRevToken)
-
-          // Perform Mock Bids for the new Token (addr1 has balance)
-          // Cover buyAmtBidRevToken which is all the amount required
-          await token1.connect(addr1).approve(gnosis.address, toBNDecimals(sellAmtRevToken, 6))
-          await gnosis.placeBid(1, {
-            bidder: addr1.address,
-            sellAmount: sellAmtRevToken,
-            buyAmount: toBNDecimals(buyAmtBidRevToken, 6).add(1),
-          })
-
-          // Advance time till auction ended
-          await advanceTime(config.batchAuctionLength.add(100).toString())
-
-          // End current auction
-          await expectEvents(facadeTest.runAuctionsForAllTraders(rToken.address), [
-            {
-              contract: backingManager,
-              name: 'TradeSettled',
-              args: [
-                anyValue,
-                rToken.address,
-                token1.address,
-                sellAmtRevToken,
-                toBNDecimals(buyAmtBidRevToken, 6).add(1),
-              ],
-              emitted: true,
-            },
+          // Trigger recollateralization -- should recapitalize by dissolving RToken
+          await expectEvents(backingManager.rebalance(TradeKind.BATCH_AUCTION), [
             {
               contract: backingManager,
               name: 'TradeStarted',
               emitted: false,
             },
+            {
+              contract: rToken,
+              name: 'BasketsNeededChanged',
+              emitted: true,
+            },
           ])
 
-          //  Check state - Order restablished
+          // Check fullyCollateralized and rest of state
           expect(await basketHandler.status()).to.equal(CollateralStatus.SOUND)
           expect(await basketHandler.fullyCollateralized()).to.equal(true)
-          expect(await token0.balanceOf(backingManager.address)).to.equal(0)
-          expect(await token1.balanceOf(backingManager.address)).to.equal(
-            toBNDecimals(issueAmount, 6).add(1)
-          )
-          expect(await rToken.balanceOf(backingManager.address)).to.be.closeTo(bn('0'), 100) // distributor leaves some
-          expect(await rToken.totalSupply()).to.be.closeTo(issueAmount, fp('0.000001')) // we have a bit more
-
-          // Check price in USD of the current RToken
-          await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
-
-          // Stakes unchanged
-          expect(await rsr.balanceOf(stRSR.address)).to.equal(stakeAmount)
-          expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmount)
+          expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.equal(issueAmount)
+          expect(await token0.balanceOf(backingManager.address)).to.equal(issueAmount)
+          expect(await token1.balanceOf(backingManager.address)).to.equal(0)
+          expect(await rToken.totalSupply()).to.equal(0)
         })
 
         it('Should recollateralize correctly in case of default - Using RSR for remainder', async () => {

--- a/test/__snapshots__/FacadeWrite.test.ts.snap
+++ b/test/__snapshots__/FacadeWrite.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `9202775`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `9069178`;
 
 exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Deploy governance 1`] = `5464736`;
 

--- a/test/__snapshots__/Main.test.ts.snap
+++ b/test/__snapshots__/Main.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Refresh 1`] = `341691`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Refresh 1`] = `341625`;
 
 exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 1`] = `192993`;
 
 exports[`MainP1 contract Gas Reporting Asset Registry - Register Asset 2`] = `192993`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Swap Registered Asset 1`] = `164122`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Swap Registered Asset 1`] = `164144`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 1`] = `80394`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 1`] = `80416`;
 
-exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 2`] = `69906`;
+exports[`MainP1 contract Gas Reporting Asset Registry - Unregister Asset 2`] = `69928`;

--- a/test/__snapshots__/RToken.test.ts.snap
+++ b/test/__snapshots__/RToken.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `772417`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `772308`;
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `610624`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `610515`;
 
-exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `586825`;
+exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `573888`;
 
 exports[`RTokenP1 contract Gas Reporting Transfer 1`] = `56570`;
 

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1332440`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1338646`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1465975`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1451081`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1689530`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1695736`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1633814`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1640020`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1731461`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1729104`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1332440`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `2230209`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1453082`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1689530`;
 
@@ -12,6 +12,6 @@ exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] =
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `2664701`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1731105`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1387984`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1332440`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1514304`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `2230209`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1755363`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1689530`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1699806`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1633814`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1790090`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `2664701`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1332440`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1453082`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1465975`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1689530`;
 
@@ -12,6 +12,6 @@ exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] =
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1731105`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1731461`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;

--- a/test/__snapshots__/Revenues.test.ts.snap
+++ b/test/__snapshots__/Revenues.test.ts.snap
@@ -14,7 +14,7 @@ exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 6`] = `212382`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `758101`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1288954`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1150171`;
 
 exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `320785`;
 

--- a/test/__snapshots__/ZZStRSR.test.ts.snap
+++ b/test/__snapshots__/ZZStRSR.test.ts.snap
@@ -14,6 +14,6 @@ exports[`StRSRP1 contract Gas Reporting Unstake 1`] = `222609`;
 
 exports[`StRSRP1 contract Gas Reporting Unstake 2`] = `139758`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `555770`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `555639`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `509774`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `509643`;

--- a/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
+++ b/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11745798`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11745689`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `9481844`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `9481800`;
 
 exports[`Max Basket Size - P1 ATokens/CTokens Should claim rewards correctly 1`] = `2292984`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 1`] = `12996783`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 1`] = `12996739`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `25811511`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `25176105`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10752586`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10752477`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `8471544`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `8471500`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 1`] = `4535205`;
+exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 1`] = `4535170`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `17426207`;
+exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `17613771`;


### PR DESCRIPTION
I already mentioned some context about this PR. In addition to that, I wanted to note that:
- The only part of the original caching I've kept around is the quantities[] array. I moved it into the primary context struct
- There's a new test for checking the RToken only gets sold after everything else
- There's new logic for preventing us from looking up the RToken price when the quantity is so low we can already tell it's not enough. I'm pretty sure the argument follows through, but it deserves a close eye. 