### PR TITLE
TRUST Recommendation 1: reward and underlying checks in RewardERC20 wrappers

### DIFF
--- a/contracts/plugins/assets/erc20/RewardableERC20Wrapper.sol
+++ b/contracts/plugins/assets/erc20/RewardableERC20Wrapper.sol
@@ -30,6 +30,10 @@ abstract contract RewardableERC20Wrapper is RewardableERC20 {
         string memory _symbol,
         IERC20 _rewardToken
     ) ERC20(_name, _symbol) RewardableERC20(_rewardToken, _underlying.decimals()) {
+        require(
+            address(_rewardToken) != address(_underlying),
+            "reward and underlying cannot match"
+        );
         underlying = _underlying;
         underlyingDecimals = _underlying.decimals();
     }

--- a/contracts/plugins/assets/erc20/RewardableERC4626Vault.sol
+++ b/contracts/plugins/assets/erc20/RewardableERC4626Vault.sol
@@ -27,7 +27,9 @@ abstract contract RewardableERC4626Vault is ERC4626, RewardableERC20 {
     )
         ERC4626(_asset, _name, _symbol)
         RewardableERC20(_rewardToken, _asset.decimals() + _decimalsOffset())
-    {}
+    {
+        require(address(_rewardToken) != address(_asset), "reward and asset cannot match");
+    }
 
     // solhint-enable no-empty-blocks
 


### PR DESCRIPTION
* adds check to ensure reward and underlying tokens are not the same for ERC20 wrappers.