### PR TITLE
3.0.0 audit tbrent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,165 +1,5 @@
 # Changelog
 
-## 1.0.0
-
-(This release is the one from the canonical lauch onstage in Bogota. We were missing semantic versioning at the time, but we call this the 1.0.0 release retroactively.)
-
-Deploy commit [eda322894a5ed379bbda2b399c9d1cc65aa8c132](https://github.com/reserve-protocol/protocol/commit/eda322894a5ed379bbda2b399c9d1cc65aa8c132)
-
-## 1.1.0
-
-- Introduce semantic versioning to the Deployer and RToken
-- `RTokenCreated` event: added `version` argument
-
-```
-event RTokenCreated(
-        IMain indexed main,
-        IRToken indexed rToken,
-        IStRSR stRSR,
-        address indexed owner
-    );
-
-```
-
-=>
-
-```
-event RTokenCreated(
-        IMain indexed main,
-        IRToken indexed rToken,
-        IStRSR stRSR,
-        address indexed owner,
-        string version
-    );
-
-```
-
-- Add `version()` getter on Deployer, Main, and all Components, via mix-in. To be updated with each subsequent release.
-
-Deploy commit [d757d3a5a6097ae42c71fc03a7c787ec001d2efc](https://github.com/reserve-protocol/protocol/commit/d757d3a5a6097ae42c71fc03a7c787ec001d2efc)
-
-## 2.0.0
-
-Candidate release for the "all clear" milestone. There wasn't any real usage of the 1.0.0/1.1.0 releases; this is the first release that we are going to spend real effort to remain backwards compatible with.
-
-- Bump solidity version to 0.8.17
-- Support multiple beneficiaries via the [`FacadeWrite`](contracts/facade/FacadeWrite.sol)
-- Add `RToken.issueTo(address recipient, uint256 amount, ..)` and `RToken.redeemTo(address recipient, uint256 amount, ..)` to support issuance/redemption to a different address than `msg.sender`
-- Add `RToken.redeem*(.., uint256 basketNonce)` to enable msg sender to control expectations around partial redemptions
-- Add `RToken.issuanceAvailable()` + `RToken.redemptionAvailable()`
-- Add `FacadeRead.primeBasket()` + `FacadeRead.backupConfig()` views
-- Many external libs moved to internal
-- Switch from price point estimates to price ranges; all prices now have a `low` and `high`. Impacted interface functions:
-  - `IAsset.price()`
-  - `IBasketHandler.price()`
-- Replace `IAsset.fallbackPrice()` with `IAsset.lotPrice()`. The lot price is the current price when available, and a fallback price otherwise.
-- Introduce decaying fallback prices. Over a finite period of time the fallback price goes to zero, linearly.
-- Remove `IAsset.pricePerTarget()` from asset interface
-- Remove rewards earning and sweeping from RToken
-- Add `safeMulDivCeil()` to `ITrading` traders. Use when overflow is possible from 2 locations:
-  - [RecollateralizationLib.sol:L271](contracts/p1/mixins/RecollateralizationLib.sol)
-  - [TradeLib.sol:L59](contracts/p1/mixins/TradeLib.sol)
-- Introduce config struct to encapsulate Collateral constructor params more neatly
-- In general it should be easier to write Collateral plugins. Implementors should _only_ ever have to override 4 functions: `tryPrice()`, `refPerTok()`, `targetPerRef()`, and `claimRewards()`.
-- Add `.div(1 - maxTradeSlippage)` to calculation of `shortfallSlippage` in [RecollateralizationLib.sol:L188](contracts/p1/mixins/RecollateralizationLib.sol).
-- FacadeRead:
-  - remove `.pendingIssuances()` + `.endIdForVest()`
-  - refactor calculations in `basketBreakdown()`
-- Bugfix: Fix claim rewards from traders in `FacadeAct`
-- Bugfix: Do not handout RSR rewards when no one is staked
-- Bugfix: Support small redemptions even when the RToken supply is massive
-- Bump component-wide `version()` getter to 2.0.0
-- Remove non-atomic issuance
-- Replace redemption battery with issuance and redemption throttles
-  - `amtRate` valid range: `[1e18, 1e48]`
-  - `pctRate` valid range: `[0, 1e18]`
-- Fix Furnace/StRSR reward period to 12 seconds
-- Gov params:
-  - --`rewardPeriod`
-  - --`issuanceRate`
-  - ++`issuanceThrottle`
-  - ++`redemptionThrottle`
-- Events:
-  - --`RToken.IssuanceStarted`
-  - --`RToken.IssuancesCompleted`
-  - --`RToken.IssuancesCanceled`
-  - `Issuance( address indexed recipient, uint256 indexed amount, uint192 baskets )` -> `Issuance( address indexed issuer, address indexed recipient, uint256 indexed amount, uint192 baskets )`
-  - `Redemption(address indexed recipient, uint256 indexed amount, uint192 baskets )` -> `Redemption(address indexed redeemer, address indexed recipient, uint256 indexed amount, uint192 baskets )`
-  - ++`RToken.IssuanceThrottleSet`
-  - ++`RToken.RedemptionThrottleSet`
-- Allow redemption while DISABLED
-- Allow `grantRTokenAllowances()` while paused
-- Add `RToken.monetizeDonations()` escape hatch for accidentally donated tokens
-- Collateral default threshold: 5% -> 1% (+ include oracleError)
-- RecollateralizationLib: Tighter basket range during recollateralization. Will now do `minTradeVolume`-size auctions to fill in dust rather than haircut.
-- Remove StRSR.setName()/setSymbol()
-- Prevent RToken exchange rate manipulation at low supply
-- Prevent StRSR exchange rate manipulation at low supply
-- Forward RSR directly to StRSR, bypassing RSRTrader
-- Accumulate melting on `Furnace.setRatio()`
-- Payout RSR rewards on `StRSR.setRatio()`
-- Distinguish oracle timeouts when dealing with multiple oracles in one plugin
-- Add safety during asset degregistration to ensure it is always possible to unregister an infinite-looping asset
-- Fix `StRSR`/`RToken` EIP712 typehash to use release version instead of "1"
-- Add `FacadeRead.redeem(IRToken rToken, uint256 amount, uint48 basketNonce)` to return the expected redemption quantities on the basketNonce, or revert
-- Integrate with OZ 4.7.3 Governance (changes to `quorum()`/t`proposalThreshold()`)
-
-## 2.1.0
-
-### Core protocol contracts
-
-- `BasketHandler`
-  - Bugfix for `getPrimeBasket()` view
-  - Minor change to `_price()` rounding
-  - Minor natspec improvement to `refreshBasket()`
-- `Broker`
-  - Fix `GnosisTrade` trade implemention to treat defensive rounding by EasyAuction correctly
-  - Add `setGnosis()` and `setTradeImplementation()` governance functions
-- `RToken`
-  - Minor gas optimization added to `redeemTo` to use saved `assetRegistry` variable
-- `StRSR`
-  - Expose RSR variables via `getDraftRSR()`, `getStakeRSR()`, and `getTotalDrafts()` views
-
-### Facades
-
-- `FacadeRead`
-  - Extend `issue()` to return the estimated USD value of deposits as `depositsUoA`
-  - Add `traderBalances()`
-  - Add `auctionsSettleable()`
-  - Add `nextRecollateralizationAuction()`
-  - Modify `backingOverview() to handle unpriced cases`
-- `FacadeAct`
-  - Add `runRevenueAuctions()`
-
-### Plugins
-
-#### Assets and Collateral
-
-Across all collateral, `tryPrice()` was updated to exclude revenueHiding considerations
-
-- Deploy CRV + CVX plugins
-- Add `AnkrStakedEthCollateral` + tests + deployment/verification scripts for ankrETH
-- Add FluxFinance collateral tests + deployment/verification scripts for fUSDC, fUSDT, fDAI, and fFRAX
-- Add CompoundV3 `CTokenV3Collateral` + tests + deployment/verification scripts for cUSDCV3
-- Add Convex `CvxStableCollateral` + tests + deployment/verification scripts for 3Pool
-- Add Convex `CvxVolatileCollateral` + tests + deployment/verification scripts for Tricrypto
-- Add Convex `CvxStableMetapoolCollateral` + tests + deployment/verification scripts for MIM/3Pool
-- Add Convex `CvxStableRTokenMetapoolCollateral` + tests + deployment/verification scripts for eUSD/fraxBP
-- Add Frax `SFraxEthCollateral` + tests + deployment/verification scripts for sfrxETH
-- Add Lido `LidoStakedEthCollateral` + tests + deployment/verification scripts for wstETH
-- Add RocketPool `RethCollateral` + tests + deployment/verification scripts for rETH
-
-### Testing
-
-- Add generic collateral testing suite at `test/plugins/individual-collateral/collateralTests.ts`
-- Add EasyAuction regression test for Broker false positive (observed during USDC de-peg)
-- Add EasyAuction extreme tests
-
-### Documentation
-
-- Add `docs/plugin-addresses.md` as well as accompanying script for generation at `scripts/collateral-params.ts`
-- Add `docs/exhaustive-tests.md` to document running exhaustive tests on GCP
-
 ## 3.0.0
 
 #### Core Protocol Contracts
@@ -273,7 +113,167 @@ Duration: 30 min (default)
 - Add `version() return (string)` getter to pave way for separation of asset versioning and core protocol versioning
 - Remove expectation of `delegatecall` during `claimRewards()` call, though assets can still do it and it won't break anything
 
+## 2.1.0
+
+### Core protocol contracts
+
+- `BasketHandler`
+  - Bugfix for `getPrimeBasket()` view
+  - Minor change to `_price()` rounding
+  - Minor natspec improvement to `refreshBasket()`
+- `Broker`
+  - Fix `GnosisTrade` trade implemention to treat defensive rounding by EasyAuction correctly
+  - Add `setGnosis()` and `setTradeImplementation()` governance functions
+- `RToken`
+  - Minor gas optimization added to `redeemTo` to use saved `assetRegistry` variable
+- `StRSR`
+  - Expose RSR variables via `getDraftRSR()`, `getStakeRSR()`, and `getTotalDrafts()` views
+
+### Facades
+
+- `FacadeRead`
+  - Extend `issue()` to return the estimated USD value of deposits as `depositsUoA`
+  - Add `traderBalances()`
+  - Add `auctionsSettleable()`
+  - Add `nextRecollateralizationAuction()`
+  - Modify `backingOverview() to handle unpriced cases`
+- `FacadeAct`
+  - Add `runRevenueAuctions()`
+
+### Plugins
+
+#### Assets and Collateral
+
+Across all collateral, `tryPrice()` was updated to exclude revenueHiding considerations
+
+- Deploy CRV + CVX plugins
+- Add `AnkrStakedEthCollateral` + tests + deployment/verification scripts for ankrETH
+- Add FluxFinance collateral tests + deployment/verification scripts for fUSDC, fUSDT, fDAI, and fFRAX
+- Add CompoundV3 `CTokenV3Collateral` + tests + deployment/verification scripts for cUSDCV3
+- Add Convex `CvxStableCollateral` + tests + deployment/verification scripts for 3Pool
+- Add Convex `CvxVolatileCollateral` + tests + deployment/verification scripts for Tricrypto
+- Add Convex `CvxStableMetapoolCollateral` + tests + deployment/verification scripts for MIM/3Pool
+- Add Convex `CvxStableRTokenMetapoolCollateral` + tests + deployment/verification scripts for eUSD/fraxBP
+- Add Frax `SFraxEthCollateral` + tests + deployment/verification scripts for sfrxETH
+- Add Lido `LidoStakedEthCollateral` + tests + deployment/verification scripts for wstETH
+- Add RocketPool `RethCollateral` + tests + deployment/verification scripts for rETH
+
+### Testing
+
+- Add generic collateral testing suite at `test/plugins/individual-collateral/collateralTests.ts`
+- Add EasyAuction regression test for Broker false positive (observed during USDC de-peg)
+- Add EasyAuction extreme tests
+
+### Documentation
+
+- Add `docs/plugin-addresses.md` as well as accompanying script for generation at `scripts/collateral-params.ts`
+- Add `docs/exhaustive-tests.md` to document running exhaustive tests on GCP
+
+## 2.0.0
+
+Candidate release for the "all clear" milestone. There wasn't any real usage of the 1.0.0/1.1.0 releases; this is the first release that we are going to spend real effort to remain backwards compatible with.
+
+- Bump solidity version to 0.8.17
+- Support multiple beneficiaries via the [`FacadeWrite`](contracts/facade/FacadeWrite.sol)
+- Add `RToken.issueTo(address recipient, uint256 amount, ..)` and `RToken.redeemTo(address recipient, uint256 amount, ..)` to support issuance/redemption to a different address than `msg.sender`
+- Add `RToken.redeem*(.., uint256 basketNonce)` to enable msg sender to control expectations around partial redemptions
+- Add `RToken.issuanceAvailable()` + `RToken.redemptionAvailable()`
+- Add `FacadeRead.primeBasket()` + `FacadeRead.backupConfig()` views
+- Many external libs moved to internal
+- Switch from price point estimates to price ranges; all prices now have a `low` and `high`. Impacted interface functions:
+  - `IAsset.price()`
+  - `IBasketHandler.price()`
+- Replace `IAsset.fallbackPrice()` with `IAsset.lotPrice()`. The lot price is the current price when available, and a fallback price otherwise.
+- Introduce decaying fallback prices. Over a finite period of time the fallback price goes to zero, linearly.
+- Remove `IAsset.pricePerTarget()` from asset interface
+- Remove rewards earning and sweeping from RToken
+- Add `safeMulDivCeil()` to `ITrading` traders. Use when overflow is possible from 2 locations:
+  - [RecollateralizationLib.sol:L271](contracts/p1/mixins/RecollateralizationLib.sol)
+  - [TradeLib.sol:L59](contracts/p1/mixins/TradeLib.sol)
+- Introduce config struct to encapsulate Collateral constructor params more neatly
+- In general it should be easier to write Collateral plugins. Implementors should _only_ ever have to override 4 functions: `tryPrice()`, `refPerTok()`, `targetPerRef()`, and `claimRewards()`.
+- Add `.div(1 - maxTradeSlippage)` to calculation of `shortfallSlippage` in [RecollateralizationLib.sol:L188](contracts/p1/mixins/RecollateralizationLib.sol).
+- FacadeRead:
+  - remove `.pendingIssuances()` + `.endIdForVest()`
+  - refactor calculations in `basketBreakdown()`
+- Bugfix: Fix claim rewards from traders in `FacadeAct`
+- Bugfix: Do not handout RSR rewards when no one is staked
+- Bugfix: Support small redemptions even when the RToken supply is massive
+- Bump component-wide `version()` getter to 2.0.0
+- Remove non-atomic issuance
+- Replace redemption battery with issuance and redemption throttles
+  - `amtRate` valid range: `[1e18, 1e48]`
+  - `pctRate` valid range: `[0, 1e18]`
+- Fix Furnace/StRSR reward period to 12 seconds
+- Gov params:
+  - --`rewardPeriod`
+  - --`issuanceRate`
+  - ++`issuanceThrottle`
+  - ++`redemptionThrottle`
+- Events:
+  - --`RToken.IssuanceStarted`
+  - --`RToken.IssuancesCompleted`
+  - --`RToken.IssuancesCanceled`
+  - `Issuance( address indexed recipient, uint256 indexed amount, uint192 baskets )` -> `Issuance( address indexed issuer, address indexed recipient, uint256 indexed amount, uint192 baskets )`
+  - `Redemption(address indexed recipient, uint256 indexed amount, uint192 baskets )` -> `Redemption(address indexed redeemer, address indexed recipient, uint256 indexed amount, uint192 baskets )`
+  - ++`RToken.IssuanceThrottleSet`
+  - ++`RToken.RedemptionThrottleSet`
+- Allow redemption while DISABLED
+- Allow `grantRTokenAllowances()` while paused
+- Add `RToken.monetizeDonations()` escape hatch for accidentally donated tokens
+- Collateral default threshold: 5% -> 1% (+ include oracleError)
+- RecollateralizationLib: Tighter basket range during recollateralization. Will now do `minTradeVolume`-size auctions to fill in dust rather than haircut.
+- Remove StRSR.setName()/setSymbol()
+- Prevent RToken exchange rate manipulation at low supply
+- Prevent StRSR exchange rate manipulation at low supply
+- Forward RSR directly to StRSR, bypassing RSRTrader
+- Accumulate melting on `Furnace.setRatio()`
+- Payout RSR rewards on `StRSR.setRatio()`
+- Distinguish oracle timeouts when dealing with multiple oracles in one plugin
+- Add safety during asset degregistration to ensure it is always possible to unregister an infinite-looping asset
+- Fix `StRSR`/`RToken` EIP712 typehash to use release version instead of "1"
+- Add `FacadeRead.redeem(IRToken rToken, uint256 amount, uint48 basketNonce)` to return the expected redemption quantities on the basketNonce, or revert
+- Integrate with OZ 4.7.3 Governance (changes to `quorum()`/t`proposalThreshold()`)
+
 TODO
+
+## 1.1.0
+
+- Introduce semantic versioning to the Deployer and RToken
+- `RTokenCreated` event: added `version` argument
+
+```
+event RTokenCreated(
+        IMain indexed main,
+        IRToken indexed rToken,
+        IStRSR stRSR,
+        address indexed owner
+    );
+
+```
+
+=>
+
+```
+event RTokenCreated(
+        IMain indexed main,
+        IRToken indexed rToken,
+        IStRSR stRSR,
+        address indexed owner,
+        string version
+    );
+
+```
+
+- Add `version()` getter on Deployer, Main, and all Components, via mix-in. To be updated with each subsequent release.
+
+Deploy commit [d757d3a5a6097ae42c71fc03a7c787ec001d2efc](https://github.com/reserve-protocol/protocol/commit/d757d3a5a6097ae42c71fc03a7c787ec001d2efc)
+
+## 1.0.0
+
+(This release is the one from the canonical lauch onstage in Bogota. We were missing semantic versioning at the time, but we call this the 1.0.0 release retroactively.)
+
+Deploy commit [eda322894a5ed379bbda2b399c9d1cc65aa8c132](https://github.com/reserve-protocol/protocol/commit/eda322894a5ed379bbda2b399c9d1cc65aa8c132)
 
 # Links
 

--- a/contracts/facade/FacadeAct.sol
+++ b/contracts/facade/FacadeAct.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Multicall.sol";
+import "../interfaces/IBackingManager.sol";
 import "../interfaces/IFacadeAct.sol";
 
 /**

--- a/contracts/facade/FacadeAct.sol
+++ b/contracts/facade/FacadeAct.sol
@@ -46,6 +46,7 @@ contract FacadeAct is IFacadeAct, Multicall {
             IBackingManager bm = revenueTrader.main().backingManager();
 
             // 3.0.0 interface
+            // solhint-disable-next-line no-empty-blocks
             try bm.forwardRevenue(toStart) {} catch {
                 // try 2.1.0 interface
                 (bool success, ) = address(bm).call{ value: 0 }(
@@ -58,6 +59,7 @@ contract FacadeAct is IFacadeAct, Multicall {
         // Start auctions
         for (uint256 i = 0; i < toStart.length; ++i) {
             // 3.0.0 RevenueTrader interface
+            // solhint-disable-next-line no-empty-blocks
             try revenueTrader.manageToken(toStart[i], kind) {} catch {
                 // Fallback to <=2.1.0 interface
                 (bool success, ) = address(revenueTrader).call{ value: 0 }(

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -86,11 +86,7 @@ contract FacadeRead is IFacadeRead {
     /// @return withdrawals The balances necessary to issue `amount` RToken
     /// @return isProrata True if the redemption is prorata and not full
     /// @custom:static-call
-    function redeem(
-        IRToken rToken,
-        uint256 amount,
-        uint48 basketNonce
-    )
+    function redeem(IRToken rToken, uint256 amount)
         external
         returns (
             address[] memory tokens,
@@ -103,7 +99,6 @@ contract FacadeRead is IFacadeRead {
         IRToken rTok = rToken;
         IBasketHandler bh = main.basketHandler();
         uint256 supply = rTok.totalSupply();
-        require(bh.nonce() == basketNonce, "non-current basket nonce");
 
         // D18{BU} = D18{BU} * {qRTok} / {qRTok}
         uint192 basketsRedeemed = rTok.basketsNeeded().muluDivu(amount, supply);
@@ -285,6 +280,7 @@ contract FacadeRead is IFacadeRead {
             IBackingManager bm = revenueTrader.main().backingManager();
 
             // First try 3.0.0 interface
+            // solhint-disable-next-line no-empty-blocks
             try bm.forwardRevenue(reg.erc20s) {} catch {
                 // try 2.1.0 interface
                 (bool success, ) = address(bm).call{ value: 0 }(
@@ -319,6 +315,7 @@ contract FacadeRead is IFacadeRead {
 
             if (reg.erc20s[i].balanceOf(address(revenueTrader)) > minTradeAmounts[i]) {
                 // 3.0.0 RevenueTrader interface
+                // solhint-disable-next-line no-empty-blocks
                 try revenueTrader.manageToken(erc20s[i], TradeKind.DUTCH_AUCTION) {} catch {
                     // try 2.1.0 interface
                     (bool success, ) = address(revenueTrader).call{ value: 0 }(

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -61,6 +61,4 @@ interface TestIBackingManager is IBackingManager, TestITrading {
     function setTradingDelay(uint48 val) external;
 
     function setBackingBuffer(uint192 val) external;
-
-    function cacheComponents() external;
 }

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -61,4 +61,6 @@ interface TestIBackingManager is IBackingManager, TestITrading {
     function setTradingDelay(uint48 val) external;
 
     function setBackingBuffer(uint192 val) external;
+
+    function cacheComponents() external;
 }

--- a/contracts/interfaces/IFacadeRead.sol
+++ b/contracts/interfaces/IFacadeRead.sol
@@ -35,11 +35,7 @@ interface IFacadeRead {
     /// @return withdrawals The balances necessary to issue `amount` RToken
     /// @return isProrata True if the redemption is prorata and not full
     /// @custom:static-call
-    function redeem(
-        IRToken rToken,
-        uint256 amount,
-        uint48 basketNonce
-    )
+    function redeem(IRToken rToken, uint256 amount)
         external
         returns (
             address[] memory tokens,

--- a/contracts/interfaces/IMain.sol
+++ b/contracts/interfaces/IMain.sol
@@ -16,7 +16,8 @@ import "./IStRSR.sol";
 import "./ITrading.sol";
 import "./IVersioned.sol";
 
-// Warning, assumption: Chain must have blocktimes >= 12s
+// Warning, assumption: Chain should have blocktimes of 12s
+// See docs/system-design.md for discussion of handling longer or shorter times
 uint48 constant ONE_BLOCK = 12; //{s}
 
 // === Auth roles ===

--- a/contracts/interfaces/IRToken.sol
+++ b/contracts/interfaces/IRToken.sol
@@ -109,18 +109,18 @@ interface IRToken is IComponent, IERC20MetadataUpgradeable, IERC20PermitUpgradea
         uint256[] memory minAmounts
     ) external returns (address[] memory erc20sOut, uint256[] memory amountsOut);
 
-    /// Mints a quantity of RToken to the `recipient`, callable only by the BackingManager
-    /// @param recipient The recipient of the newly minted RToken
-    /// @param amount {qRTok} The amount to be minted
+    /// Mint an amount of RToken equivalent to baskets BUs, scaling basketsNeeded up
+    /// Callable only by BackingManager
+    /// @param baskets {BU} The number of baskets to mint RToken for
     /// @custom:protected
-    function mint(address recipient, uint256 amount) external;
+    function mint(uint192 baskets) external;
 
     /// Melt a quantity of RToken from the caller's account
     /// @param amount {qRTok} The amount to be melted
     /// @custom:protected
     function melt(uint256 amount) external;
 
-    /// Dissolve an amount of RToken from caller's account and scale basketsNeeded down
+    /// Burn an amount of RToken from caller's account and scale basketsNeeded down
     /// Callable only by BackingManager
     /// @custom:protected
     function dissolve(uint256 amount) external;

--- a/contracts/interfaces/IRevenueTrader.sol
+++ b/contracts/interfaces/IRevenueTrader.sol
@@ -36,6 +36,4 @@ interface IRevenueTrader is IComponent, ITrading {
 // solhint-disable-next-line no-empty-blocks
 interface TestIRevenueTrader is IRevenueTrader, TestITrading {
     function tokenToBuy() external view returns (IERC20);
-
-    function cacheComponents() external;
 }

--- a/contracts/interfaces/IRevenueTrader.sol
+++ b/contracts/interfaces/IRevenueTrader.sol
@@ -36,4 +36,6 @@ interface IRevenueTrader is IComponent, ITrading {
 // solhint-disable-next-line no-empty-blocks
 interface TestIRevenueTrader is IRevenueTrader, TestITrading {
     function tokenToBuy() external view returns (IERC20);
+
+    function cacheComponents() external;
 }

--- a/contracts/p0/Broker.sol
+++ b/contracts/p0/Broker.sol
@@ -58,11 +58,7 @@ contract BrokerP0 is ComponentP0, IBroker {
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
     /// @dev Requires setting an allowance in advance
     /// @custom:protected
-    function openTrade(TradeKind kind, TradeRequest memory req)
-        external
-        notTradingPausedOrFrozen
-        returns (ITrade)
-    {
+    function openTrade(TradeKind kind, TradeRequest memory req) external returns (ITrade) {
         require(!disabled, "broker disabled");
         assert(req.sellAmount > 0);
 

--- a/contracts/p0/Distributor.sol
+++ b/contracts/p0/Distributor.sol
@@ -41,7 +41,7 @@ contract DistributorP0 is ComponentP0, IDistributor {
     /// Distribute revenue, in rsr or rtoken, per the distribution table.
     /// Requires that this contract has an allowance of at least
     /// `amount` tokens, from `from`, of the token at `erc20`.
-    function distribute(IERC20 erc20, uint256 amount) external notTradingPausedOrFrozen {
+    function distribute(IERC20 erc20, uint256 amount) external {
         IERC20 rsr = main.rsr();
 
         require(erc20 == rsr || erc20 == IERC20(address(main.rToken())), "RSR or RToken");

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -302,6 +302,7 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         exchangeRateIsValidAfter
     {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
+        require(totalSupply() > 0, "0 supply");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;
     }

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -294,7 +294,11 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
 
     /// An affordance of last resort for Main in order to ensure re-capitalization
     /// @custom:protected
-    function setBasketsNeeded(uint192 basketsNeeded_) external exchangeRateIsValidAfter {
+    function setBasketsNeeded(uint192 basketsNeeded_)
+        external
+        notTradingPausedOrFrozen
+        exchangeRateIsValidAfter
+    {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -121,11 +121,8 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
             IERC20(erc20s[i]).safeTransferFrom(issuer, address(main.backingManager()), deposits[i]);
         }
 
-        _mint(recipient, amount);
+        _scaleUp(recipient, baskets);
         emit Issuance(issuer, recipient, amount, baskets);
-
-        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.plus(baskets));
-        basketsNeeded = basketsNeeded.plus(baskets);
     }
 
     /// Redeem RToken for basket collateral
@@ -153,11 +150,11 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         redemptionThrottle.useAvailable(totalSupply(), int256(amount)); // reverts on overuse
 
         // {BU}
-        uint192 basketsRedeemed = _redeem(_msgSender(), amount);
-        emit Redemption(_msgSender(), recipient, amount, basketsRedeemed);
+        uint192 baskets = _scaleDown(_msgSender(), amount);
+        emit Redemption(_msgSender(), recipient, amount, baskets);
 
         (address[] memory erc20s, uint256[] memory amounts) = main.basketHandler().quote(
-            basketsRedeemed,
+            baskets,
             FLOOR
         );
 
@@ -206,7 +203,7 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
         redemptionThrottle.useAvailable(totalSupply(), int256(amount)); // reverts on overuse
 
         // {BU}
-        uint192 basketsRedeemed = _redeem(_msgSender(), amount);
+        uint192 basketsRedeemed = _scaleDown(_msgSender(), amount);
         emit Redemption(_msgSender(), recipient, amount, basketsRedeemed);
 
         // === Get basket redemption amounts ===
@@ -269,17 +266,13 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
 
     // ===
 
-    /// Mint a quantity of RToken to the `recipient`, decreasing the basket rate
-    /// @param recipient The recipient of the newly minted RToken
-    /// @param amount {qRTok} The amount to be minted
+    /// Mint an amount of RToken equivalent to baskets BUs, scaling basketsNeeded up
+    /// Callable only by BackingManager
+    /// @param baskets {BU} The number of baskets to mint RToken for
     /// @custom:protected
-    function mint(address recipient, uint256 amount)
-        external
-        notTradingPausedOrFrozen
-        exchangeRateIsValidAfter
-    {
+    function mint(uint192 baskets) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
-        _mint(recipient, amount);
+        _scaleUp(address(main.backingManager()), baskets);
     }
 
     /// Melt a quantity of RToken from the caller's account, increasing the basket rate
@@ -294,18 +287,14 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
     /// Callable only by backingManager
     /// @param amount {qRTok}
     /// @custom:protected
-    function dissolve(uint256 amount) external notTradingPausedOrFrozen exchangeRateIsValidAfter {
+    function dissolve(uint256 amount) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
-        _redeem(_msgSender(), amount);
+        _scaleDown(_msgSender(), amount);
     }
 
     /// An affordance of last resort for Main in order to ensure re-capitalization
     /// @custom:protected
-    function setBasketsNeeded(uint192 basketsNeeded_)
-        external
-        notTradingPausedOrFrozen
-        exchangeRateIsValidAfter
-    {
+    function setBasketsNeeded(uint192 basketsNeeded_) external exchangeRateIsValidAfter {
         require(_msgSender() == address(main.backingManager()), "not backing manager");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;
@@ -363,16 +352,29 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
 
     // === Private ===
 
-    /// Redeem an amount of RToken from an account for basket units, without transferring tokens
-    /// @param account The address to redeem RTokens from
-    /// @param amount {qRTok} The amount of RToken to be redeemed
-    /// @param basketsRedeemed {BU} The number of baskets redeemed
-    function _redeem(address account, uint256 amount) private returns (uint192 basketsRedeemed) {
-        // {BU} = {BU} * {qRTok} / {qRTok}
-        basketsRedeemed = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
-        assert(basketsRedeemed.lte(basketsNeeded));
-        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(basketsRedeemed));
-        basketsNeeded = basketsNeeded.minus(basketsRedeemed);
+    /// Mint an amount of RToken equivalent to amtBaskets and scale basketsNeeded up
+    /// @param recipient The address to receive the RTokens
+    /// @param amtBaskets {BU} The number of amtBaskets to mint RToken for
+    function _scaleUp(address recipient, uint192 amtBaskets) private {
+        uint256 amtRToken = totalSupply() > 0
+            ? amtBaskets.muluDivu(totalSupply(), uint256(basketsNeeded))
+            : amtBaskets; // {rTok}
+        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.plus(amtBaskets));
+        basketsNeeded = basketsNeeded.plus(amtBaskets);
+
+        // Mint RToken to recipient
+        _mint(recipient, amtRToken); // take advantage of 18 decimals in cast
+    }
+
+    /// Burn an amount of RToken and scale basketsNeeded down
+    /// @param account The address to dissolve RTokens from
+    /// @param amount {qRTok} The amount of RToken to be dissolved
+    /// @return baskets {BU} The equivalent number of baskets dissolved
+    function _scaleDown(address account, uint256 amount) private returns (uint192 baskets) {
+        // D18{BU} = D18{BU} * {qRTok} / {qRTok}
+        baskets = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
+        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(baskets));
+        basketsNeeded = basketsNeeded.minus(baskets);
 
         // Burn RToken from account; reverts if not enough balance
         _burn(account, amount);

--- a/contracts/p0/RToken.sol
+++ b/contracts/p0/RToken.sol
@@ -368,16 +368,16 @@ contract RTokenP0 is ComponentP0, ERC20PermitUpgradeable, IRToken {
 
     /// Burn an amount of RToken and scale basketsNeeded down
     /// @param account The address to dissolve RTokens from
-    /// @param amount {qRTok} The amount of RToken to be dissolved
-    /// @return baskets {BU} The equivalent number of baskets dissolved
-    function _scaleDown(address account, uint256 amount) private returns (uint192 baskets) {
+    /// @param amtRToken {qRTok} The amount of RToken to be dissolved
+    /// @return amtBaskets {BU} The equivalent number of baskets dissolved
+    function _scaleDown(address account, uint256 amtRToken) private returns (uint192 amtBaskets) {
         // D18{BU} = D18{BU} * {qRTok} / {qRTok}
-        baskets = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR
-        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(baskets));
-        basketsNeeded = basketsNeeded.minus(baskets);
+        amtBaskets = basketsNeeded.muluDivu(amtRToken, totalSupply()); // FLOOR
+        emit BasketsNeededChanged(basketsNeeded, basketsNeeded.minus(amtBaskets));
+        basketsNeeded = basketsNeeded.minus(amtBaskets);
 
         // Burn RToken from account; reverts if not enough balance
-        _burn(account, amount);
+        _burn(account, amtRToken);
     }
 
     /**

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -228,7 +228,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         main.rsr().safeTransfer(account, total);
     }
 
-    function cancelUnstake(uint256 endId) external notTradingPausedOrFrozen {
+    function cancelUnstake(uint256 endId) external notFrozen {
         address account = _msgSender();
 
         // IBasketHandler bh = main.basketHandler();

--- a/contracts/p0/mixins/Trading.sol
+++ b/contracts/p0/mixins/Trading.sol
@@ -43,12 +43,7 @@ abstract contract TradingP0 is RewardableP0, ITrading {
     /// @param sell The sell token in the trade
     /// @return trade The ITrade contract settled
     /// @custom:interaction
-    function settleTrade(IERC20 sell)
-        public
-        virtual
-        notTradingPausedOrFrozen
-        returns (ITrade trade)
-    {
+    function settleTrade(IERC20 sell) public virtual returns (ITrade trade) {
         trade = trades[sell];
         require(address(trade) != address(0), "no trade open");
         require(trade.canSettle(), "cannot settle yet");

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -99,6 +99,8 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     /// Apply the overall backing policy using the specified TradeKind, taking a haircut if unable
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
     /// @custom:interaction not RCEI, nonReentrant
+    // untested:
+    //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
     function rebalance(TradeKind kind) external nonReentrant notTradingPausedOrFrozen {
         // == Refresh ==
         assetRegistry.refresh();
@@ -161,6 +163,8 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     /// Forward revenue to RevenueTraders; reverts if not fully collateralized
     /// @param erc20s The tokens to forward
     /// @custom:interaction not RCEI, nonReentrant
+    // untested:
+    //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
     function forwardRevenue(IERC20[] calldata erc20s)
         external
         nonReentrant

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -72,7 +72,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         IERC20(address(erc20)).safeApprove(address(main.rToken()), type(uint256).max);
     }
 
-    /// Settle a single trade. If DUTCH_AUCTION, try rebalance()
+    /// Settle a single trade. If the caller is the trade, try chaining into rebalance()
     /// While this function is not nonReentrant, its two subsets each individually are
     /// @param sell The sell token in the trade
     /// @return trade The ITrade contract settled
@@ -98,7 +98,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
 
     /// Apply the overall backing policy using the specified TradeKind, taking a haircut if unable
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
-    /// @custom:interaction not RCEI, nonReentrant
+    /// @custom:interaction not RCEI; nonReentrant
     // untested:
     //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
     function rebalance(TradeKind kind) external nonReentrant notTradingPausedOrFrozen {
@@ -162,7 +162,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
 
     /// Forward revenue to RevenueTraders; reverts if not fully collateralized
     /// @param erc20s The tokens to forward
-    /// @custom:interaction not RCEI, nonReentrant
+    /// @custom:interaction not RCEI; nonReentrant
     // untested:
     //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
     function forwardRevenue(IERC20[] calldata erc20s)

--- a/contracts/p1/Broker.sol
+++ b/contracts/p1/Broker.sol
@@ -84,7 +84,7 @@ contract BrokerP1 is ComponentP1, IBroker {
     /// Handle a trade request by deploying a customized disposable trading contract
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
     /// @dev Requires setting an allowance in advance
-    /// @custom:interaction CEI
+    /// @custom:protected and @custom:interaction CEI
     // checks:
     //   not disabled, paused (trading), or frozen
     //   caller is a system Trader
@@ -94,11 +94,7 @@ contract BrokerP1 is ComponentP1, IBroker {
     // actions:
     //   Transfers req.sellAmount of req.sell.erc20 from caller to `trade`
     //   Calls trade.init() with appropriate parameters
-    function openTrade(TradeKind kind, TradeRequest memory req)
-        external
-        notTradingPausedOrFrozen
-        returns (ITrade)
-    {
+    function openTrade(TradeKind kind, TradeRequest memory req) external returns (ITrade) {
         require(!disabled, "broker disabled");
 
         address caller = _msgSender();

--- a/contracts/p1/Distributor.sol
+++ b/contracts/p1/Distributor.sol
@@ -84,7 +84,7 @@ contract DistributorP1 is ComponentP1, IDistributor {
     // actions:
     //   for dest where w[dest] != 0:
     //     erc20.transferFrom(from, addrOf(dest), tokensPerShare * w[dest])
-    function distribute(IERC20 erc20, uint256 amount) external notTradingPausedOrFrozen {
+    function distribute(IERC20 erc20, uint256 amount) external {
         require(erc20 == rsr || erc20 == rToken, "RSR or RToken");
         bool isRSR = erc20 == rsr; // if false: isRToken
         uint256 tokensPerShare;

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -471,6 +471,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
     /// @param recipient The address to receive the RTokens
     /// @param amtBaskets {BU} The number of amtBaskets to mint RToken for
     /// @param totalSupply {qRTok} The current totalSupply
+    // BU exchange rate cannot decrease, and it can only increase when < FIX_ONE.
     function _scaleUp(
         address recipient,
         uint192 amtBaskets,
@@ -491,6 +492,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
     /// @param account The address to dissolve RTokens from
     /// @param amount {qRTok} The amount of RToken to be dissolved
     /// @return baskets {BU} The equivalent number of baskets dissolved
+    // BU exchange rate cannot decrease, and it can only increase when < FIX_ONE.
     function _scaleDown(address account, uint256 amount) private returns (uint192 baskets) {
         // D18{BU} = D18{BU} * {qRTok} / {qRTok}
         baskets = basketsNeeded.muluDivu(amount, totalSupply()); // FLOOR

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -181,7 +181,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
 
         assetRegistry.refresh();
         // solhint-disable-next-line no-empty-blocks
-        try main.furnace().melt() {} catch {}
+        try main.furnace().melt() {} catch {} // nice for the redeemer, but not necessary
 
         // == Checks and Effects ==
 

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -386,14 +386,14 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
     /// @custom:protected
     // checks: caller is backingManager
     // effects: basketsNeeded' = basketsNeeded_
-    function setBasketsNeeded(uint192 basketsNeeded_) external {
+    function setBasketsNeeded(uint192 basketsNeeded_) external notTradingPausedOrFrozen {
         require(_msgSender() == address(backingManager), "not backing manager");
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;
 
         // Ensure exchange rate is valid
         uint256 supply = totalSupply();
-        assert(supply > 0);
+        assert(supply > 0); // BackingManager should not be calling
 
         // Note: These are D18s, even though they are uint256s. This is because
         // we cannot assume we stay inside our valid range here, as that is what

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -391,7 +391,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
         emit BasketsNeededChanged(basketsNeeded, basketsNeeded_);
         basketsNeeded = basketsNeeded_;
 
-        // Ensure exchange rate is valid
+        // == P0 exchangeRateIsValidAfter modifier ==
         uint256 supply = totalSupply();
         require(supply > 0, "0 supply");
 

--- a/contracts/p1/RToken.sol
+++ b/contracts/p1/RToken.sol
@@ -393,7 +393,7 @@ contract RTokenP1 is ComponentP1, ERC20PermitUpgradeable, IRToken {
 
         // Ensure exchange rate is valid
         uint256 supply = totalSupply();
-        assert(supply > 0); // BackingManager should not be calling
+        require(supply > 0, "0 supply");
 
         // Note: These are D18s, even though they are uint256s. This is because
         // we cannot assume we stay inside our valid range here, as that is what

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -64,7 +64,7 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
     /// If erc20 is tokenToBuy, distribute it; else, sell it for tokenToBuy
     /// @dev Intended to be used with multicall
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
-    /// @custom:interaction RCEI
+    /// @custom:interaction RCEI and nonReentrant
     // let bal = this contract's balance of erc20
     // checks: !paused (trading), !frozen
     // does nothing if erc20 == addr(0) or bal == 0

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -78,6 +78,8 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
     //   actions:
     //     tryTrade(kind, prepareTradeSell(toAsset(erc20), toAsset(tokenToBuy), bal))
     //     (i.e, start a trade, selling as much of our bal of erc20 as we can, to buy tokenToBuy)
+    // untested:
+    //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
     function manageToken(IERC20 erc20, TradeKind kind)
         external
         nonReentrant

--- a/contracts/p1/RevenueTrader.sol
+++ b/contracts/p1/RevenueTrader.sol
@@ -40,8 +40,13 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
     /// @param sell The sell token in the trade
     /// @return trade The ITrade contract settled
     /// @custom:interaction
-    function settleTrade(IERC20 sell) public override(ITrading, TradingP1) returns (ITrade trade) {
-        trade = super.settleTrade(sell); // modifier: notTradingPausedOrFrozen
+    function settleTrade(IERC20 sell)
+        public
+        override(ITrading, TradingP1)
+        notTradingPausedOrFrozen
+        returns (ITrade trade)
+    {
+        trade = super.settleTrade(sell); // nonReentrant
         distributeTokenToBuy();
         // unlike BackingManager, do _not_ chain trades; b2b trades of the same token are unlikely
     }
@@ -73,7 +78,11 @@ contract RevenueTraderP1 is TradingP1, IRevenueTrader {
     //   actions:
     //     tryTrade(kind, prepareTradeSell(toAsset(erc20), toAsset(tokenToBuy), bal))
     //     (i.e, start a trade, selling as much of our bal of erc20 as we can, to buy tokenToBuy)
-    function manageToken(IERC20 erc20, TradeKind kind) external notTradingPausedOrFrozen {
+    function manageToken(IERC20 erc20, TradeKind kind)
+        external
+        nonReentrant
+        notTradingPausedOrFrozen
+    {
         if (erc20 == tokenToBuy) {
             distributeTokenToBuy();
             return;

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -198,7 +198,8 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
 
     /// Assign reward payouts to the staker pool
     /// @custom:refresher
-    function payoutRewards() external notFrozen {
+    function payoutRewards() external {
+        requireNotFrozen();
         _payoutRewards();
     }
 
@@ -333,8 +334,7 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
     }
 
     function cancelUnstake(uint256 endId) external {
-        requireNotTradingPausedOrFrozen();
-
+        requireNotFrozen();
         address account = _msgSender();
 
         // We specifically allow unstaking when under collateralized
@@ -699,6 +699,10 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
     // contract-size-saver
     // solhint-disable-next-line no-empty-blocks
     function requireNotTradingPausedOrFrozen() private notTradingPausedOrFrozen {}
+
+    // contract-size-saver
+    // solhint-disable-next-line no-empty-blocks
+    function requireNotFrozen() private notFrozen {}
 
     // ==== ERC20 ====
     // This section extracted from ERC20; adjusted to work with stakes/eras

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -83,13 +83,7 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     //   tradesOpen' = tradesOpen - 1
     // untested:
     //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
-    function settleTrade(IERC20 sell)
-        public
-        virtual
-        notTradingPausedOrFrozen
-        nonReentrant
-        returns (ITrade trade)
-    {
+    function settleTrade(IERC20 sell) public virtual nonReentrant returns (ITrade trade) {
         trade = trades[sell];
         require(address(trade) != address(0), "no trade open");
         require(trade.canSettle(), "cannot settle yet");
@@ -121,11 +115,7 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     // This is reentrancy-safe because we're using the `nonReentrant` modifier on every method of
     // this contract that changes state this function refers to.
     // slither-disable-next-line reentrancy-vulnerabilities-1
-    function tryTrade(TradeKind kind, TradeRequest memory req)
-        internal
-        nonReentrant
-        returns (ITrade trade)
-    {
+    function tryTrade(TradeKind kind, TradeRequest memory req) internal returns (ITrade trade) {
         /*  */
         IERC20 sell = req.sell.erc20();
         assert(address(trades[sell]) == address(0));

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -109,23 +109,18 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     // effects:
     //   trades' = trades.set(req.sell, tradeID)
     //   tradesOpen' = tradesOpen + 1
-    //
-    // untested:
-    //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
-    // This is reentrancy-safe because we're using the `nonReentrant` modifier on every method of
-    // this contract that changes state this function refers to.
-    // slither-disable-next-line reentrancy-vulnerabilities-1
     function tryTrade(TradeKind kind, TradeRequest memory req) internal returns (ITrade trade) {
         /*  */
         IERC20 sell = req.sell.erc20();
         assert(address(trades[sell]) == address(0));
 
-        IERC20Upgradeable(address(sell)).safeApprove(address(broker), 0);
-        IERC20Upgradeable(address(sell)).safeApprove(address(broker), req.sellAmount);
-
-        trade = broker.openTrade(kind, req);
         trades[sell] = trade;
         tradesOpen++;
+
+        IERC20Upgradeable(address(sell)).safeApprove(address(broker), 0);
+        IERC20Upgradeable(address(sell)).safeApprove(address(broker), req.sellAmount);
+        trade = broker.openTrade(kind, req);
+
         emit TradeStarted(trade, sell, req.buy.erc20(), req.sellAmount, req.minBuyAmount);
     }
 

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -99,7 +99,7 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     /// Try to initiate a trade with a trading partner provided by the broker
     /// @param kind TradeKind.DUTCH_AUCTION or TradeKind.BATCH_AUCTION
     /// @return trade The trade contract created
-    /// @custom:interaction (only reads or writes `trades`, and is marked `nonReentrant`)
+    /// @custom:interaction Assumption: Caller is nonReentrant
     // checks:
     //   (not external, so we don't need auth or pause checks)
     //   trades[req.sell] == 0
@@ -114,12 +114,12 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
         IERC20 sell = req.sell.erc20();
         assert(address(trades[sell]) == address(0));
 
-        trades[sell] = trade;
-        tradesOpen++;
-
         IERC20Upgradeable(address(sell)).safeApprove(address(broker), 0);
         IERC20Upgradeable(address(sell)).safeApprove(address(broker), req.sellAmount);
+
         trade = broker.openTrade(kind, req);
+        trades[sell] = trade;
+        tradesOpen++;
 
         emit TradeStarted(trade, sell, req.buy.erc20(), req.sellAmount, req.minBuyAmount);
     }

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -37,6 +37,22 @@ Some of the core contracts in our system regularly own ERC20 tokens. In each cas
 2. At vesting time, the `RToken` contract mints new RToken to the recipient and transfers the held collateral to the `BackingManager`. If the `BasketHandler` has updated the basket since issuance began, then the collateral is instead returned to the recipient and no RToken is minted.
 3. During redemption, RToken is burnt from the redeemer's account and they are transferred a prorata share of backing collateral from the `BackingManager`.
 
+## Protocol Assumptions
+
+### Blocktime = 12s
+
+The protocol (weakly) assumes a 12-second blocktime. This section documents the places where this assumption is made and whether changes would be required if blocktime were different.
+
+#### Should-be-changed if blocktime different
+
+- The `Furnace` melts RToken in periods of 12 seconds. If the protocol is deployed to a chain with shorter blocktime, it is possible it may be rational to issue right before melting and redeem directly after, in order to selfishly benefit. The `Furnace` shouild be updated to melt more often. 
+
+#### Probably fine if blocktime different
+
+- `DutchTrade` price curve can handle 1s blocktimes as-is, as well as longer blocktimes
+- The `StRSR` contract hands out RSR rewards in periods of 12 seconds. Since the unstaking period is usually much larger than this, it is fine to deploy StRSR to another chain without changing anything, with shorter or longer blocktimes
+- `BackingManager` spaces out same-kind auctions by 12s. No change is required is blocktime is less; some change required is blocktime is longer
+
 ## Some Monetary Units
 
 Our system refers to units of financial value in a handful of different ways, and treats them as different dimensions. Some of these distinctions may seem like splitting hairs if you're just thinking about one or two example RTokens, but the differences are crucial to understanding how the protocol works in a wide variety of different settings.

--- a/test/Broker.test.ts
+++ b/test/Broker.test.ts
@@ -384,48 +384,6 @@ describe(`BrokerP${IMPLEMENTATION} contract #fast`, () => {
       })
     })
 
-    it('Should not allow to open trade if trading paused', async () => {
-      await main.connect(owner).pauseTrading()
-
-      // Attempt to open trade
-      const tradeRequest: ITradeRequest = {
-        sell: collateral0.address,
-        buy: collateral1.address,
-        sellAmount: bn('100e18'),
-        minBuyAmount: bn('0'),
-      }
-
-      await whileImpersonating(backingManager.address, async (bmSigner) => {
-        await expect(
-          broker.connect(bmSigner).openTrade(TradeKind.BATCH_AUCTION, tradeRequest)
-        ).to.be.revertedWith('frozen or trading paused')
-        await expect(
-          broker.connect(bmSigner).openTrade(TradeKind.DUTCH_AUCTION, tradeRequest)
-        ).to.be.revertedWith('frozen or trading paused')
-      })
-    })
-
-    it('Should not allow to open trade if frozen', async () => {
-      await main.connect(owner).freezeShort()
-
-      // Attempt to open trade
-      const tradeRequest: ITradeRequest = {
-        sell: collateral0.address,
-        buy: collateral1.address,
-        sellAmount: bn('100e18'),
-        minBuyAmount: bn('0'),
-      }
-
-      await whileImpersonating(backingManager.address, async (bmSigner) => {
-        await expect(
-          broker.connect(bmSigner).openTrade(TradeKind.BATCH_AUCTION, tradeRequest)
-        ).to.be.revertedWith('frozen or trading paused')
-        await expect(
-          broker.connect(bmSigner).openTrade(TradeKind.DUTCH_AUCTION, tradeRequest)
-        ).to.be.revertedWith('frozen or trading paused')
-      })
-    })
-
     it('Should only allow to open trade if a trader', async () => {
       const amount: BigNumber = bn('100e18')
 

--- a/test/FacadeRead.test.ts
+++ b/test/FacadeRead.test.ts
@@ -195,11 +195,9 @@ describe('FacadeRead contract', () => {
     })
 
     it('Should return redeemable quantities correctly', async () => {
-      const nonce = await basketHandler.nonce()
       const [toks, quantities, isProrata] = await facade.callStatic.redeem(
         rToken.address,
-        issueAmount,
-        nonce
+        issueAmount
       )
       expect(toks.length).to.equal(4)
       expect(toks[0]).to.equal(token.address)
@@ -216,17 +214,11 @@ describe('FacadeRead contract', () => {
       await token.burn(await main.backingManager(), issueAmount.div(8))
       const [newToks, newQuantities, newIsProrata] = await facade.callStatic.redeem(
         rToken.address,
-        issueAmount,
-        nonce
+        issueAmount
       )
       expect(newToks[0]).to.equal(token.address)
       expect(newQuantities[0]).to.equal(issueAmount.div(8))
       expect(newIsProrata).to.equal(true)
-
-      // Wrong nonce
-      await expect(
-        facade.callStatic.redeem(rToken.address, issueAmount, nonce - 1)
-      ).to.be.revertedWith('non-current basket nonce')
     })
 
     it('Should return backingOverview correctly', async () => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -2285,6 +2285,42 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       })
     })
 
+    it('Should not allow setBasketsNeeded if paused', async () => {
+      // Check initial status
+      expect(await rToken.basketsNeeded()).to.equal(issueAmount)
+
+      // Pause Main
+      await main.connect(owner).pauseTrading()
+
+      // Try to set baskets needed
+      await whileImpersonating(backingManager.address, async (bhSigner) => {
+        await expect(rToken.connect(bhSigner).setBasketsNeeded(fp('1'))).to.be.revertedWith(
+          'frozen or trading paused'
+        )
+      })
+
+      // Check value remains the same
+      expect(await rToken.basketsNeeded()).to.equal(issueAmount)
+    })
+
+    it('Should not allow setBasketsNeeded if frozen', async () => {
+      // Check initial status
+      expect(await rToken.basketsNeeded()).to.equal(issueAmount)
+
+      // Freeze Main
+      await main.connect(owner).freezeShort()
+
+      // Try to set baskets needed
+      await whileImpersonating(backingManager.address, async (bhSigner) => {
+        await expect(rToken.connect(bhSigner).setBasketsNeeded(fp('1'))).to.be.revertedWith(
+          'frozen or trading paused'
+        )
+      })
+
+      // Check value remains the same
+      expect(await rToken.basketsNeeded()).to.equal(issueAmount)
+    })
+
     it('mint() should not change the BU exchange rate', async () => {
       // mint()
       await whileImpersonating(backingManager.address, async (signer) => {

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -2240,6 +2240,19 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       await expect(rToken.connect(addr1).melt(issueAmount)).to.be.revertedWith('furnace only')
     })
 
+    it('Should not allow transfer/transferFrom to address(this)', async () => {
+      // transfer
+      await expect(rToken.connect(addr1).transfer(rToken.address, 1)).to.be.revertedWith(
+        'RToken transfer to self'
+      )
+
+      // transferFrom
+      await rToken.connect(addr1).approve(addr2.address, 1)
+      await expect(
+        rToken.connect(addr2).transferFrom(addr1.address, rToken.address, 1)
+      ).to.be.revertedWith('RToken transfer to self')
+    })
+
     it('Should only allow to mint tokens when called by backing manager', async () => {
       // Mint tokens
       const mintAmount: BigNumber = bn('10e18')

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -28,7 +28,6 @@ import {
   StaticATokenMock,
   TestIBackingManager,
   TestIBasketHandler,
-  TestIFurnace,
   TestIMain,
   TestIRToken,
   USDCMock,
@@ -97,7 +96,6 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
   let assetRegistry: IAssetRegistry
   let backingManager: TestIBackingManager
   let basketHandler: TestIBasketHandler
-  let furnace: TestIFurnace
 
   beforeEach(async () => {
     ;[owner, addr1, addr2, other] = await ethers.getSigners()
@@ -113,7 +111,6 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
       main,
       rToken,
       rTokenAsset,
-      furnace,
     } = await loadFixture(defaultFixture))
 
     // Get assets and tokens

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -17,6 +17,7 @@ import { bn, fp, pow10, toBNDecimals, divCeil } from '../common/numbers'
 import {
   Asset,
   ATokenFiatCollateral,
+  BackingManagerP1,
   CTokenMock,
   DutchTrade,
   CTokenVaultMock,
@@ -201,7 +202,10 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
 
     await backupToken1.connect(owner).mint(addr2.address, initialBal)
     await backupToken2.connect(owner).mint(addr2.address, initialBal)
-    await backingManager.cacheComponents()
+
+    if (IMPLEMENTATION === Implementation.P1) {
+      await (<BackingManagerP1>backingManager).cacheComponents()
+    }
   }
 
   beforeEach(async () => {

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -17,7 +17,6 @@ import { bn, fp, pow10, toBNDecimals, divCeil } from '../common/numbers'
 import {
   Asset,
   ATokenFiatCollateral,
-  BackingManagerP1,
   CTokenMock,
   DutchTrade,
   CTokenVaultMock,
@@ -204,7 +203,9 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
     await backupToken2.connect(owner).mint(addr2.address, initialBal)
 
     if (IMPLEMENTATION === Implementation.P1) {
-      await (<BackingManagerP1>backingManager).cacheComponents()
+      await (
+        await ethers.getContractAt('BackingManagerP1', backingManager.address)
+      ).cacheComponents()
     }
   }
 

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -201,6 +201,7 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
 
     await backupToken1.connect(owner).mint(addr2.address, initialBal)
     await backupToken2.connect(owner).mint(addr2.address, initialBal)
+    await backingManager.cacheComponents()
   }
 
   beforeEach(async () => {

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -2601,7 +2601,7 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
 
           const supply = bonus.sub(bonus.mul(config.backingBuffer).div(fp('1')))
           // Should mint the excess in order to re-handout to RToken holders and stakers
-          expect(await rToken.totalSupply()).to.be.closeTo(supply, supply.div(bn('1e6')))
+          expect(await rToken.totalSupply()).to.be.closeTo(supply, supply.div(bn('1e4')))
           expect(await rToken.totalSupply()).to.be.gte(supply)
 
           // Check price in USD of the current RToken - overcollateralized and still targeting 1

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -189,6 +189,8 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
     // Mint initial balances
     initialBal = bn('1000000e18')
     await mintCollaterals(owner, [addr1, addr2], initialBal, basket)
+    await rTokenTrader.cacheComponents()
+    await rsrTrader.cacheComponents()
   })
 
   describe('Deployment', () => {

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -27,7 +27,6 @@ import {
   IAssetRegistry,
   InvalidATokenFiatCollateralMock,
   MockV3Aggregator,
-  RevenueTraderP1,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
@@ -191,8 +190,8 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
     initialBal = bn('1000000e18')
     await mintCollaterals(owner, [addr1, addr2], initialBal, basket)
     if (IMPLEMENTATION === Implementation.P1) {
-      await (<RevenueTraderP1>rTokenTrader).cacheComponents()
-      await (<RevenueTraderP1>rsrTrader).cacheComponents()
+      await (await ethers.getContractAt('RevenueTraderP1', rTokenTrader.address)).cacheComponents()
+      await (await ethers.getContractAt('RevenueTraderP1', rsrTrader.address)).cacheComponents()
     }
   })
 

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -27,6 +27,7 @@ import {
   IAssetRegistry,
   InvalidATokenFiatCollateralMock,
   MockV3Aggregator,
+  RevenueTraderP1,
   RTokenAsset,
   StaticATokenMock,
   TestIBackingManager,
@@ -189,8 +190,10 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
     // Mint initial balances
     initialBal = bn('1000000e18')
     await mintCollaterals(owner, [addr1, addr2], initialBal, basket)
-    await rTokenTrader.cacheComponents()
-    await rsrTrader.cacheComponents()
+    if (IMPLEMENTATION === Implementation.P1) {
+      await (<RevenueTraderP1>rTokenTrader).cacheComponents()
+      await (<RevenueTraderP1>rsrTrader).cacheComponents()
+    }
   })
 
   describe('Deployment', () => {

--- a/test/__snapshots__/Broker.test.ts.snap
+++ b/test/__snapshots__/Broker.test.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Initialize Trade  1`] = `233100`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Initialize Trade  1`] = `233035`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  1`] = `350227`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  1`] = `337662`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  2`] = `352276`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  2`] = `339776`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  3`] = `354414`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  3`] = `341914`;
 
 exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Settle Trade  1`] = `63429`;
 
 exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Initialize Trade  1`] = `451427`;
 
-exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  1`] = `552471`;
+exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  1`] = `539971`;
 
-exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  2`] = `540309`;
+exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  2`] = `527809`;
 
-exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  3`] = `542447`;
+exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Open Trade  3`] = `529947`;
 
 exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Settle Trade  1`] = `113056`;

--- a/test/__snapshots__/Broker.test.ts.snap
+++ b/test/__snapshots__/Broker.test.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Initialize Trade  1`] = `233035`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Initialize Trade  1`] = `233492`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  1`] = `337662`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  1`] = `338119`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  2`] = `339776`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  2`] = `340233`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  3`] = `341914`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Open Trade  3`] = `342371`;
 
-exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Settle Trade  1`] = `63429`;
+exports[`BrokerP1 contract #fast Gas Reporting DutchTrade Settle Trade  1`] = `63421`;
 
 exports[`BrokerP1 contract #fast Gas Reporting GnosisTrade Initialize Trade  1`] = `451427`;
 

--- a/test/__snapshots__/FacadeWrite.test.ts.snap
+++ b/test/__snapshots__/FacadeWrite.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `9069178`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 1 - RToken Deployment 1`] = `9070064`;
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Deploy governance 1`] = `5464736`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Deploy governance 1`] = `5464714`;
 
-exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Without governance 1`] = `114917`;
+exports[`FacadeWrite contract Deployment Process Gas Reporting Phase 2 - Without governance 1`] = `114895`;

--- a/test/__snapshots__/Furnace.test.ts.snap
+++ b/test/__snapshots__/Furnace.test.ts.snap
@@ -2,34 +2,34 @@
 
 exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 1`] = `83925`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 2`] = `92751`;
+exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 2`] = `89814`;
 
 exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 1`] = `83925`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `78297`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `78297`;
 
 exports[`FurnaceP1 contract Gas Reporting Melt - One period  1`] = `64025`;
 
 exports[`FurnaceP1 contract Gas Reporting Melt - One period  2`] = `80657`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `81234`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `78297`;
 
 exports[`FurnaceP1 contract Gas Reporting Melt - One period  4`] = `40755`;

--- a/test/__snapshots__/Furnace.test.ts.snap
+++ b/test/__snapshots__/Furnace.test.ts.snap
@@ -1,35 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 1`] = `83816`;
+exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 1`] = `83925`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 2`] = `92565`;
+exports[`FurnaceP1 contract Gas Reporting Melt - A million periods, all at once 2`] = `92751`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 1`] = `83816`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 1`] = `83925`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 2`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 3`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 4`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 5`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 6`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 7`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 8`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 9`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 10`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - Many periods, one after the other 11`] = `81234`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  1`] = `63916`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  1`] = `64025`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  2`] = `80548`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  2`] = `80657`;
 
-exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `81048`;
+exports[`FurnaceP1 contract Gas Reporting Melt - One period  3`] = `81234`;
 
 exports[`FurnaceP1 contract Gas Reporting Melt - One period  4`] = `40755`;

--- a/test/__snapshots__/RToken.test.ts.snap
+++ b/test/__snapshots__/RToken.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `772308`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 1`] = `770967`;
 
-exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `610515`;
+exports[`RTokenP1 contract Gas Reporting Issuance: within block 2`] = `597971`;
 
-exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `573888`;
+exports[`RTokenP1 contract Gas Reporting Redemption 1`] = `573851`;
 
-exports[`RTokenP1 contract Gas Reporting Transfer 1`] = `56570`;
+exports[`RTokenP1 contract Gas Reporting Transfer 1`] = `56658`;
 
-exports[`RTokenP1 contract Gas Reporting Transfer 2`] = `34670`;
+exports[`RTokenP1 contract Gas Reporting Transfer 2`] = `34758`;
 
-exports[`RTokenP1 contract Gas Reporting Transfer 3`] = `51770`;
+exports[`RTokenP1 contract Gas Reporting Transfer 3`] = `51858`;

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1334404`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1336127`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1459732`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1468729`;
+
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  3`] = `649733`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1691559`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1635843`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1635487`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] =
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1635487`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1635843`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1338646`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1334404`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1451081`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1459732`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1695736`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1691559`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1640020`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1635487`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1729104`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1725283`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;

--- a/test/__snapshots__/Revenues.test.ts.snap
+++ b/test/__snapshots__/Revenues.test.ts.snap
@@ -12,14 +12,14 @@ exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 5`] = `229482`;
 
 exports[`Revenues - P1 Gas Reporting Claim and Sweep Rewards 6`] = `212382`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `758101`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 1`] = `754579`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1150171`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 2`] = `1146627`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `320785`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 3`] = `317989`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `273846`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 4`] = `271345`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `741001`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 5`] = `737479`;
 
-exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `251645`;
+exports[`Revenues - P1 Gas Reporting Settle Trades / Manage Funds 6`] = `248849`;

--- a/test/__snapshots__/ZZStRSR.test.ts.snap
+++ b/test/__snapshots__/ZZStRSR.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`StRSRP1 contract Gas Reporting Stake 1`] = `152134`;
 
-exports[`StRSRP1 contract Gas Reporting Stake 2`] = `164488`;
+exports[`StRSRP1 contract Gas Reporting Stake 2`] = `147334`;
 
 exports[`StRSRP1 contract Gas Reporting Transfer 1`] = `63389`;
 

--- a/test/__snapshots__/ZZStRSR.test.ts.snap
+++ b/test/__snapshots__/ZZStRSR.test.ts.snap
@@ -14,6 +14,6 @@ exports[`StRSRP1 contract Gas Reporting Unstake 1`] = `222609`;
 
 exports[`StRSRP1 contract Gas Reporting Unstake 2`] = `139758`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `555639`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 1`] = `555617`;
 
-exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `509643`;
+exports[`StRSRP1 contract Gas Reporting Withdraw 2`] = `509621`;

--- a/test/__snapshots__/ZZStRSR.test.ts.snap
+++ b/test/__snapshots__/ZZStRSR.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`StRSRP1 contract Gas Reporting Stake 1`] = `152134`;
 
-exports[`StRSRP1 contract Gas Reporting Stake 2`] = `147334`;
+exports[`StRSRP1 contract Gas Reporting Stake 2`] = `164488`;
 
 exports[`StRSRP1 contract Gas Reporting Transfer 1`] = `63389`;
 

--- a/test/integration/mainnet-test/StaticATokens.test.ts
+++ b/test/integration/mainnet-test/StaticATokens.test.ts
@@ -366,7 +366,7 @@ describeFork(`Static ATokens - Mainnet Check - Mainnet Forking P${IMPLEMENTATION
       })
 
       // Wrap aBusd  - Underlying = false
-      expect(await aBusd.balanceOf(addr1.address)).to.equal(initialBal)
+      expect(await aBusd.balanceOf(addr1.address)).to.be.closeTo(initialBal, 1)
       expect(await stataBusd.balanceOf(addr1.address)).to.equal(0)
 
       // Wrap aBUSD into a staticaBUSD

--- a/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
+++ b/test/scenario/__snapshots__/MaxBasketSize.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11745689`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 1`] = `11745060`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `9481800`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should Issue/Redeem with max basket correctly 2`] = `9481763`;
 
 exports[`Max Basket Size - P1 ATokens/CTokens Should claim rewards correctly 1`] = `2292984`;
 
 exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 1`] = `12996739`;
 
-exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `25176105`;
+exports[`Max Basket Size - P1 ATokens/CTokens Should switch basket correctly 2`] = `25285711`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10752477`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 1`] = `10751848`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `8471500`;
+exports[`Max Basket Size - P1 Fiatcoins Should Issue/Redeem with max basket correctly 2`] = `8471463`;
 
 exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 1`] = `4535170`;
 
-exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `17613771`;
+exports[`Max Basket Size - P1 Fiatcoins Should switch basket correctly 2`] = `17723377`;


### PR DESCRIPTION
This PR represents my internal audit. I want to:
- Remove redundant notTradingPausedOrFrozen modifiers in `@custom:protected` functions
- Move modifiers in BackingManager to the top-level of the function where possible. In BackingManager's case this allows us to undo some RCEI structure that was costing gas. We had stuffed our modifiers into the Trading parent contract. In general it's dangerous to have nonReentrant anywhere other than first in the execution trace. Note that neither RCEI nor nonReentrant guards us from cross-contract reentrancy attacks; we have already accepted as a constraint of governance that ERC20 transfers should not pass execution. 
- Remove redundant notTradingPausedOrFrozen modifiers. Mainly: (i) Broker doesn't need it on openTrade and (ii) Distributor doesn't need it on distribute()
- Simplify BackingManager.forwardRevenue() when it is minting RTokens. It was doing two separate calls to `mint()` and `setBasketsNeeded()`, which was inefficient but more importantly obscured a very subtle bug where we were using the backingBuffer-bumped `needed` variable to calculate how many RTokens to mint, when this should have been left to RToken contract. The way it is now the RToken.mint() function handles basketsNeeded updates. 
- Make uniform _all_ RToken supply change logic. All supply changes go through the same 2 private helpers now: `_scaleUp()` and `_scaleDown()`. I'm down for different names, but I think this overall approach of pushing everything through the same BU-exchange-rate-preserving functions is good and we should stick with it. 
- I did an analysis of which functions in RToken could change the BU exchange rate and how. `melt()` and `setBasketsNeeded()` are the only ones at-risk of moving outside our [1e-9, 1e9] bounds. We had actually already done the analysis to figure out that `issue()/redeem()` were safe. Since we trust the furnace already not to `melt()` too fast, it only seems necessary to have the modifier on `setBasketsNeeded()`. I left it on _all_ the functions in the P0 implementation. Hopefully this doesn't cause problems for fuzzing.
- Change StRSR.cancelUnstake() modifier from notTradingPausedOrFrozen to notFrozen. StRSR.stake() is allowed while frozen or paused. For similar reasons we should allow cancelling an unstaking when paused. I'm hesitant to allow it when frozen as well because it's not a key part of the governance defense system, but we definitely can allow it when paused. 

Gas costs are pretty much better across the board. I think removing modifiers from RToken.melt() is worth it because of how many times it is going to get executed. It's part of all the important flows (issuance, redemption, trading). And moving exchangeRateIsValidAfter off issuance and redemption is going to provide massive savings in the long-run. 