### PR TITLE
TRST-M-1A: Restrict `redeemCustom()` to recent nonces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ This release makes bidding in dutch auctions easier for MEV searchers and gives 
 
 ## Upgrade Steps
 
-Upgrade BasketHandler and Distributor.
+Upgrade BasketHandler, BackingManager, and Distributor.
 
 Call `broker.setDutchTradeImplementation(newGnosisTrade)` with the new `DutchTrade` contract address.
 
 If this is the first upgrade to a >= 3.0.0 token, call `*.cacheComponents()` on all components.
+
+For plugins, upgrade Stargate.
 
 ## Core Protocol Contracts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,14 @@ If this is the first upgrade to a >= 3.0.0 token, call `*.cacheComponents()` on 
 
 New governance param added: `reweightable`
 
+- `BackingManager`
+  - Track basket nonce last collateralized at end of `settleTrade()`
 - `BasketHandler` [+1 slot]
+  - Restrict `redeemCustom()` to nonces after `lastCollateralized`
+  - New `LastCollateralizedChanged()` event -- track to determine earliest basket nonce to use for `redeemCustom()`
   - Add concept of a reweightable basket: a basket that can have its target amounts (once grouped by target unit) changed
   - Add `reweightable()` view
+  -
 - `Deployer`
   - New boolean field `reweightable` added to `IDeployer.DeploymentParams`
 - `Distributor`

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -85,6 +85,9 @@ interface IBackingManager is IComponent, ITrading {
         external
         view
         returns (TradingContext memory ctx, Registry memory reg);
+
+    /// @return {basketNonce} The basket nonce of the last full recollateralization effort
+    function lastCollateralized() external view returns (uint48);
 }
 
 interface TestIBackingManager is IBackingManager, TestITrading {

--- a/contracts/interfaces/IBackingManager.sol
+++ b/contracts/interfaces/IBackingManager.sol
@@ -85,9 +85,6 @@ interface IBackingManager is IComponent, ITrading {
         external
         view
         returns (TradingContext memory ctx, Registry memory reg);
-
-    /// @return {basketNonce} The basket nonce of the last full recollateralization effort
-    function lastCollateralized() external view returns (uint48);
 }
 
 interface TestIBackingManager is IBackingManager, TestITrading {

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -48,6 +48,11 @@ interface IBasketHandler is IComponent {
     /// @param newStatus The new basket status
     event BasketStatusChanged(CollateralStatus oldStatus, CollateralStatus newStatus);
 
+    /// Emitted when the last basket nonce available for redemption is changed
+    /// @param oldVal The old value of lastCollateralized
+    /// @param newVal The new value of lastCollateralized
+    event LastCollateralizedChanged(uint48 oldVal, uint48 newVal);
+
     // Initialization
     function init(
         IMain main_,
@@ -86,6 +91,10 @@ interface IBasketHandler is IComponent {
     /// Track the basket status changes
     /// @custom:refresher
     function trackStatus() external;
+
+    /// Track when last collateralized
+    /// @custom:refresher
+    function trackCollateralization() external;
 
     /// @return If the BackingManager has sufficient collateral to redeem the entire RToken supply
     function fullyCollateralized() external view returns (bool);

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -34,8 +34,6 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
 
     mapping(IERC20 => uint192) private tokensOut; // {tok} token balances out in ITrades
 
-    uint48 public lastCollateralized; // {basketNonce} nonce of the most recent collateralization
-
     constructor() {
         ONE_BLOCK = NetworkConfigLib.blocktime();
     }
@@ -85,13 +83,7 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
             }
         }
 
-        // Track lastCollateralized basket nonce
-        if (
-            main.basketHandler().nonce() > lastCollateralized &&
-            main.basketHandler().fullyCollateralized()
-        ) {
-            lastCollateralized = main.basketHandler().nonce();
-        }
+        main.basketHandler().trackCollateralization();
     }
 
     /// Apply the overall backing policy using the specified TradeKind, taking a haircut if unable

--- a/contracts/p0/BackingManager.sol
+++ b/contracts/p0/BackingManager.sol
@@ -34,6 +34,8 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
 
     mapping(IERC20 => uint192) private tokensOut; // {tok} token balances out in ITrades
 
+    uint48 public lastCollateralized; // {basketNonce} nonce of the most recent collateralization
+
     constructor() {
         ONE_BLOCK = NetworkConfigLib.blocktime();
     }
@@ -81,6 +83,14 @@ contract BackingManagerP0 is TradingP0, IBackingManager {
                 // see: docs/solidity-style.md#Catching-Empty-Data
                 if (errData.length == 0) revert(); // solhint-disable-line reason-string
             }
+        }
+
+        // Track lastCollateralized basket nonce
+        if (
+            main.basketHandler().nonce() > lastCollateralized &&
+            main.basketHandler().fullyCollateralized()
+        ) {
+            lastCollateralized = main.basketHandler().nonce();
         }
     }
 

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -476,7 +476,11 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
         // Calculate the linear combination basket
         for (uint48 i = 0; i < basketNonces.length; ++i) {
-            require(basketNonces[i] <= nonce, "invalid basketNonce");
+            require(
+                basketNonces[i] >= main.backingManager().lastCollateralized() &&
+                    basketNonces[i] <= nonce,
+                "invalid basketNonce"
+            );
             Basket storage b = basketHistory[basketNonces[i]];
 
             // Add-in refAmts contribution from historical basket

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -124,6 +124,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     Basket private basket;
 
     uint48 public nonce; // {basketNonce} A unique identifier for this basket instance
+    uint48 public lastCollateralized; // {basketNonce} Nonce of most recent full collateralization
     uint48 public timestamp; // The timestamp when this basket was last set
 
     // If disabled is true, status() is DISABLED, the basket is invalid, and the whole system should
@@ -229,6 +230,17 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         }
     }
 
+
+    /// Track when last collateralized
+    // effects: lastCollateralized' = nonce if nonce > lastCollateralized && fullyCapitalized
+    /// @custom:refresher
+    function trackCollateralization() external {
+        if (nonce > lastCollateralized && fullyCollateralized()) {
+            emit LastCollateralizedChanged(lastCollateralized, nonce);
+            lastCollateralized = nonce;
+        }
+    }
+
     /// Set the prime basket in the basket configuration, in terms of erc20s and target amounts
     /// @param erc20s The collateral for the new prime basket
     /// @param targetAmts The target amounts (in) {target/BU} for the new prime basket
@@ -315,7 +327,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
     /// @return Whether this contract owns enough collateral to cover rToken.basketsNeeded() BUs
     /// ie, whether the protocol is currently fully collateralized
-    function fullyCollateralized() external view returns (bool) {
+    function fullyCollateralized() public view returns (bool) {
         BasketRange memory held = basketsHeldBy(address(main.backingManager()));
         return held.bottom >= main.rToken().basketsNeeded();
     }
@@ -477,7 +489,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         // Calculate the linear combination basket
         for (uint48 i = 0; i < basketNonces.length; ++i) {
             require(
-                basketNonces[i] >= main.backingManager().lastCollateralized() &&
+                basketNonces[i] >= lastCollateralized &&
                     basketNonces[i] <= nonce,
                 "invalid basketNonce"
             );

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -230,7 +230,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         }
     }
 
-
     /// Track when last collateralized
     // effects: lastCollateralized' = nonce if nonce > lastCollateralized && fullyCapitalized
     /// @custom:refresher
@@ -489,8 +488,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         // Calculate the linear combination basket
         for (uint48 i = 0; i < basketNonces.length; ++i) {
             require(
-                basketNonces[i] >= lastCollateralized &&
-                    basketNonces[i] <= nonce,
+                basketNonces[i] >= lastCollateralized && basketNonces[i] <= nonce,
                 "invalid basketNonce"
             );
             Basket storage b = basketHistory[basketNonces[i]];

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -187,10 +187,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     /// @custom:interaction not RCEI; nonReentrant
     // untested:
     //      OZ nonReentrant line is assumed to be working. cost/benefit of direct testing is high
-    function forwardRevenue(IERC20[] calldata erc20s)
-        external
-        nonReentrant
-    {
+    function forwardRevenue(IERC20[] calldata erc20s) external nonReentrant {
         requireNotTradingPausedOrFrozen();
         require(ArrayLib.allUnique(erc20s), "duplicate tokens");
 

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -48,6 +48,9 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
     // === 3.1.0 ===
     mapping(IERC20 => uint192) private tokensOut; // {tok} token balances out in ITrades
 
+    // === 3.2.0 ===
+    uint48 public lastCollateralized; // {basketNonce} nonce of the most recent collateralization
+
     // ==== Invariants ====
     // tradingDelay <= MAX_TRADING_DELAY and backingBuffer <= MAX_BACKING_BUFFER
 
@@ -106,6 +109,11 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
                 // see: docs/solidity-style.md#Catching-Empty-Data
                 if (errData.length == 0) revert(); // solhint-disable-line reason-string
             }
+        }
+
+        // Track lastCollateralized basket nonce
+        if (basketHandler.nonce() > lastCollateralized && basketHandler.fullyCollateralized()) {
+            lastCollateralized = basketHandler.nonce();
         }
     }
 
@@ -351,5 +359,5 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[38] private __gap;
+    uint256[37] private __gap;
 }

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -422,7 +422,10 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
         // Calculate the linear combination basket
         for (uint48 i = 0; i < basketNonces.length; ++i) {
-            require(basketNonces[i] <= nonce, "invalid basketNonce");
+            require(
+                basketNonces[i] >= backingManager.lastCollateralized() && basketNonces[i] <= nonce,
+                "invalid basketNonce"
+            );
             Basket storage b = basketHistory[basketNonces[i]];
 
             // Add-in refAmts contribution from historical basket

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -182,7 +182,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         }
     }
 
-
     /// Set the prime basket in the basket configuration, in terms of erc20s and target amounts
     /// @param erc20s The collateral for the new prime basket
     /// @param targetAmts The target amounts (in) {target/BU} for the new prime basket
@@ -206,7 +205,13 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
         // If this isn't initial setup, require targets remain constant
         if (!reweightable && config.erc20s.length > 0) {
-            BasketLibP1.requireConstantConfigTargets(assetRegistry, config, _targetAmts, erc20s, targetAmts);
+            BasketLibP1.requireConstantConfigTargets(
+                assetRegistry,
+                config,
+                _targetAmts,
+                erc20s,
+                targetAmts
+            );
         }
 
         // Clean up previous basket config

--- a/contracts/p1/mixins/BasketLib.sol
+++ b/contracts/p1/mixins/BasketLib.sol
@@ -309,7 +309,6 @@ library BasketLibP1 {
         }
     }
 
-
     // === Contract-size saver ===
 
     /// Require that newERC20s and newTargetAmts preserve the current config targets
@@ -319,7 +318,7 @@ library BasketLibP1 {
         EnumerableMap.Bytes32ToUintMap storage targetAmts,
         IERC20[] calldata newERC20s,
         uint192[] calldata newTargetAmts
-    ) external  {
+    ) external {
         // Populate targetAmts mapping with old basket config
         uint256 len = config.erc20s.length;
         for (uint256 i = 0; i < len; ++i) {

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -58,10 +58,8 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     }
 
     /// Contract-size helper
-    /// solhint-disable no-empty-blocks
+    // solhint-disable-next-line no-empty-blocks
     function requireNotTradingPausedOrFrozen() internal view notTradingPausedOrFrozen {}
-
-    /// solhint-enable no-empty-blocks
 
     /// Claim all rewards
     /// Collective Action

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -57,10 +57,15 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
         setMinTradeVolume(minTradeVolume_);
     }
 
+    /// Contract-size helper
+    /// solhint-disable-next-line no-empty-blocks
+    function requireNotTradingPausedOrFrozen() internal view notTradingPausedOrFrozen {}
+
     /// Claim all rewards
     /// Collective Action
     /// @custom:interaction CEI
-    function claimRewards() external notTradingPausedOrFrozen {
+    function claimRewards() external {
+        requireNotTradingPausedOrFrozen();
         RewardableLibP1.claimRewards(main.assetRegistry());
     }
 
@@ -68,7 +73,8 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     /// Collective Action
     /// @param erc20 The ERC20 to claimRewards on
     /// @custom:interaction CEI
-    function claimRewardsSingle(IERC20 erc20) external notTradingPausedOrFrozen {
+    function claimRewardsSingle(IERC20 erc20) external {
+        requireNotTradingPausedOrFrozen();
         RewardableLibP1.claimRewardsSingle(main.assetRegistry().toAsset(erc20));
     }
 

--- a/contracts/p1/mixins/Trading.sol
+++ b/contracts/p1/mixins/Trading.sol
@@ -58,8 +58,10 @@ abstract contract TradingP1 is Multicall, ComponentP1, ReentrancyGuardUpgradeabl
     }
 
     /// Contract-size helper
-    /// solhint-disable-next-line no-empty-blocks
+    /// solhint-disable no-empty-blocks
     function requireNotTradingPausedOrFrozen() internal view notTradingPausedOrFrozen {}
+
+    /// solhint-enable no-empty-blocks
 
     /// Claim all rewards
     /// Collective Action

--- a/test/RToken.test.ts
+++ b/test/RToken.test.ts
@@ -1227,23 +1227,23 @@ describe(`RTokenP${IMPLEMENTATION} contract`, () => {
           .connect(addr1)
           .redeemCustom(addr1.address, fp('1'), [await basketHandler.nonce()], [fp('1')], [], [])
 
-        // New reference basket
+        // Cannot redeem after new reference basket
         await basketHandler.refreshBasket()
         expect(await basketHandler.fullyCollateralized()).to.equal(false)
-
-        // Custom redemption should not revert since there is collateral overlap
         await expect(rToken.connect(addr1).redeem(1)).to.be.revertedWith(
           'partial redemption; use redeemCustom'
         )
+
+        // Can redeemCustom at latest basket nonce
         const nonce = await basketHandler.nonce()
         await rToken.connect(addr1).redeemCustom(addr1.address, fp('1'), [nonce], [fp('1')], [], [])
 
-        // Previous basket nonce should be redeemable
+        // Can redeemCustom at previous basket nonce
         await rToken
           .connect(addr1)
           .redeemCustom(addr1.address, fp('1'), [nonce - 1], [fp('1')], [], [])
 
-        // Future basket nonce should not be redeemable
+        // Cannot redeemCustom at future basket nonce
         await expect(
           rToken.connect(addr1).redeemCustom(addr1.address, fp('1'), [nonce + 1], [fp('1')], [], [])
         ).to.be.revertedWith('invalid basketNonce')

--- a/test/Recollateralization.test.ts
+++ b/test/Recollateralization.test.ts
@@ -1183,6 +1183,12 @@ describe(`Recollateralization - P${IMPLEMENTATION}`, () => {
           )
           expect(await rToken.totalSupply()).to.equal(issueAmount) // assets kept in backing buffer
 
+          // Regression test -- Jan 29 2024
+          // After recollateralization: should NOT allow redeemCustom at previous basket
+          await expect(
+            rToken.connect(addr1).redeemCustom(addr1.address, bn('1'), [2], [fp('1')], [], [])
+          ).to.be.revertedWith('invalid basketNonce')
+
           // Check price in USD of the current RToken
           await expectRTokenPrice(rTokenAsset.address, fp('1'), ORACLE_ERROR)
         })


### PR DESCRIPTION
Restrict `RToken.redeemCustom()` basket nonces to be `>= lastCollateralized`, where `lastCollateralized` is the basket nonce of the last successful collateralization effort. BackingManager is in charge of calling `RToken.trackCollateralization()` after each trade. 

There were contract size issues. I tried two approaches out: one with the new state and associated tracking in BackingManager and one in BasketHandler (current approach). Both pushed their contracts over the size limit, but BasketHandler had much more headroom for easy contract-size-savers. BackingManager did need one small contract-size saver in order to even be able to make the `.trackCollateralization()` call. 

Regression test confirmed to fail on commit 79061148dbe9dc8fd36a0364f11bd5a4224b98b1