### PR TITLE
fix call to settle trade

### DIFF
--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -235,7 +235,7 @@ contract FacadeRead is IFacadeRead {
             for (uint256 i = 0; i < erc20s.length; ++i) {
                 ITrade trade = bm.trades(erc20s[i]);
                 if (address(trade) != address(0) && trade.canSettle()) {
-                    trade.settle();
+                    bm.settleTrade(erc20s[i]);
                     break; // backingManager can only have 1 trade open at a time
                 }
             }


### PR DESCRIPTION
* Fix bug in `FacadeRead`, this call reverts if not done from the Trade origin (BM)
* Tests are being done as part of my coverage checks, but wanted to push this fix quickly in case its needed to redeploy (this was not covered thats why it was not detected)