### PR TITLE
Clarify rewards handling on transfer

### DIFF
--- a/contracts/plugins/assets/aave/StaticATokenLM.sol
+++ b/contracts/plugins/assets/aave/StaticATokenLM.sol
@@ -366,6 +366,9 @@ contract StaticATokenLM is
 
     /**
      * @notice Updates rewards for senders and receiver in a transfer (not updating rewards for address(0))
+     *  Only rewards which were previously collected from the Incentives Controller will be updated on
+     *  every transfer. It is designed this way to reduce gas costs on `transfer`, which will likely
+     *  outweigh the pending (uncollected) rewards for the sender under certain circumstances.
      * @param from The address of the sender of tokens
      * @param to The address of the receiver of tokens
      */

--- a/contracts/plugins/assets/aave/StaticATokenLM.sol
+++ b/contracts/plugins/assets/aave/StaticATokenLM.sol
@@ -24,7 +24,17 @@ import { SafeMath } from "@aave/protocol-v2/contracts/dependencies/openzeppelin/
  * @title StaticATokenLM
  * @notice Wrapper token that allows to deposit tokens on the Aave protocol and receive
  * a token which balance doesn't increase automatically, but uses an ever-increasing exchange rate.
- * The token support claiming liquidity mining rewards from the Aave system.
+ *
+ * The token supports claiming liquidity mining rewards from the Aave system. However, there might be
+ * be permanent loss of rewards for the sender of the token when a `transfer` is performed. This is due
+ * to the fact that only rewards previously collected from the Incentives Controller are processed (and
+ * assigned to the `sender`) when tokens are transferred. Any rewards pending to be collected are ignored
+ * on `transfer`, and might be later claimed by the `receiver`. It was designed this way to reduce gas
+ * costs on every transfer which would probably outweigh any missing/unprocessed/unclaimed rewards.
+ * It is important to remark that several operations such as `deposit`, `withdraw`, `collectAndUpdateRewards`,
+ * among others, will update rewards balances correctly, so while it is true that under certain circumstances
+ * rewards may not be fully accurate, we expect them only to be slightly off.
+ *
  * @author Aave
  * From: https://github.com/aave/protocol-v2/blob/238e5af2a95c3fbb83b0c8f44501ed2541215122/contracts/protocol/tokenization/StaticATokenLM.sol#L255
  **/


### PR DESCRIPTION
* Adds comment for `StaticATokenLM` to clarify that only those rewards previously collected are the ones that are updated on every `transfer`.  This addresses the following C4 issues:

C4 Issue #4 - https://github.com/code-423n4/2023-07-reserve-findings/issues/4
C4 issue #12 - https://github.com/code-423n4/2023-07-reserve-findings/issues/12