### PR TITLE
RecollateralizationLib gas optimization

### DIFF
--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -5191,10 +5191,10 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
       let tradeAddr = await backingManager.trades(token2.address)
       let trade = await ethers.getContractAt('DutchTrade', tradeAddr)
       await backupToken1.connect(addr1).approve(trade.address, initialBal)
-      await advanceToTimestamp((await trade.endTime()) - 1)
+      await advanceBlocks((await trade.endBlock()).sub(await getLatestBlockNumber()).sub(1))
       await snapshotGasCost(trade.connect(addr1).bid())
 
-      // Expect new trade started -- bid in first block at ~1000x price
+      // Expect new trade started -- bid in last block
       expect(await backingManager.tradesOpen()).to.equal(1)
       expect(await backingManager.trades(token2.address)).to.equal(ZERO_ADDRESS)
       expect(await backingManager.trades(rsr.address)).to.not.equal(ZERO_ADDRESS)

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1305108`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1430387`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1445319`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1555412`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  3`] = `649717`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  3`] = `745259`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1675046`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1736054`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `184816`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `174808`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1624723`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1666295`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `184816`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `174808`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1714111`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1754506`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `212916`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `202908`;

--- a/test/__snapshots__/Recollateralization.test.ts.snap
+++ b/test/__snapshots__/Recollateralization.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1430387`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  1`] = `1390986`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1555412`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  2`] = `1517200`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - DutchTrade  3`] = `745259`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1736054`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  1`] = `1685173`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  2`] = `174808`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1666295`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  3`] = `1616603`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  4`] = `174808`;
 
-exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1754506`;
+exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  5`] = `1704814`;
 
 exports[`Recollateralization - P1 Gas Reporting rebalance() - GnosisTrade  6`] = `202908`;


### PR DESCRIPTION
Couple things happening in this PR
1. Fix Recollateralization gas tests to actually run successfully
2. Update gas snapshots to show where `3.0.0-rc5` actually was
3. Apply gas optimizations to `RecollateralizationLibP1.sol` to reduce the need for a mulDiv for every single asset, on the range.bottom side.
4. Compute new gas snapshots

So the total diff shown in the PR is the result of (i) a large increase that was already present in `3.0.0-rc5` and (ii) a moderate decrease that I applied by gas optimizing the range.bottom computation. Attaching a screenshot of _just_ that decrease so it can be easily seen, but you could also go [here](https://github.com/reserve-protocol/protocol/commit/392997d51002d45d249cddab72522356553d45be)

![Screenshot 2023-08-10 at 6 56 11 PM](https://github.com/reserve-protocol/protocol/assets/13439795/bead334b-832d-4d9e-a5d3-53b4619e339e)
