### PR TITLE
Make FacadeAct.runRevenueOverview() work when toStart is empty

### DIFF
--- a/contracts/facade/FacadeAct.sol
+++ b/contracts/facade/FacadeAct.sol
@@ -59,6 +59,8 @@ contract FacadeAct is IFacadeAct, Multicall {
             );
         }
 
+        if (toStart.length == 0) return;
+
         // Transfer revenue backingManager -> revenueTrader
         _forwardRevenue(revenueTrader.main().backingManager(), toStart);
 

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -1164,6 +1164,18 @@ describe('FacadeRead + FacadeAct contracts', () => {
           },
         ]
       )
+
+      // Nothing should be settleable
+      expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
+
+      // Advance time till auction ended
+      await advanceBlocks(1 + auctionLength / 12)
+
+      // Settleable now
+      expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
+
+      // Should not revert, even when not starting new auctions
+      await facadeAct.runRevenueAuctions(rsrTrader.address, [token.address], [], [])
     })
 
     it('Should handle other versions when running revenue auctions', async () => {

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -1139,7 +1139,10 @@ describe('FacadeRead + FacadeAct contracts', () => {
       expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
 
       // Advance time till auction ended
-      await advanceBlocks(1 + auctionLength / 12)
+      await advanceBlocks(2 + auctionLength / 12)
+
+      // Settleable now
+      expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(1)
 
       // Settle and start new auction - Will retry
       await expectEvents(
@@ -1169,10 +1172,10 @@ describe('FacadeRead + FacadeAct contracts', () => {
       expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
 
       // Advance time till auction ended
-      await advanceBlocks(1 + auctionLength / 12)
+      await advanceBlocks(2 + auctionLength / 12)
 
       // Settleable now
-      expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(0)
+      expect((await facade.auctionsSettleable(rsrTrader.address)).length).to.equal(1)
 
       // Should not revert, even when not starting new auctions
       await facadeAct.runRevenueAuctions(rsrTrader.address, [token.address], [], [])


### PR DESCRIPTION
Not ready to merge; needs deploy