### PR TITLE
TRUST QA-4: Smoother exposedRefPrice in case of default

### DIFF
--- a/contracts/plugins/assets/AppreciatingFiatCollateral.sol
+++ b/contracts/plugins/assets/AppreciatingFiatCollateral.sol
@@ -88,7 +88,7 @@ abstract contract AppreciatingFiatCollateral is FiatCollateral {
 
         // uint192(<) is equivalent to Fix.lt
         if (underlyingRefPerTok < exposedReferencePrice) {
-            exposedReferencePrice = hiddenReferencePrice;
+            exposedReferencePrice = underlyingRefPerTok;
             markStatus(CollateralStatus.DISABLED);
         } else if (hiddenReferencePrice > exposedReferencePrice) {
             exposedReferencePrice = hiddenReferencePrice;

--- a/contracts/plugins/assets/L2LSDCollateral.sol
+++ b/contracts/plugins/assets/L2LSDCollateral.sol
@@ -53,7 +53,7 @@ abstract contract L2LSDCollateral is AppreciatingFiatCollateral {
 
             // uint192(<) is equivalent to Fix.lt
             if (underlyingRefPerTok < exposedReferencePrice) {
-                exposedReferencePrice = hiddenReferencePrice;
+                exposedReferencePrice = underlyingRefPerTok;
                 markStatus(CollateralStatus.DISABLED);
             } else if (hiddenReferencePrice > exposedReferencePrice) {
                 exposedReferencePrice = hiddenReferencePrice;

--- a/contracts/plugins/assets/compoundv3/CTokenV3Collateral.sol
+++ b/contracts/plugins/assets/compoundv3/CTokenV3Collateral.sol
@@ -77,7 +77,7 @@ contract CTokenV3Collateral is AppreciatingFiatCollateral {
 
         // uint192(<) is equivalent to Fix.lt
         if (underlyingRefPerTok < exposedReferencePrice) {
-            exposedReferencePrice = hiddenReferencePrice;
+            exposedReferencePrice = underlyingRefPerTok;
             markStatus(CollateralStatus.DISABLED);
         } else if (hiddenReferencePrice > exposedReferencePrice) {
             exposedReferencePrice = hiddenReferencePrice;

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -88,7 +88,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
 
         // uint192(<) is equivalent to Fix.lt
         if (underlyingRefPerTok < exposedReferencePrice) {
-            exposedReferencePrice = hiddenReferencePrice;
+            exposedReferencePrice = underlyingRefPerTok;
             markStatus(CollateralStatus.DISABLED);
         } else if (hiddenReferencePrice > exposedReferencePrice) {
             exposedReferencePrice = hiddenReferencePrice;

--- a/test/plugins/individual-collateral/collateralTests.ts
+++ b/test/plugins/individual-collateral/collateralTests.ts
@@ -339,14 +339,29 @@ export default function fn<X extends CollateralFixtureContext>(
           })
 
           // Should remain SOUND after a 1% decrease
+          let refPerTok = await ctx.collateral.refPerTok()
           await reduceRefPerTok(ctx, 1) // 1% decrease
           await ctx.collateral.refresh()
           expect(await ctx.collateral.status()).to.equal(CollateralStatus.SOUND)
 
+          // refPerTok should be unchanged
+          expect(await ctx.collateral.refPerTok()).to.be.closeTo(
+            refPerTok,
+            refPerTok.div(bn('1e3'))
+          ) // within 1-part-in-1-thousand
+
           // Should become DISABLED if drops more than that
+          refPerTok = await ctx.collateral.refPerTok()
           await reduceRefPerTok(ctx, 1) // another 1% decrease
           await ctx.collateral.refresh()
           expect(await ctx.collateral.status()).to.equal(CollateralStatus.DISABLED)
+
+          // refPerTok should have fallen 1%
+          refPerTok = refPerTok.sub(refPerTok.div(100))
+          expect(await ctx.collateral.refPerTok()).to.be.closeTo(
+            refPerTok,
+            refPerTok.div(bn('1e3'))
+          ) // within 1-part-in-1-thousand
         })
 
         it('reverts if Chainlink feed reverts or runs out of gas, maintains status', async () => {

--- a/test/plugins/individual-collateral/compoundv3/CometTestSuite.test.ts
+++ b/test/plugins/individual-collateral/compoundv3/CometTestSuite.test.ts
@@ -356,6 +356,7 @@ const collateralSpecificStatusTests = () => {
     })
 
     // Should remain SOUND after a 1% decrease
+    let refPerTok = await collateral.refPerTok()
     let currentExchangeRate = await wcusdcV3Mock.exchangeRate()
     await wcusdcV3Mock.setMockExchangeRate(
       true,
@@ -364,7 +365,11 @@ const collateralSpecificStatusTests = () => {
     await collateral.refresh()
     expect(await collateral.status()).to.equal(CollateralStatus.SOUND)
 
+    // refPerTok should be unchanged
+    expect(await collateral.refPerTok()).to.be.closeTo(refPerTok, refPerTok.div(bn('1e3'))) // within 1-part-in-1-thousand
+
     // Should become DISABLED if drops more than that
+    refPerTok = await collateral.refPerTok()
     currentExchangeRate = await wcusdcV3Mock.exchangeRate()
     await wcusdcV3Mock.setMockExchangeRate(
       true,
@@ -372,6 +377,10 @@ const collateralSpecificStatusTests = () => {
     )
     await collateral.refresh()
     expect(await collateral.status()).to.equal(CollateralStatus.DISABLED)
+
+    // refPerTok should have fallen 1%
+    refPerTok = refPerTok.sub(refPerTok.div(100))
+    expect(await collateral.refPerTok()).to.be.closeTo(refPerTok, refPerTok.div(bn('1e3'))) // within 1-part-in-1-thousand
   })
 }
 


### PR DESCRIPTION
Sets `exposedRefPrice` to `underlyingRefPerTok` in case of default