### PR TITLE
3.0.0 executor

### DIFF
--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -165,7 +165,7 @@ contract FacadeWrite is IFacadeWrite {
             timelock.grantRole(timelock.PROPOSER_ROLE(), governance); // Gov only proposer
             // Set Guardian as canceller, if address(0) then no one can cancel
             timelock.grantRole(timelock.CANCELLER_ROLE(), govRoles.guardian);
-            timelock.grantRole(timelock.EXECUTOR_ROLE(), address(0)); // Anyone as executor
+            timelock.grantRole(timelock.EXECUTOR_ROLE(), governance); // Gov only executor
             timelock.revokeRole(timelock.TIMELOCK_ADMIN_ROLE(), address(this)); // Revoke admin role
 
             // Set new owner to timelock

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -688,6 +688,9 @@ describe('FacadeWrite contract', () => {
           timelock = <TimelockController>(
             await ethers.getContractAt('TimelockController', timelockAddr)
           )
+          expect(await timelock.hasRole(await timelock.EXECUTOR_ROLE(), governor.address)).to.equal(
+            true
+          )
         })
 
         it('Should setup owner, freezer and pauser correctly', async () => {
@@ -772,6 +775,9 @@ describe('FacadeWrite contract', () => {
           governor = <Governance>await ethers.getContractAt('Governance', governanceAddr)
           timelock = <TimelockController>(
             await ethers.getContractAt('TimelockController', timelockAddr)
+          )
+          expect(await timelock.hasRole(await timelock.EXECUTOR_ROLE(), governor.address)).to.equal(
+            true
           )
         })
 


### PR DESCRIPTION
`FacadeWrite` was setting up executor incorrectly, so that anyone could execute. Bypasses same-era checks in `Governance`