### PR TITLE
UnstakingStarted event fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Finally, call `Broker.setBatchTradeImplementation(newGnosisTrade)`.
   - Allow melting while frozen
 - `StRSR`
   - Use correct era in `UnstakingStarted` event
+  - Expose `draftEra` via `getDraftEra()` view
 
 ### Facades
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Finally, call `Broker.setBatchTradeImplementation(newGnosisTrade)`.
   - Disallow starting dutch trades with non-RTokenAsset assets when `lastSave() != block.timestamp`
 - `Furnace`
   - Allow melting while frozen
+- `StRSR`
+  - Use correct era in `UnstakingStarted` event
+
+### Facades
+
+- `FacadeRead`
+  - Add `draftEra` argument to `pendingUnstakings(..)`
 
 ## Plugins
 

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -274,17 +274,17 @@ contract FacadeRead is IFacadeRead {
         returns (Pending[] memory unstakings)
     {
         StRSRP1Votes stRSR = StRSRP1Votes(address(rToken.main().stRSR()));
-        uint256 era = stRSR.currentEra();
-        uint256 left = stRSR.firstRemainingDraft(era, account);
-        uint256 right = stRSR.draftQueueLen(era, account);
+        uint256 draftEra = stRSR.getDraftEra();
+        uint256 left = stRSR.firstRemainingDraft(draftEra, account);
+        uint256 right = stRSR.draftQueueLen(draftEra, account);
 
         unstakings = new Pending[](right - left);
         for (uint256 i = 0; i < right - left; i++) {
-            (uint192 drafts, uint64 availableAt) = stRSR.draftQueues(era, account, i + left);
+            (uint192 drafts, uint64 availableAt) = stRSR.draftQueues(draftEra, account, i + left);
 
             uint192 diff = drafts;
             if (i + left > 0) {
-                (uint192 prevDrafts, ) = stRSR.draftQueues(era, account, i + left - 1);
+                (uint192 prevDrafts, ) = stRSR.draftQueues(draftEra, account, i + left - 1);
                 diff = drafts - prevDrafts;
             }
 

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -266,15 +266,16 @@ contract FacadeRead is IFacadeRead {
 
     // === Views ===
 
+    /// @param draftEra {draftEra} The draft era to query unstakings for
     /// @param account The account for the query
-    /// @return unstakings All the pending StRSR unstakings for an account
-    function pendingUnstakings(RTokenP1 rToken, address account)
-        external
-        view
-        returns (Pending[] memory unstakings)
-    {
-        StRSRP1Votes stRSR = StRSRP1Votes(address(rToken.main().stRSR()));
-        uint256 draftEra = stRSR.getDraftEra();
+    /// @dev Use stRSR.draftRate() to convert {qDrafts} to {qRSR}
+    /// @return unstakings {qDrafts} All the pending StRSR unstakings for an account, in drafts
+    function pendingUnstakings(
+        RTokenP1 rToken,
+        uint256 draftEra,
+        address account
+    ) external view returns (Pending[] memory unstakings) {
+        StRSRP1 stRSR = StRSRP1(address(rToken.main().stRSR()));
         uint256 left = stRSR.firstRemainingDraft(draftEra, account);
         uint256 right = stRSR.draftQueueLen(draftEra, account);
 

--- a/contracts/interfaces/IFacadeRead.sol
+++ b/contracts/interfaces/IFacadeRead.sol
@@ -85,12 +85,15 @@ interface IFacadeRead {
         uint256 amount;
     }
 
+    /// @param draftEra {draftEra} The draft era to query unstakings for
     /// @param account The account for the query
-    /// @return All the pending StRSR unstakings for an account
-    function pendingUnstakings(RTokenP1 rToken, address account)
-        external
-        view
-        returns (Pending[] memory);
+    /// @dev Use stRSR.draftRate() to convert {qDrafts} to {qRSR}
+    /// @return {qDrafts} All the pending unstakings for an account, in drafts
+    function pendingUnstakings(
+        RTokenP1 rToken,
+        uint256 draftEra,
+        address account
+    ) external view returns (Pending[] memory);
 
     /// Returns the prime basket
     /// @dev Indices are shared across return values

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -338,7 +338,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         uint256 withdrawalRSRtoTake = (rsrBeingWithdrawn() * rsrAmount + (rsrBalance - 1)) /
             rsrBalance;
         if (
-            withdrawalRSRtoTake == 0 || 
+            withdrawalRSRtoTake == 0 ||
             rsrBeingWithdrawn() - withdrawalRSRtoTake <
             MIN_EXCHANGE_RATE.mulu_toUint(stakeBeingWithdrawn())
         ) {

--- a/contracts/p0/StRSR.sol
+++ b/contracts/p0/StRSR.sol
@@ -77,9 +77,11 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
     // {qRSR} How much reward RSR was held the last time rewards were paid out
     uint256 internal rsrRewardsAtLastPayout;
 
-    // Era. If ever there's a total RSR wipeout, this is incremented
-    // This is only really here for equivalence with P1, which requires it
+    // Eras. These are only really here for equivalence with P1, which requires it
+    // If there's ever a total RSR wipeout to balances, this is incremented
     uint256 internal era;
+    // If there's ever a total RSR wipeout to pending withdrawals, this is incremented
+    uint256 internal draftEra;
 
     // The momentary stake/unstake rate is rsrBacking/totalStaked {RSR/stRSR}
     // That rate is locked in when slow unstaking *begins*
@@ -136,6 +138,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         setRewardRatio(rewardRatio_);
         setWithdrawalLeak(withdrawalLeak_);
         era = 1;
+        draftEra = 1;
     }
 
     /// Assign reward payouts to the staker pool
@@ -201,7 +204,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         uint256 lastAvailableAt = index > 0 ? withdrawals[account][index - 1].availableAt : 0;
         uint256 availableAt = Math.max(block.timestamp + unstakingDelay, lastAvailableAt);
         withdrawals[account].push(Withdrawal(account, rsrAmount, stakeAmount, availableAt));
-        emit UnstakingStarted(index, era, account, rsrAmount, stakeAmount, availableAt);
+        emit UnstakingStarted(index, draftEra, account, rsrAmount, stakeAmount, availableAt);
     }
 
     /// Complete delayed staking for an account, up to but not including draft ID `endId`
@@ -239,7 +242,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         require(bh.isReady(), "basket not ready");
 
         // Execute accumulated withdrawals
-        emit UnstakingCompleted(start, i, era, account, total);
+        emit UnstakingCompleted(start, i, draftEra, account, total);
         main.rsr().safeTransfer(account, total);
     }
 
@@ -280,7 +283,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         }
 
         // Execute accumulated withdrawals
-        emit UnstakingCancelled(start, i, era, account, total);
+        emit UnstakingCancelled(start, i, draftEra, account, total);
 
         uint256 stakeAmount = total;
         if (totalStaked > 0) stakeAmount = (total * totalStaked) / rsrBacking;
@@ -335,6 +338,7 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
         uint256 withdrawalRSRtoTake = (rsrBeingWithdrawn() * rsrAmount + (rsrBalance - 1)) /
             rsrBalance;
         if (
+            withdrawalRSRtoTake == 0 || 
             rsrBeingWithdrawn() - withdrawalRSRtoTake <
             MIN_EXCHANGE_RATE.mulu_toUint(stakeBeingWithdrawn())
         ) {
@@ -382,7 +386,8 @@ contract StRSRP0 is IStRSR, ComponentP0, EIP712Upgradeable {
             address account = accounts.at(i);
             delete withdrawals[account];
         }
-        emit AllUnstakingReset(era);
+        draftEra++;
+        emit AllUnstakingReset(draftEra);
     }
 
     /// @custom:governance

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -76,14 +76,14 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
     // === Financial State: Drafts ===
     // Era. If drafts get wiped out due to RSR seizure, increment the era to zero draft values.
     // Only ever directly written by beginDraftEra()
-    uint256 internal draftEra;
+    uint256 internal draftEra; // {draftEra}
     // Drafts: share of the withdrawing tokens. Not transferrable and not revenue-earning.
     struct CumulativeDraft {
         // Avoid re-using uint192 in order to avoid confusion with our type system; 176 is enough
         uint176 drafts; // Total amount of drafts that will become available // {qDrafts}
         uint64 availableAt; // When the last of the drafts will become available
     }
-    // draftEra => ({account} => {drafts})
+    // {draftEra} => ({account} => {drafts})
     mapping(uint256 => mapping(address => CumulativeDraft[])) public draftQueues; // {drafts}
     mapping(uint256 => mapping(address => uint256)) public firstRemainingDraft; // draft index
     uint256 private totalDrafts; // Total of all drafts {qDrafts}
@@ -285,7 +285,7 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
 
         // Create draft
         (uint256 index, uint64 availableAt) = pushDraft(account, rsrAmount);
-        emit UnstakingStarted(index, era, account, rsrAmount, stakeAmount, availableAt);
+        emit UnstakingStarted(index, draftEra, account, rsrAmount, stakeAmount, availableAt);
     }
 
     /// Complete an account's unstaking; callable by anyone
@@ -562,6 +562,12 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
     /// @return {qDrafts} The amount of StRSR currently being withdrawn
     function getTotalDrafts() external view returns (uint256) {
         return totalDrafts;
+    }
+
+    /// @dev Can differ from the era for stakes
+    /// @return {draftEra} The era of the draft queue
+    function getDraftEra() external view returns (uint256){
+        return draftEra;
     }
 
     // ==== Internal Functions ====

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -564,6 +564,12 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
         return totalDrafts;
     }
 
+
+    /// @return {draftEra} The current era for drafts (withdrawals)
+    function getDraftEra() external view returns (uint256) {
+        return draftEra;
+    }
+
     // ==== Internal Functions ====
 
     /// Assign reward payouts to the staker pool

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -83,8 +83,8 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
         uint176 drafts; // Total amount of drafts that will become available // {qDrafts}
         uint64 availableAt; // When the last of the drafts will become available
     }
-    // {draftEra} => ({account} => {drafts})
-    mapping(uint256 => mapping(address => CumulativeDraft[])) public draftQueues; // {drafts}
+    // {draftEra} => ({account} => {qDrafts})
+    mapping(uint256 => mapping(address => CumulativeDraft[])) public draftQueues; // {qDrafts}
     mapping(uint256 => mapping(address => uint256)) public firstRemainingDraft; // draft index
     uint256 private totalDrafts; // Total of all drafts {qDrafts}
     uint256 private draftRSR; // Amount of RSR backing all drafts {qRSR}
@@ -562,12 +562,6 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
     /// @return {qDrafts} The amount of StRSR currently being withdrawn
     function getTotalDrafts() external view returns (uint256) {
         return totalDrafts;
-    }
-
-    /// @dev Can differ from the era for stakes
-    /// @return {draftEra} The era of the draft queue
-    function getDraftEra() external view returns (uint256){
-        return draftEra;
     }
 
     // ==== Internal Functions ====

--- a/contracts/p1/StRSR.sol
+++ b/contracts/p1/StRSR.sol
@@ -564,7 +564,6 @@ abstract contract StRSRP1 is Initializable, ComponentP1, IStRSR, EIP712Upgradeab
         return totalDrafts;
     }
 
-
     /// @return {draftEra} The current era for drafts (withdrawals)
     function getDraftEra() external view returns (uint256) {
         return draftEra;

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -971,6 +971,8 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
         await whileImpersonating(backingManager.address, async (signer) => {
           await stRSRP1.connect(signer).seizeRSR(1)
         })
+        const draftEra = await stRSRP1.getDraftEra()
+        expect(draftEra).to.equal(2)
 
         // Stake
         const unstakeAmount = bn('10000e18')
@@ -981,7 +983,7 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
         await stRSRP1.connect(addr1).unstake(unstakeAmount)
         await stRSRP1.connect(addr1).unstake(unstakeAmount.add(1))
 
-        const pendings = await facade.pendingUnstakings(rToken.address, 2, addr1.address)
+        const pendings = await facade.pendingUnstakings(rToken.address, draftEra, addr1.address)
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
         expect(pendings[0][2]).to.eql(unstakeAmount) // amount

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -9,7 +9,7 @@ import { IConfig, IMonitorParams } from '#/common/configuration'
 import { bn, fp } from '../common/numbers'
 import { setOraclePrice } from './utils/oracles'
 import { disableBatchTrade, disableDutchTrade } from './utils/trades'
-
+import { whileImpersonating } from './utils/impersonation'
 import {
   Asset,
   BackingManagerP1,
@@ -966,16 +966,22 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
       })
 
       it('Should return pending unstakings', async () => {
-        const unstakeAmount = bn('10000e18')
-        await rsr.connect(owner).mint(addr1.address, unstakeAmount.mul(10))
+        // Bump draftEra by seizing RSR when the withdrawal queue is empty
+        await rsr.connect(owner).mint(stRSRP1.address, 1)
+        await whileImpersonating(backingManager.address, async (signer) => {
+          await stRSRP1.connect(signer).seizeRSR(1)
+        })
 
         // Stake
+        const unstakeAmount = bn('10000e18')
+        await rsr.connect(owner).mint(addr1.address, unstakeAmount.mul(10))
         await rsr.connect(addr1).approve(stRSR.address, unstakeAmount.mul(10))
         await stRSRP1.connect(addr1).stake(unstakeAmount.mul(10))
+
         await stRSRP1.connect(addr1).unstake(unstakeAmount)
         await stRSRP1.connect(addr1).unstake(unstakeAmount.add(1))
 
-        const pendings = await facade.pendingUnstakings(rToken.address, addr1.address)
+        const pendings = await facade.pendingUnstakings(rToken.address, 2, addr1.address)
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
         expect(pendings[0][2]).to.eql(unstakeAmount) // amount

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -1298,23 +1298,6 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
           stRSRP1 = await ethers.getContractAt('StRSRP1Votes', stRSR.address)
         })
 
-        it('Should read draftEra', async () => {
-          // Empty withdrawal queue
-          await setNextBlockTimestamp(Number(await getLatestBlockTimestamp()) + stkWithdrawalDelay)
-          await stRSR.connect(addr1).withdraw(addr1.address, 1)
-
-          // Eras should begin same
-          expect(await stRSRP1.currentEra()).to.equal(1)
-          expect(await stRSRP1.getDraftEra()).to.equal(1)
-
-          // seizeRSR should bump draftEra but not stakes era
-          await whileImpersonating(backingManager.address, async (signer) => {
-            await stRSR.connect(signer).seizeRSR(amount1)
-          })
-          expect(await stRSRP1.currentEra()).to.equal(1)
-          expect(await stRSRP1.getDraftEra()).to.equal(2)
-        })
-
         it('Should read draftRSR', async () => {
           expect(await stRSRP1.getDraftRSR()).to.equal(amount1)
         })

--- a/test/ZZStRSR.test.ts
+++ b/test/ZZStRSR.test.ts
@@ -2028,7 +2028,7 @@ describe(`StRSRP${IMPLEMENTATION} contract`, () => {
 
       await expect(stRSR.connect(addr1).unstake(one))
         .emit(stRSR, 'UnstakingStarted')
-        .withArgs(0, 1, addr1.address, bn(0), one, availableAt)
+        .withArgs(0, 2, addr1.address, bn(0), one, availableAt)
 
       // Check withdrawal properly registered - Check draft era
       //await expectWithdrawal(addr1.address, 0, { rsrAmount: bn(1) })


### PR DESCRIPTION
Fix use of `era` in emitted `UnstakingStarted`; use `draftEra`

The changes to the P1 core contracts are so obviously safe I think this can go in 3.1.0. 

Also changes `FacadeRead.pendingUnstakings()` to take the draftEra.