### PR TITLE
TRUST QA-12: default decimals

### DIFF
--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -43,7 +43,7 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
     }
 
     /// @return number of decimals
-    function decimals() public pure override returns (uint8) {
+    function decimals() public pure override(IERC20Metadata, WrappedERC20) returns (uint8) {
         return 6;
     }
 

--- a/contracts/plugins/assets/compoundv3/WrappedERC20.sol
+++ b/contracts/plugins/assets/compoundv3/WrappedERC20.sol
@@ -76,6 +76,13 @@ abstract contract WrappedERC20 is IWrappedERC20 {
     }
 
     /**
+     * @dev Returns the decimals places of the token.
+     */
+    function decimals() public pure virtual returns (uint8) {
+        return 18;
+    }
+
+    /**
      * @dev See {IERC20-totalSupply}.
      */
     function totalSupply() public view virtual override returns (uint256) {


### PR DESCRIPTION
Adds 18 as default decimals for WrappedERC20