### PR TITLE
Prevent Stargate wrapper from reverting on failed claimRewards

### DIFF
--- a/contracts/plugins/assets/stargate/StargateRewardableWrapper.sol
+++ b/contracts/plugins/assets/stargate/StargateRewardableWrapper.sol
@@ -46,7 +46,11 @@ contract StargateRewardableWrapper is RewardableERC20Wrapper {
     }
 
     function _claimAssetRewards() internal override {
-        if (stakingContract.totalAllocPoint() == 0) {
+        try stakingContract.totalAllocPoint() returns (uint256 totalAllocPoint) {
+            if (totalAllocPoint == 0) {
+                return;
+            }
+        } catch {
             return;
         }
 
@@ -59,24 +63,25 @@ contract StargateRewardableWrapper is RewardableERC20Wrapper {
 
     function _afterDeposit(uint256, address) internal override {
         uint256 underlyingBalance = underlying.balanceOf(address(this));
-        IStargateLPStaking.PoolInfo memory poolInfo = stakingContract.poolInfo(poolId);
-
-        if (poolInfo.allocPoint != 0 && underlyingBalance != 0) {
-            pool.approve(address(stakingContract), underlyingBalance);
-            stakingContract.deposit(poolId, underlyingBalance);
-        }
+        try stakingContract.poolInfo(poolId) returns (IStargateLPStaking.PoolInfo memory poolInfo) {
+            if (poolInfo.allocPoint != 0 && underlyingBalance != 0) {
+                pool.approve(address(stakingContract), underlyingBalance);
+                try stakingContract.deposit(poolId, underlyingBalance) {} catch {}
+            }
+        } catch {}
     }
 
     function _beforeWithdraw(uint256 _amount, address) internal override {
-        IStargateLPStaking.PoolInfo memory poolInfo = stakingContract.poolInfo(poolId);
+        try stakingContract.poolInfo(poolId) returns (IStargateLPStaking.PoolInfo memory poolInfo) {
+            uint256 underlyingBalance = underlying.balanceOf(address(this));
 
-        uint256 underlyingBalance = underlying.balanceOf(address(this));
-        if (underlyingBalance < _amount) {
-            if (poolInfo.allocPoint != 0) {
-                stakingContract.withdraw(poolId, _amount - underlyingBalance);
-            } else {
-                stakingContract.emergencyWithdraw(poolId);
+            if (underlyingBalance < _amount) {
+                if (poolInfo.allocPoint != 0) {
+                    try stakingContract.withdraw(poolId, _amount - underlyingBalance) {} catch {}
+                } else {
+                    try stakingContract.emergencyWithdraw(poolId) {} catch {}
+                }
             }
-        }
+        } catch {}
     }
 }

--- a/contracts/plugins/assets/stargate/StargateRewardableWrapper.sol
+++ b/contracts/plugins/assets/stargate/StargateRewardableWrapper.sol
@@ -46,9 +46,15 @@ contract StargateRewardableWrapper is RewardableERC20Wrapper {
     }
 
     function _claimAssetRewards() internal override {
-        if (stakingContract.totalAllocPoint() != 0) {
-            stakingContract.deposit(poolId, 0);
+        if (stakingContract.totalAllocPoint() == 0) {
+            return;
         }
+
+        // `.deposit` call in a try/catch to prevent staking contract
+        // this is because `_claimAssetRewards` is called on all movements
+        // and we want to prevent external calls from bricking the contract
+        // solhint-disable-next-line no-empty-blocks
+        try stakingContract.deposit(poolId, 0) {} catch {}
     }
 
     function _afterDeposit(uint256, address) internal override {

--- a/contracts/plugins/assets/stargate/interfaces/IStargateLPStaking.sol
+++ b/contracts/plugins/assets/stargate/interfaces/IStargateLPStaking.sol
@@ -24,7 +24,7 @@ interface IStargateLPStaking {
 
     function poolInfo(uint256) external view returns (PoolInfo memory);
 
-    function pendingStargate(uint256 _pid, address _user) external view returns (uint256);
+    function pendingEmissionToken(uint256 _pid, address _user) external view returns (uint256);
 
     /// @param _pid The pid specifies the pool
     function updatePool(uint256 _pid) external;

--- a/contracts/plugins/assets/stargate/mocks/StargateLPStakingMock.sol
+++ b/contracts/plugins/assets/stargate/mocks/StargateLPStakingMock.sol
@@ -15,6 +15,8 @@ contract StargateLPStakingMock is IStargateLPStaking {
 
     uint256 public totalAllocPoint = 0;
 
+    uint256 public availableRewards = type(uint256).max;
+
     constructor(ERC20Mock stargateMock_) {
         stargateMock = stargateMock_;
         stargate = address(stargateMock_);
@@ -25,7 +27,16 @@ contract StargateLPStakingMock is IStargateLPStaking {
         return _poolInfo.length;
     }
 
-    function pendingStargate(uint256 pid, address user) external view override returns (uint256) {
+    function setAvailableRewards(uint256 amount) external {
+        availableRewards = amount;
+    }
+
+    function pendingEmissionToken(uint256 pid, address user)
+        external
+        view
+        override
+        returns (uint256)
+    {
         return poolToUserRewardsPending[pid][user];
     }
 
@@ -84,6 +95,8 @@ contract StargateLPStakingMock is IStargateLPStaking {
 
     function _emitUserRewards(uint256 pid, address user) private {
         uint256 amount = poolToUserRewardsPending[pid][user];
+        require(availableRewards >= amount, "LPStakingTime: eTokenBal must be >= _amount");
+        availableRewards -= amount;
         stargateMock.mint(user, amount);
         poolToUserRewardsPending[pid][user] = 0;
     }


### PR DESCRIPTION
Wrap the .deposit call in a try {} catch {}

