### PR TITLE
c4: #5 Potential Early Exploit in Morho-Aave ERC4626 Implementation

### DIFF
--- a/contracts/plugins/assets/morpho-aave/IMorpho.sol
+++ b/contracts/plugins/assets/morpho-aave/IMorpho.sol
@@ -7,6 +7,12 @@ import { IERC4626 } from "../../../vendor/oz/IERC4626.sol";
 interface IMorpho {
     function supply(address _poolToken, uint256 _amount) external;
 
+    function supply(
+        address _poolToken,
+        address _onBehalf,
+        uint256 _amount
+    ) external;
+
     function withdraw(address _poolToken, uint256 _amount) external;
 }
 

--- a/contracts/plugins/assets/morpho-aave/MorphoTokenisedDeposit.sol
+++ b/contracts/plugins/assets/morpho-aave/MorphoTokenisedDeposit.sol
@@ -64,7 +64,7 @@ abstract contract MorphoTokenisedDeposit is RewardableERC4626Vault {
     }
 
     function _decimalsOffset() internal view virtual override returns (uint8) {
-        return 0;
+        return 9;
     }
 
     function _withdraw(

--- a/test/plugins/individual-collateral/collateralTests.ts
+++ b/test/plugins/individual-collateral/collateralTests.ts
@@ -132,12 +132,12 @@ export default function fn<X extends CollateralFixtureContext>(
           await mintCollateralTo(ctx, amount, alice, alice.address)
 
           const aliceBal = await collateral.bal(alice.address)
-          const amount18d = decimals <= 18 ? amount.mul(bn(10).pow(18 - decimals)) : amount.div(bn(10).pow(decimals - 18))
+          const amount18d =
+            decimals <= 18
+              ? amount.mul(bn(10).pow(18 - decimals))
+              : amount.div(bn(10).pow(decimals - 18))
           const dist18d = decimals <= 18 ? bn('100').mul(bn(10).pow(18 - decimals)) : bn('10')
-          expect(aliceBal).to.closeTo(
-            amount18d,
-            dist18d
-          )
+          expect(aliceBal).to.closeTo(amount18d, dist18d)
         })
       })
 

--- a/test/plugins/individual-collateral/collateralTests.ts
+++ b/test/plugins/individual-collateral/collateralTests.ts
@@ -127,13 +127,16 @@ export default function fn<X extends CollateralFixtureContext>(
 
       describe('functions', () => {
         it('returns the correct bal (18 decimals)', async () => {
-          const amount = bn('20').mul(bn(10).pow(await ctx.tok.decimals()))
+          const decimals = await ctx.tok.decimals()
+          const amount = bn('20').mul(bn(10).pow(decimals))
           await mintCollateralTo(ctx, amount, alice, alice.address)
 
           const aliceBal = await collateral.bal(alice.address)
+          const amount18d = decimals <= 18 ? amount.mul(bn(10).pow(18 - decimals)) : amount.div(bn(10).pow(decimals - 18))
+          const dist18d = decimals <= 18 ? bn('100').mul(bn(10).pow(18 - decimals)) : bn('10')
           expect(aliceBal).to.closeTo(
-            amount.mul(bn(10).pow(18 - (await ctx.tok.decimals()))),
-            bn('100').mul(bn(10).pow(18 - (await ctx.tok.decimals())))
+            amount18d,
+            dist18d
           )
         })
       })

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
@@ -252,7 +252,7 @@ const execTestForToken = ({
       await closeTo(methods.assets(bob), fraction(50))
     })
 
-    it('Check that inflation attacks are not possible', async () => {
+    it('Regression Test - C4 July 2023 Issue #5', async () => {
       const {
         users: { alice, bob },
         methods,

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
@@ -274,11 +274,11 @@ const execTestForToken = ({
 
       await instances.morphoAaveV2Controller
         .connect(bob)
-      ['supply(address,address,uint256)'](
-        await instances.tokenVault.poolToken(),
-        instances.tokenVault.address,
-        amountBN
-      )
+        ['supply(address,address,uint256)'](
+          await instances.tokenVault.poolToken(),
+          instances.tokenVault.address,
+          amountBN
+        )
 
       await closeTo(methods.balanceUnderlying(bob), '0.0')
       expect(await methods.shares(alice)).to.equal('0.0')

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAaveV2TokenisedDeposit.test.ts
@@ -2,10 +2,11 @@ import { ITokens, networkConfig } from '#/common/configuration'
 import { ethers } from 'hardhat'
 import { whileImpersonating } from '../../../utils/impersonation'
 import { whales } from '#/tasks/testing/upgrade-checker-utils/constants'
-import { Signer } from 'ethers'
+import { BigNumber, Signer } from 'ethers'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
 import { expect } from 'chai'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { bn } from '#/common/numbers'
 
 type ITokenSymbol = keyof ITokens
 const networkConfigToUse = networkConfig[31337]
@@ -14,32 +15,47 @@ const mkToken = (symbol: ITokenSymbol) => ({
   address: networkConfigToUse.tokens[symbol]! as string,
   symbol: symbol,
 })
-const mkTestCase = <T extends ITokenSymbol>(symbol: T, amount: string) => ({
+const mkTestCase = <T extends ITokenSymbol>(
+  symbol: T,
+  amount: string,
+  inflationStartAmount: string
+) => ({
   token: mkToken(symbol),
   poolToken: mkToken(`a${symbol}` as ITokenSymbol),
   amount,
+  inflationStartAmount,
 })
 
 const TOKENS_TO_TEST = [
-  mkTestCase('USDC', '1000.0'),
-  mkTestCase('USDT', '1000.0'),
-  mkTestCase('DAI', '1000.0'),
-  mkTestCase('WETH', '1.0'),
-  mkTestCase('stETH', '1.0'),
-  mkTestCase('WBTC', '1.0'),
+  mkTestCase('USDC', '1000.0', '1'),
+  mkTestCase('USDT', '1000.0', '1'),
+  mkTestCase('DAI', '1000.0', '1'),
+  mkTestCase('WETH', '200.0', '1'),
+  mkTestCase('stETH', '1.0', '2'),
+  mkTestCase('WBTC', '1.0', '1'),
 ]
 type ITestSuiteVariant = typeof TOKENS_TO_TEST[number]
 
-const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
+const execTestForToken = ({
+  token,
+  poolToken,
+  amount,
+  inflationStartAmount,
+}: ITestSuiteVariant) => {
   describe('Tokenised Morpho Position - ' + token.symbol, () => {
     const beforeEachFn = async () => {
       const factories = {
         ERC20Mock: await ethers.getContractFactory('ERC20Mock'),
         MorphoTokenisedDeposit: await ethers.getContractFactory('MorphoAaveV2TokenisedDeposit'),
       }
+
       const instances = {
         underlying: factories.ERC20Mock.attach(token.address),
         morpho: factories.ERC20Mock.attach(networkConfigToUse.tokens.MORPHO!),
+        morphoAaveV2Controller: await ethers.getContractAt(
+          'IMorpho',
+          networkConfigToUse.MORPHO_AAVE_CONTROLLER!
+        ),
         tokenVault: await factories.MorphoTokenisedDeposit.deploy({
           underlyingERC20: token.address,
           poolToken: poolToken.address,
@@ -51,6 +67,8 @@ const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
       }
       const underlyingDecimals = await instances.underlying.decimals()
       const shareDecimals = await instances.tokenVault.decimals()
+      const amountBN = parseUnits(amount, underlyingDecimals)
+
       const signers = await ethers.getSigners()
       const users = {
         alice: signers[0],
@@ -59,32 +77,46 @@ const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
       }
 
       await whileImpersonating(whales[token.address.toLowerCase()], async (whaleSigner) => {
-        await instances.underlying
-          .connect(whaleSigner)
-          .transfer(users.alice.address, parseUnits(amount, underlyingDecimals))
-        await instances.underlying
-          .connect(whaleSigner)
-          .transfer(users.bob.address, parseUnits(amount, underlyingDecimals))
-        await instances.underlying
-          .connect(whaleSigner)
-          .transfer(users.charlie.address, parseUnits(amount, underlyingDecimals))
+        await instances.underlying.connect(whaleSigner).transfer(users.alice.address, amountBN)
+        await instances.underlying.connect(whaleSigner).transfer(users.bob.address, amountBN)
+        await instances.underlying.connect(whaleSigner).transfer(users.charlie.address, amountBN)
       })
       return {
         factories,
         instances,
+        amountBN,
         users,
         methods: {
+          async mint(user: Signer, amount: BigNumber) {
+            await whileImpersonating(whales[token.address.toLowerCase()], async (whaleSigner) => {
+              await instances.underlying
+                .connect(whaleSigner)
+                .transfer(await user.getAddress(), amount)
+            })
+          },
           deposit: async (user: Signer, amount: string, dest?: string) => {
+            await instances.underlying.connect(user).approve(instances.tokenVault.address, 0)
             await instances.underlying
               .connect(user)
-              .approve(instances.tokenVault.address, parseUnits(amount, underlyingDecimals))
+              .approve(instances.tokenVault.address, ethers.constants.MaxUint256)
             await instances.tokenVault
               .connect(user)
               .deposit(parseUnits(amount, underlyingDecimals), dest ?? (await user.getAddress()))
           },
+
+          depositBN: async (user: Signer, amount: BigNumber, dest?: string) => {
+            await instances.underlying.connect(user).approve(instances.tokenVault.address, 0)
+            await instances.underlying
+              .connect(user)
+              .approve(instances.tokenVault.address, ethers.constants.MaxUint256)
+
+            await instances.tokenVault
+              .connect(user)
+              .deposit(amount, dest ?? (await user.getAddress()))
+          },
           shares: async (user: Signer) => {
             return formatUnits(
-              await instances.tokenVault.connect(user).maxRedeem(await user.getAddress()),
+              await instances.tokenVault.connect(user).balanceOf(await user.getAddress()),
               shareDecimals
             )
           },
@@ -103,17 +135,26 @@ const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
                 await user.getAddress()
               )
           },
+          redeem: async (user: Signer, shares: string, dest?: string) => {
+            await instances.tokenVault
+              .connect(user)
+              .redeem(
+                parseUnits(shares, await instances.tokenVault.decimals()),
+                dest ?? (await user.getAddress()),
+                await user.getAddress()
+              )
+          },
           balanceUnderlying: async (user: Signer) => {
             return formatUnits(
-              await instances.underlying.connect(user).balanceOf(await user.getAddress()),
+              await instances.underlying.balanceOf(await user.getAddress()),
               underlyingDecimals
             )
           },
+          balanceUnderlyingBn: async (user: Signer) => {
+            return await instances.underlying.balanceOf(await user.getAddress())
+          },
           balanceMorpho: async (user: Signer) => {
-            return formatUnits(
-              await instances.morpho.connect(user).balanceOf(await user.getAddress()),
-              18
-            )
+            return formatUnits(await instances.morpho.balanceOf(await user.getAddress()), 18)
           },
           transferShares: async (from: Signer, to: Signer, amount: string) => {
             await instances.tokenVault
@@ -146,7 +187,6 @@ const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
     const fraction = (percent: number) => ((amountAsNumber * percent) / 100).toFixed(1)
 
     const closeTo = async (actual: Promise<string>, expected: string) => {
-      await new Promise((r) => setTimeout(r, 200))
       expect(parseFloat(await actual)).to.closeTo(parseFloat(expected), 0.5)
     }
 
@@ -212,11 +252,57 @@ const execTestForToken = ({ token, poolToken, amount }: ITestSuiteVariant) => {
       await closeTo(methods.assets(bob), fraction(50))
     })
 
+    it('Check that inflation attacks are not possible', async () => {
+      const {
+        users: { alice, bob },
+        methods,
+        instances,
+        amountBN,
+      } = context
+      const orignalBalance = await methods.balanceUnderlying(bob)
+      await instances.underlying
+        .connect(bob)
+        .approve(instances.morphoAaveV2Controller.address, ethers.constants.MaxUint256)
+
+      await instances.underlying
+        .connect(bob)
+        .approve(instances.tokenVault.address, ethers.constants.MaxUint256)
+
+      // Mint a few more tokens so we have enough for the initial 1 wei of a share
+      await methods.mint(bob, bn(inflationStartAmount).mul(10))
+      await methods.depositBN(bob, bn(inflationStartAmount))
+
+      await instances.morphoAaveV2Controller
+        .connect(bob)
+      ['supply(address,address,uint256)'](
+        await instances.tokenVault.poolToken(),
+        instances.tokenVault.address,
+        amountBN
+      )
+
+      await closeTo(methods.balanceUnderlying(bob), '0.0')
+      expect(await methods.shares(alice)).to.equal('0.0')
+      await methods.depositBN(alice, amountBN.div(2))
+
+      expect(await methods.shares(alice)).to.not.equal('0.0')
+      // expect(await methods.shares(alice)).to.equal('0.0') // <- inflation attack check
+      // Bob inflated his 1 wei of a share share to be worth all of Alices deposit
+      // ^ The attack above ultimately does not seem to be worth it for the attacker
+      // half 25% of the attackers funds end up locked in the zero'th share of the vault
+
+      await methods.withdraw(bob, await methods.assets(bob))
+      const postWithdrawalBalance = parseFloat(await methods.balanceUnderlying(bob))
+
+      // Bob should loose funds from the attack
+      expect(postWithdrawalBalance).lt(parseFloat(orignalBalance))
+    })
+
     /**
      * There is a test for claiming rewards in the MorphoAAVEFiatCollateral.test.ts
      */
   })
 }
+
 describe('MorphoAaveV2TokenisedDeposit', () => {
   TOKENS_TO_TEST.forEach(execTestForToken)
 })


### PR DESCRIPTION
Findings:

It **is** possible to inflate the value of a single share by manupuating the amount of tokens the vault holds.

But I don't think it is possible to do this in a profitable manner - as I can't see anyway to execute the attack in a way where the attacker does not loose funds. The issue comes from our implementation of the ERC4626 essentially adding an additional share to the vault. This zero'th share will end up holding the profit of the attack with no way to redeem it.

The inflation attack was fixed by setting the decimalOffset to 9. I added a test that will fail if the inflation attack manifests again.