### PR TITLE
TRUST H-3:  calling incorrect hasPermission() function

### DIFF
--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -81,7 +81,7 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
         address dst,
         uint256 amount
     ) internal {
-        if (!hasPermission(src, operator)) revert Unauthorized();
+        if (!underlyingComet.hasPermission(src, operator)) revert Unauthorized();
         // {Comet}
         uint256 srcBal = underlyingComet.balanceOf(src);
         if (amount > srcBal) amount = srcBal;

--- a/contracts/plugins/assets/compoundv3/vendor/CometExtInterface.sol
+++ b/contracts/plugins/assets/compoundv3/vendor/CometExtInterface.sol
@@ -95,4 +95,12 @@ abstract contract CometExtInterface {
     function allowance(address owner, address spender) external view virtual returns (uint256);
 
     event Approval(address indexed owner, address indexed spender, uint256 amount);
+
+    /**
+     * @notice Determine if the manager has permission to act on behalf of the owner
+     * @param owner The owner account
+     * @param manager The manager account
+     * @return Whether or not the manager has permission
+     */
+    function hasPermission(address owner, address manager) external view virtual returns (bool);
 }


### PR DESCRIPTION
* Fixes  CusdcV3Wrapper._deposit() to call the correct hasPermission() function
* Now permission has to be done on the actual token that is going to be spent (`cuscdv3`) and not on the wrapper for depositing on behalf of someone else
* Adapts tests