### PR TITLE
TRUST M-9: pegprice in `frxETH`

### DIFF
--- a/contracts/plugins/assets/frax-eth/README.md
+++ b/contracts/plugins/assets/frax-eth/README.md
@@ -34,4 +34,4 @@ This function returns rate of `frxETH/sfrxETH`, getting from [pricePerShare()](h
 
 #### tryPrice
 
-This function uses `refPerTok`, the chainlink price of `ETH/frxETH`, and the chainlink price of `USD/ETH` to return the current price range of the collateral.
+This function uses `refPerTok` and the chainlink price of `USD/ETH` to return the current price range of the collateral. Once an oracle becomes available for `frxETH/ETH`, this function should be modified to use it and return the appropiate `pegPrice`.

--- a/contracts/plugins/assets/frax-eth/SFraxEthCollateral.sol
+++ b/contracts/plugins/assets/frax-eth/SFraxEthCollateral.sol
@@ -57,7 +57,7 @@ contract SFraxEthCollateral is AppreciatingFiatCollateral {
         high = p + err;
         // assert(low <= high); obviously true just by inspection
 
-        // Note: Currently not checking for depegs between `frxETH` and `ETH`
+        // TODO: Currently not checking for depegs between `frxETH` and `ETH`
         // Should be modified to use a `frxETH/ETH` oracle when available
         pegPrice = targetPerRef();
     }

--- a/contracts/plugins/assets/frax-eth/SFraxEthCollateral.sol
+++ b/contracts/plugins/assets/frax-eth/SFraxEthCollateral.sol
@@ -8,6 +8,12 @@ import "../OracleLib.sol";
 import "./vendor/IsfrxEth.sol";
 
 /**
+ * ************************************************************
+ * WARNING: this plugin is not ready to be used in Production
+ * ************************************************************
+ */
+
+/**
  * @title SFraxEthCollateral
  * @notice Collateral plugin for Frax-ETH,
  * tok = sfrxETH
@@ -32,7 +38,7 @@ contract SFraxEthCollateral is AppreciatingFiatCollateral {
     /// Can revert, used by other contract functions in order to catch errors
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
-    /// @return pegPrice {target/ref} The actual price observed in the peg
+    /// @return pegPrice {target/ref} FIX_ONE until an oracle becomes available
     function tryPrice()
         external
         view
@@ -51,6 +57,8 @@ contract SFraxEthCollateral is AppreciatingFiatCollateral {
         high = p + err;
         // assert(low <= high); obviously true just by inspection
 
+        // Note: Currently not checking for depegs between `frxETH` and `ETH`
+        // Should be modified to use a `frxETH/ETH` oracle when available
         pegPrice = targetPerRef();
     }
 


### PR DESCRIPTION
* Adds comments clarifying that the plugin is not ready to be used in Production because no oracle is available yet