### PR TITLE
C4: StRSR reset stakes functionality

### DIFF
--- a/contracts/interfaces/IStRSR.sol
+++ b/contracts/interfaces/IStRSR.sol
@@ -134,15 +134,15 @@ interface IStRSR is IERC20MetadataUpgradeable, IERC20PermitUpgradeable, ICompone
     /// @custom:protected
     function seizeRSR(uint256 amount) external;
 
+    /// Reset all stakes and advance era
+    /// @custom:governance
+    function resetStakes() external;
+
     /// Return the maximum valid value of endId such that withdraw(endId) should immediately work
     function endIdForWithdraw(address account) external view returns (uint256 endId);
 
     /// @return {qRSR/qStRSR} The exchange rate between RSR and StRSR
     function exchangeRate() external view returns (uint192);
-
-    /// Reset all stakes and advance era
-    /// @custom:governance
-    function resetStakes() external;
 }
 
 interface TestIStRSR is IStRSR {

--- a/contracts/interfaces/IStRSR.sol
+++ b/contracts/interfaces/IStRSR.sol
@@ -139,6 +139,10 @@ interface IStRSR is IERC20MetadataUpgradeable, IERC20PermitUpgradeable, ICompone
 
     /// @return {qRSR/qStRSR} The exchange rate between RSR and StRSR
     function exchangeRate() external view returns (uint192);
+
+    /// Reset all stakes and advance era
+    /// @custom:governance
+    function resetStakes() external;
 }
 
 interface TestIStRSR is IStRSR {

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -99,8 +99,8 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
     uint192 private constant MIN_EXCHANGE_RATE = uint192(1e9); // 1e-9
 
     // stake rate under/over which governance can reset all stakes
-    uint192 private constant MAX_SAFE_STAKE_RATE = 1e6 * FIX_ONE; // 1e6   D18{qStRSR/qRSR}
-    uint192 private constant MIN_SAFE_STAKE_RATE = uint192(1e12); // 1e-6  D18{qStRSR/qRSR}
+    uint192 private constant MAX_SAFE_STAKE_RATE = 1e6 * FIX_ONE; // 1e6
+    uint192 private constant MIN_SAFE_STAKE_RATE = uint192(1e12); // 1e-6
 
     // Withdrawal Leak
     uint192 private leaked; // {1} stake fraction that has withdrawn without a refresh
@@ -388,7 +388,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
     /// @custom:governance
     /// Reset all stakes and advance era
     function resetStakes() external governance {
-        uint192 stakeRate = FIX_ONE.div(exchangeRate());
+        uint192 stakeRate = divuu(totalStaked, rsrBacking);
         require(
             stakeRate <= MIN_SAFE_STAKE_RATE || stakeRate >= MAX_SAFE_STAKE_RATE,
             "rate still safe"

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -98,6 +98,10 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
     // Min exchange rate {qRSR/qStRSR} (compile-time constant)
     uint192 private constant MIN_EXCHANGE_RATE = uint192(1e9); // 1e-9
 
+    // stake rate under/over which governance can reset all stakes
+    uint192 private constant MAX_SAFE_STAKE_RATE = 1e6 * FIX_ONE; // 1e6   D18{qStRSR/qRSR}
+    uint192 private constant MIN_SAFE_STAKE_RATE = uint192(1e12); // 1e-6  D18{qStRSR/qRSR}
+
     // Withdrawal Leak
     uint192 private leaked; // {1} stake fraction that has withdrawn without a refresh
     uint48 private lastWithdrawRefresh; // {s} timestamp of last refresh() during withdraw()
@@ -378,6 +382,20 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
             address account = accounts.at(i);
             delete withdrawals[account];
         }
+        emit AllUnstakingReset(era);
+    }
+
+    /// @custom:governance
+    /// Reset all stakes and advance era
+    function resetStakes() external governance {
+        uint192 stakeRate = FIX_ONE.div(exchangeRate());
+        require(
+            stakeRate <= MIN_SAFE_STAKE_RATE || stakeRate >= MAX_SAFE_STAKE_RATE,
+            "rate still safe"
+        );
+
+        bankruptStakers();
+        bankruptWithdrawals();
     }
 
     /// Refresh if too much RSR has exited since the last refresh occurred

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -2189,6 +2189,8 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
       // check new rate
       expectedRate = fp(stakeAmt.sub(seizeAmt).sub(seizeAmt2)).div(stakeAmt)
       expect(await stRSR.exchangeRate()).to.be.closeTo(expectedRate, 1)
+      expect(await stRSR.exchangeRate()).to.be.lte(fp('1e-6'))
+      expect(await stRSR.exchangeRate()).to.be.gte(fp('1e-9'))
 
       // Now governance can reset stakes
       await expect(stRSR.connect(owner).resetStakes()).to.emit(stRSR, 'AllBalancesReset')
@@ -2248,7 +2250,8 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
       // Payout rewards - Advance time - rate will be unsafe
       await setNextBlockTimestamp(Number(ONE_PERIOD.mul(100).add(await getLatestBlockTimestamp())))
       await expect(stRSR.payoutRewards()).to.emit(stRSR, 'ExchangeRateSet')
-      expect(await stRSR.exchangeRate()).to.be.gt(newRate) // increased
+      expect(await stRSR.exchangeRate()).to.be.gte(fp('1e6'))
+      expect(await stRSR.exchangeRate()).to.be.lte(fp('1e9'))
       expect(await stRSR.totalSupply()).to.equal(stakeAmt)
       expect(await stRSR.balanceOf(addr1.address)).to.equal(stakeAmt)
 


### PR DESCRIPTION
* Allows governance to reset all stakes if the stake rate is outside of the safe limites [`1e-6,1e6`]

Resolves https://github.com/code-423n4/2023-06-reserve-findings/issues/2
