### PR TITLE
Wcusdcv3 rewards fix

### DIFF
--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -26,7 +26,7 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
     ICometRewards public immutable rewardsAddr;
     IERC20 public immutable rewardERC20;
 
-    mapping(address => uint64) public baseTrackingIndex; // uint64 to stay consistent with CometHelpers
+    mapping(address => uint64) public baseTrackingIndex; // uint64 for consistency with CometHelpers
     mapping(address => uint256) public baseTrackingAccrued; // uint256 to avoid overflow in L:199
     mapping(address => uint256) public rewardsClaimed;
 

--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -257,7 +257,8 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
 
         uint256 indexDelta = uint256(trackingSupplyIndex - baseTrackingIndex[account]);
         uint256 newBaseTrackingAccrued = baseTrackingAccrued[account] +
-            safe64((safe104(balanceOf(account)) * indexDelta) / TRACKING_INDEX_SCALE);
+            (safe104(balanceOf(account)) * indexDelta) /
+            TRACKING_INDEX_SCALE;
 
         uint256 claimed = rewardsClaimed[account];
         uint256 accrued = newBaseTrackingAccrued * RESCALE_FACTOR;

--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -26,8 +26,8 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
     ICometRewards public immutable rewardsAddr;
     IERC20 public immutable rewardERC20;
 
-    mapping(address => uint64) public baseTrackingIndex;
-    mapping(address => uint64) public baseTrackingAccrued;
+    mapping(address => uint64) public baseTrackingIndex; // keep uint64 to stay consistent with comet
+    mapping(address => uint256) public baseTrackingAccrued; // uint256 to avoid overflow
     mapping(address => uint256) public rewardsClaimed;
 
     constructor(
@@ -286,9 +286,7 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
         (, uint64 trackingSupplyIndex) = getSupplyIndices();
         uint256 indexDelta = uint256(trackingSupplyIndex - baseTrackingIndex[account]);
 
-        baseTrackingAccrued[account] += safe64(
-            (safe104(accountBal) * indexDelta) / TRACKING_INDEX_SCALE
-        );
+        baseTrackingAccrued[account] += (safe104(accountBal) * indexDelta) / TRACKING_INDEX_SCALE;
         baseTrackingIndex[account] = trackingSupplyIndex;
     }
 

--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -20,7 +20,7 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
     /// From cUSDCv3, used in principal <> present calculations
     uint256 public constant TRACKING_INDEX_SCALE = 1e15;
     /// From cUSDCv3, scaling factor for USDC rewards
-    uint64 public constant RESCALE_FACTOR = 1e12;
+    uint256 public constant RESCALE_FACTOR = 1e12;
 
     CometInterface public immutable underlyingComet;
     ICometRewards public immutable rewardsAddr;

--- a/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/CusdcV3Wrapper.sol
@@ -26,8 +26,8 @@ contract CusdcV3Wrapper is ICusdcV3Wrapper, WrappedERC20, CometHelpers {
     ICometRewards public immutable rewardsAddr;
     IERC20 public immutable rewardERC20;
 
-    mapping(address => uint64) public baseTrackingIndex; // keep uint64 to stay consistent with comet
-    mapping(address => uint256) public baseTrackingAccrued; // uint256 to avoid overflow
+    mapping(address => uint64) public baseTrackingIndex; // uint64 to stay consistent with CometHelpers
+    mapping(address => uint256) public baseTrackingAccrued; // uint256 to avoid overflow in L:199
     mapping(address => uint256) public rewardsClaimed;
 
     constructor(

--- a/contracts/plugins/assets/compoundv3/ICusdcV3Wrapper.sol
+++ b/contracts/plugins/assets/compoundv3/ICusdcV3Wrapper.sol
@@ -51,7 +51,7 @@ interface ICusdcV3Wrapper is IWrappedERC20, IRewardable {
 
     function convertDynamicToStatic(uint256 amount) external view returns (uint104);
 
-    function baseTrackingAccrued(address account) external view returns (uint64);
+    function baseTrackingAccrued(address account) external view returns (uint256);
 
     function baseTrackingIndex(address account) external view returns (uint64);
 

--- a/contracts/plugins/assets/yearnv2/YearnV2CurveFiatCollateral.sol
+++ b/contracts/plugins/assets/yearnv2/YearnV2CurveFiatCollateral.sol
@@ -77,10 +77,14 @@ contract YearnV2CurveFiatCollateral is CurveStableCollateral {
         return (low, high, 0);
     }
 
+    // solhint-disable no-empty-blocks
+
     /// DEPRECATED: claimRewards() will be removed from all assets and collateral plugins
     function claimRewards() external virtual override {
         // No rewards to claim, everything is part of the pricePerShare
     }
+
+    // solhint-enable no-empty-blocks
 
     // === Internal ===
 


### PR DESCRIPTION
- Add regression test for large COMP reward amounts; confirmed fails on previous implementation
- Implement fix to avoid overflow. I considered changing all uint64 to uint256, but this would break the re-use of comet functions in `CometHelper`. It would actually be a much larger change to do this, and I don't think it's worth the cost. Just changing the storage type for `baseTrackingAccrued` is I think the minimal fix that is also slightly more robust than just adding a `uint256` cast to the broken multiplication in L:199. 

Needs review from everyone