### PR TITLE
TRUST H-4: Single reward token

### DIFF
--- a/contracts/plugins/assets/curve/crv/CurveGaugeWrapper.sol
+++ b/contracts/plugins/assets/curve/crv/CurveGaugeWrapper.sol
@@ -16,6 +16,9 @@ interface ILiquidityGauge {
     function withdraw(uint256 _value) external;
 }
 
+// Note: Only supports CRV rewards. If a Curve pool with multiple reward tokens is
+// used, other reward tokens beyond CRV will never be claimed and distributed to
+// depositors. These unclaimed rewards will be lost forever.
 contract CurveGaugeWrapper is RewardableERC20Wrapper {
     using SafeERC20 for IERC20;
 
@@ -45,6 +48,7 @@ contract CurveGaugeWrapper is RewardableERC20Wrapper {
         gauge.withdraw(_amount);
     }
 
+    // claim rewards - only supports CRV rewards
     function _claimAssetRewards() internal virtual override {
         MINTER.mint(address(gauge));
     }

--- a/contracts/plugins/assets/erc20/RewardableERC20.sol
+++ b/contracts/plugins/assets/erc20/RewardableERC20.sol
@@ -14,6 +14,7 @@ uint256 constant SHARE_DECIMAL_OFFSET = 9; // to prevent reward rounding issues
  * @notice An abstract class that can be extended to create rewardable wrapper.
  * @notice `_claimAssetRewards` keeps tracks of rewards by snapshotting the balance
  * and calculating the difference between the current balance and the previous balance.
+ * Limitation: Currently supports only one single reward token.
  * @dev To inherit:
  *   - override _claimAssetRewards()
  *   - call ERC20 constructor elsewhere during construction
@@ -41,6 +42,7 @@ abstract contract RewardableERC20 is IRewardable, ERC20, ReentrancyGuard {
         one = 10**(_decimals + SHARE_DECIMAL_OFFSET);
     }
 
+    // claim rewards - Only supports one single reward token
     function claimRewards() external nonReentrant {
         _claimAndSyncRewards();
         _syncAccount(msg.sender);


### PR DESCRIPTION
* Adds comments to `CurveGaugeWrapper` and `RewardableERC20` that only one single reward token is supported