### PR TITLE
advance oracles to prevent timeouts

### DIFF
--- a/test/plugins/individual-collateral/ankr/AnkrEthCollateralTestSuite.test.ts
+++ b/test/plugins/individual-collateral/ankr/AnkrEthCollateralTestSuite.test.ts
@@ -10,6 +10,7 @@ import {
   TestICollateral,
   IAnkrETH,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { ZERO_ADDRESS } from '../../../../common/constants'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -99,6 +100,9 @@ export const deployCollateral = async (
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
 
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible

--- a/test/plugins/individual-collateral/cbeth/CBETHCollateral.test.ts
+++ b/test/plugins/individual-collateral/cbeth/CBETHCollateral.test.ts
@@ -12,6 +12,7 @@ import {
   ORACLE_TIMEOUT,
   PRICE_TIMEOUT,
 } from './constants'
+import { pushOracleForward } from '../../../utils/oracles'
 import { BigNumber, BigNumberish, ContractFactory } from 'ethers'
 import { bn, fp } from '#/common/numbers'
 import { TestICollateral } from '@typechain/TestICollateral'
@@ -59,6 +60,10 @@ export const deployCollateral = async (
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feeds
+  await pushOracleForward(opts.chainlinkFeed!)
+  await pushOracleForward(opts.targetPerTokChainlinkFeed ?? CBETH_ETH_PRICE_FEED)
 
   await expect(collateral.refresh())
 

--- a/test/plugins/individual-collateral/collateralTests.ts
+++ b/test/plugins/individual-collateral/collateralTests.ts
@@ -264,6 +264,36 @@ export default function fn<X extends CollateralFixtureContext>(
           expect(newHigh).to.be.gt(initHigh)
         })
 
+        it('decays for 0-valued oracle', async () => {
+          const initialPrice = await collateral.price()
+
+          // Set price of underlying to 0
+          const updateAnswerTx = await chainlinkFeed.updateAnswer(0)
+          await updateAnswerTx.wait()
+
+          // Price remains same at first, though IFFY
+          await collateral.refresh()
+          await expectExactPrice(collateral.address, initialPrice)
+          expect(await collateral.status()).to.equal(CollateralStatus.IFFY)
+
+          // After oracle timeout decay begins
+          const oracleTimeout = await collateral.oracleTimeout()
+          await setNextBlockTimestamp((await getLatestBlockTimestamp()) + oracleTimeout)
+          await advanceBlocks(1 + oracleTimeout / 12)
+          await collateral.refresh()
+          await expectDecayedPrice(collateral.address)
+
+          // After price timeout it becomes unpriced
+          const priceTimeout = await collateral.priceTimeout()
+          await setNextBlockTimestamp((await getLatestBlockTimestamp()) + priceTimeout)
+          await advanceBlocks(1 + priceTimeout / 12)
+          await expectUnpriced(collateral.address)
+
+          // When refreshed, sets status to DISABLED
+          await collateral.refresh()
+          expect(await collateral.status()).to.equal(CollateralStatus.DISABLED)
+        })
+
         it('does not revert in case of invalid timestamp', async () => {
           await chainlinkFeed.setInvalidTimestamp()
 
@@ -342,36 +372,6 @@ export default function fn<X extends CollateralFixtureContext>(
           // Should be unpriced after full priceTimeout
           await advanceTime(priceTimeout / 2)
           await expectUnpriced(collateral.address)
-        })
-
-        it('decays for 0-valued oracle', async () => {
-          const initialPrice = await collateral.price()
-
-          // Set price of underlying to 0
-          const updateAnswerTx = await chainlinkFeed.updateAnswer(0)
-          await updateAnswerTx.wait()
-
-          // Price remains same at first, though IFFY
-          await collateral.refresh()
-          await expectExactPrice(collateral.address, initialPrice)
-          expect(await collateral.status()).to.equal(CollateralStatus.IFFY)
-
-          // After oracle timeout decay begins
-          const oracleTimeout = await collateral.oracleTimeout()
-          await setNextBlockTimestamp((await getLatestBlockTimestamp()) + oracleTimeout)
-          await advanceBlocks(1 + oracleTimeout / 12)
-          await collateral.refresh()
-          await expectDecayedPrice(collateral.address)
-
-          // After price timeout it becomes unpriced
-          const priceTimeout = await collateral.priceTimeout()
-          await setNextBlockTimestamp((await getLatestBlockTimestamp()) + priceTimeout)
-          await advanceBlocks(1 + priceTimeout / 12)
-          await expectUnpriced(collateral.address)
-
-          // When refreshed, sets status to DISABLED
-          await collateral.refresh()
-          expect(await collateral.status()).to.equal(CollateralStatus.DISABLED)
         })
       })
 

--- a/test/plugins/individual-collateral/compoundv3/CometTestSuite.test.ts
+++ b/test/plugins/individual-collateral/compoundv3/CometTestSuite.test.ts
@@ -22,6 +22,7 @@ import {
   CometMock__factory,
   TestICollateral,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { MAX_UINT48 } from '../../../../common/constants'
 import { expect } from 'chai'
@@ -117,6 +118,9 @@ export const deployCollateral = async (
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
 
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible

--- a/test/plugins/individual-collateral/dsr/SDaiCollateralTestSuite.test.ts
+++ b/test/plugins/individual-collateral/dsr/SDaiCollateralTestSuite.test.ts
@@ -12,6 +12,7 @@ import {
   PotMock,
   TestICollateral,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { ZERO_ADDRESS } from '../../../../common/constants'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -69,6 +70,10 @@ export const deployCollateral = async (opts: CollateralOpts = {}): Promise<TestI
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
+
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible
   await expect(collateral.refresh())

--- a/test/plugins/individual-collateral/flux-finance/FTokenFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/flux-finance/FTokenFiatCollateral.test.ts
@@ -9,6 +9,7 @@ import {
   MockV3Aggregator__factory,
   TestICollateral,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { networkConfig } from '../../../../common/configuration'
 import { bn, fp } from '../../../../common/numbers'
 import { ZERO_ADDRESS } from '../../../../common/constants'
@@ -144,6 +145,9 @@ all.forEach((curr: FTokenEnumeration) => {
       { gasLimit: 2000000000 }
     )
     await collateral.deployed()
+
+    // Push forward chainlink feed
+    await pushOracleForward(opts.chainlinkFeed!)
 
     // sometimes we are trying to test a negative test case and we want this to fail silently
     // fortunately this syntax fails silently because our tools are terrible

--- a/test/plugins/individual-collateral/frax-eth/SFrxEthTestSuite.test.ts
+++ b/test/plugins/individual-collateral/frax-eth/SFrxEthTestSuite.test.ts
@@ -12,6 +12,7 @@ import {
   TestICollateral,
   IsfrxEth,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { CollateralStatus } from '../../../../common/constants'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -84,6 +85,10 @@ export const deployCollateral = async (opts: CollateralOpts = {}): Promise<TestI
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
+
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible
   await expect(collateral.refresh())

--- a/test/plugins/individual-collateral/lido/LidoStakedEthTestSuite.test.ts
+++ b/test/plugins/individual-collateral/lido/LidoStakedEthTestSuite.test.ts
@@ -12,6 +12,7 @@ import {
   TestICollateral,
   IWSTETH,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { ZERO_ADDRESS } from '../../../../common/constants'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -91,6 +92,11 @@ export const deployCollateral = async (
     opts.targetPerRefChainlinkTimeout,
     { gasLimit: 2000000000 }
   )
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
+  await pushOracleForward(opts.targetPerRefChainlinkFeed!)
+
   await collateral.deployed()
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAAVEFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAAVEFiatCollateral.test.ts
@@ -10,6 +10,7 @@ import { ethers } from 'hardhat'
 import collateralTests from '../collateralTests'
 import { getResetFork } from '../helpers'
 import { CollateralOpts } from '../pluginTestTypes'
+import { pushOracleForward } from '../../../utils/oracles'
 import {
   DEFAULT_THRESHOLD,
   DELAY_UNTIL_DEFAULT,
@@ -74,6 +75,9 @@ const makeAaveFiatCollateralTestSuite = (
       { gasLimit: 2000000000 }
     )
     await collateral.deployed()
+
+    // Push forward chainlink feed
+    await pushOracleForward(opts.chainlinkFeed!)
 
     await expect(collateral.refresh())
 

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAAVENonFiatCollateral.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAAVENonFiatCollateral.test.ts
@@ -15,6 +15,7 @@ import { ethers } from 'hardhat'
 import collateralTests from '../collateralTests'
 import { getResetFork } from '../helpers'
 import { CollateralOpts } from '../pluginTestTypes'
+import { pushOracleForward } from '../../../utils/oracles'
 import {
   DEFAULT_THRESHOLD,
   DELAY_UNTIL_DEFAULT,
@@ -76,6 +77,10 @@ const makeAaveNonFiatCollateralTestSuite = (
       { gasLimit: 2000000000 }
     )) as unknown as TestICollateral
     await collateral.deployed()
+
+    // Push forward chainlink feed
+    await pushOracleForward(opts.chainlinkFeed!)
+    await pushOracleForward(opts.targetPrRefFeed!)
 
     await expect(collateral.refresh())
 

--- a/test/plugins/individual-collateral/morpho-aave/MorphoAAVESelfReferentialCollateral.test.ts
+++ b/test/plugins/individual-collateral/morpho-aave/MorphoAAVESelfReferentialCollateral.test.ts
@@ -15,6 +15,7 @@ import { ethers } from 'hardhat'
 import collateralTests from '../collateralTests'
 import { getResetFork } from '../helpers'
 import { CollateralOpts } from '../pluginTestTypes'
+import { pushOracleForward } from '../../../utils/oracles'
 import {
   DELAY_UNTIL_DEFAULT,
   FORK_BLOCK,
@@ -69,6 +70,9 @@ const deployCollateral = async (opts: MAFiatCollateralOpts = {}): Promise<TestIC
     { gasLimit: 2000000000 }
   )) as unknown as TestICollateral
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
 
   await expect(collateral.refresh())
 

--- a/test/plugins/individual-collateral/rocket-eth/RethCollateralTestSuite.test.ts
+++ b/test/plugins/individual-collateral/rocket-eth/RethCollateralTestSuite.test.ts
@@ -12,6 +12,7 @@ import {
   IReth,
   WETH9,
 } from '../../../../typechain'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '../../../../common/numbers'
 import { ZERO_ADDRESS } from '../../../../common/constants'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -89,6 +90,11 @@ export const deployCollateral = async (opts: RethCollateralOpts = {}): Promise<T
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
+  await pushOracleForward(opts.targetPerTokChainlinkFeed!)
+
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible
   await expect(collateral.refresh())

--- a/test/plugins/individual-collateral/stargate/StargateUSDCTestSuite.test.ts
+++ b/test/plugins/individual-collateral/stargate/StargateUSDCTestSuite.test.ts
@@ -12,6 +12,7 @@ import {
   StargateRewardableWrapper,
   StargateRewardableWrapper__factory,
 } from '@typechain/index'
+import { pushOracleForward } from '../../../utils/oracles'
 import { bn, fp } from '#/common/numbers'
 import { expect } from 'chai'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
@@ -89,6 +90,9 @@ export const deployCollateral = async (
     { gasLimit: 2000000000 }
   )
   await collateral.deployed()
+
+  // Push forward chainlink feed
+  await pushOracleForward(opts.chainlinkFeed!)
 
   // sometimes we are trying to test a negative test case and we want this to fail silently
   // fortunately this syntax fails silently because our tools are terrible

--- a/test/utils/oracles.ts
+++ b/test/utils/oracles.ts
@@ -1,5 +1,7 @@
+import { setCode } from '@nomicfoundation/hardhat-network-helpers'
+import { EACAggregatorProxyMock } from '@typechain/EACAggregatorProxyMock'
 import { BigNumber } from 'ethers'
-import { ethers } from 'hardhat'
+import { ethers, network } from 'hardhat'
 import { expect } from 'chai'
 import { fp, bn, divCeil } from '../../common/numbers'
 import { MAX_UINT192 } from '../../common/constants'
@@ -130,4 +132,34 @@ export const setInvalidOracleAnsweredRound = async (assetAddr: string) => {
   const chainlinkFeedAddr = await asset.chainlinkFeed()
   const v3Aggregator = await ethers.getContractAt('MockV3Aggregator', chainlinkFeedAddr)
   await v3Aggregator.setInvalidAnsweredRound()
+}
+
+// === Pushing oracles (real or mock) forward ===
+
+export const overrideOracle = async (oracleAddress: string): Promise<EACAggregatorProxyMock> => {
+  const oracle = await ethers.getContractAt(
+    'contracts/plugins/mocks/EACAggregatorProxyMock.sol:EACAggregatorProxy',
+    oracleAddress
+  )
+  const aggregator = await oracle.aggregator()
+  const accessController = await oracle.accessController()
+  const initPrice = await oracle.latestAnswer()
+  const mockOracleFactory = await ethers.getContractFactory('EACAggregatorProxyMock')
+  const mockOracle = await mockOracleFactory.deploy(aggregator, accessController, initPrice)
+  const bytecode = await network.provider.send('eth_getCode', [mockOracle.address])
+  await setCode(oracleAddress, bytecode)
+  return ethers.getContractAt('EACAggregatorProxyMock', oracleAddress)
+}
+
+export const pushOracleForward = async (chainlinkAddr: string) => {
+  const chainlinkFeed = await ethers.getContractAt('MockV3Aggregator', await chainlinkAddr)
+  const initPrice = await chainlinkFeed.latestAnswer()
+  try {
+    // Try to update as if it's a mock already
+    await chainlinkFeed.updateAnswer(initPrice)
+  } catch {
+    // Not a mock; need to override the oracle first
+    const oracle = await overrideOracle(chainlinkFeed.address)
+    await oracle.updateAnswer(initPrice)
+  }
 }


### PR DESCRIPTION
Problem was that even though hardhat rolls back state between tests, it still progresses the chain time and blocks, resulting in our forked oracles eventually timing out. The solution is to refresh oracle values between each test. We were already doing this almost everywhere, just missing it in `deployCollateral()`. I also considered creating a new function in the suite `refreshOracles()` for each suite to implement, but this seemed slightly worse to me because the default fixture setup _was_ doing it correctly, it was just the `deployCollateral()` function that was not. 

I restored the previous ordering of the tests to prove this works. 

Also sped up the generic suite a bit by removing one unnecessary `resetFork()`. 