### PR TITLE
TRUST QA-8: No revenue hiding in SDAI

### DIFF
--- a/scripts/deployment/phase2-assets/collaterals/deploy_dsr_sdai.ts
+++ b/scripts/deployment/phase2-assets/collaterals/deploy_dsr_sdai.ts
@@ -59,7 +59,7 @@ async function main() {
       defaultThreshold: fp('0.0125').toString(), // 1.25%
       delayUntilDefault: bn('86400').toString(), // 24h
     },
-    fp('1e-6').toString(), // revenueHiding = 0.0001%
+    bn(0), // does not require revenue hiding
     POT
   )
   await collateral.deployed()

--- a/scripts/verification/collateral-plugins/verify_sdai.ts
+++ b/scripts/verification/collateral-plugins/verify_sdai.ts
@@ -42,7 +42,7 @@ async function main() {
         defaultThreshold: fp('0.0125').toString(), // 1.25%
         delayUntilDefault: bn('86400').toString(), // 24h
       },
-      fp('1e-6').toString(), // revenueHiding = 0.0001%
+      bn(0),
       POT,
     ],
     'contracts/plugins/assets/dsr/SDaiCollateral.sol:SDaiCollateral'

--- a/test/plugins/individual-collateral/dsr/SDaiCollateralTestSuite.test.ts
+++ b/test/plugins/individual-collateral/dsr/SDaiCollateralTestSuite.test.ts
@@ -214,7 +214,7 @@ const opts = {
   itChecksRefPerTokDefault: it,
   itChecksPriceChanges: it,
   itChecksNonZeroDefaultThreshold: it,
-  itHasRevenueHiding: it,
+  itHasRevenueHiding: it.skip,
   resetFork,
   collateralName: 'SDaiCollateral',
   chainlinkDefaultAnswer,


### PR DESCRIPTION
* Remove revenue hiding from tests, deployment and verification scripts.
* Do not modify code of plugin (on purpose)

Requires redeployment of the SDAI plugin on Mainnet.