### PR TITLE
Make `pendingUnstakings` return RSR amount

### DIFF
--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -269,7 +269,7 @@ contract FacadeRead is IFacadeRead {
     /// @param draftEra {draftEra} The draft era to query unstakings for
     /// @param account The account for the query
     /// @dev Use stRSR.draftRate() to convert {qDrafts} to {qRSR}
-    /// @return unstakings {qDrafts} All the pending StRSR unstakings for an account, in drafts
+    /// @return unstakings {qRSR} All the pending StRSR unstakings for an account, in RSR
     function pendingUnstakings(
         RTokenP1 rToken,
         uint256 draftEra,

--- a/contracts/facade/FacadeRead.sol
+++ b/contracts/facade/FacadeRead.sol
@@ -278,6 +278,7 @@ contract FacadeRead is IFacadeRead {
         StRSRP1 stRSR = StRSRP1(address(rToken.main().stRSR()));
         uint256 left = stRSR.firstRemainingDraft(draftEra, account);
         uint256 right = stRSR.draftQueueLen(draftEra, account);
+        uint192 draftRate = stRSR.draftRate();
 
         unstakings = new Pending[](right - left);
         for (uint256 i = 0; i < right - left; i++) {
@@ -289,7 +290,8 @@ contract FacadeRead is IFacadeRead {
                 diff = drafts - prevDrafts;
             }
 
-            unstakings[i] = Pending(i + left, availableAt, diff);
+            // {qRSR} = {qDrafts} / {qDrafts/qRSR}
+            unstakings[i] = Pending(i + left, availableAt, diff.div(draftRate));
         }
     }
 

--- a/contracts/interfaces/IFacadeRead.sol
+++ b/contracts/interfaces/IFacadeRead.sol
@@ -88,7 +88,7 @@ interface IFacadeRead {
     /// @param draftEra {draftEra} The draft era to query unstakings for
     /// @param account The account for the query
     /// @dev Use stRSR.draftRate() to convert {qDrafts} to {qRSR}
-    /// @return {qDrafts} All the pending unstakings for an account, in drafts
+    /// @return {qRSR} All the pending StRSR unstakings for an account, in RSR
     function pendingUnstakings(
         RTokenP1 rToken,
         uint256 draftEra,

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -966,30 +966,41 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
       })
 
       it('Should return pending unstakings', async () => {
-        // Bump draftEra by seizing RSR when the withdrawal queue is empty
-        await rsr.connect(owner).mint(stRSRP1.address, 1)
-        await whileImpersonating(backingManager.address, async (signer) => {
-          await stRSRP1.connect(signer).seizeRSR(1)
-        })
-        const draftEra = await stRSRP1.getDraftEra()
-        expect(draftEra).to.equal(2)
-
         // Stake
         const unstakeAmount = bn('10000e18')
-        await rsr.connect(owner).mint(addr1.address, unstakeAmount.mul(10))
-        await rsr.connect(addr1).approve(stRSR.address, unstakeAmount.mul(10))
-        await stRSRP1.connect(addr1).stake(unstakeAmount.mul(10))
+        await rsr.connect(owner).mint(addr1.address, unstakeAmount.mul(20))
+        await rsr.connect(addr1).approve(stRSR.address, unstakeAmount.mul(20))
+        await stRSRP1.connect(addr1).stake(unstakeAmount.mul(20))
 
-        await stRSRP1.connect(addr1).unstake(unstakeAmount)
-        await stRSRP1.connect(addr1).unstake(unstakeAmount.add(1))
+        // Bump draftEra by seizing half the RSR when the withdrawal queue is empty
+        let draftEra = await stRSRP1.getDraftEra()
+        expect(draftEra).to.equal(1)
+        await whileImpersonating(backingManager.address, async (signer) => {
+          await stRSRP1.connect(signer).seizeRSR(unstakeAmount.mul(10)) // seize half
+        })
+        draftEra = await stRSRP1.getDraftEra()
+        expect(draftEra).to.equal(2) // era bumps because queue is empty
+
+        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(2)) // 50% StRSR/RSR depreciation
+
+        // Bump draftEra by seizing half the RSR when the queue is empty
+        await whileImpersonating(backingManager.address, async (signer) => {
+          await stRSRP1.connect(signer).seizeRSR(unstakeAmount.mul(5)) // seize half, again
+        })
+        draftEra = await stRSRP1.getDraftEra()
+        expect(draftEra).to.equal(2) // no era bump
+
+        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(4).add(1)) // 75% depreciation; test rounding
 
         const pendings = await facade.pendingUnstakings(rToken.address, draftEra, addr1.address)
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
-        expect(pendings[0][2]).to.eql(unstakeAmount) // amount
+        console.log(pendings[0][2], unstakeAmount)
+        expect(pendings[0][2]).to.eql(unstakeAmount) // RSR amount, not draft amount
 
         expect(pendings[1][0]).to.eql(bn(1)) // index
-        expect(pendings[1][2]).to.eql(unstakeAmount.add(1)) // amount
+        console.log(pendings[1][2])
+        expect(pendings[1][2]).to.eql(unstakeAmount) // RSR amount, not draft amount
       })
 
       it('Should return prime basket', async () => {

--- a/test/Facade.test.ts
+++ b/test/Facade.test.ts
@@ -981,7 +981,7 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
         draftEra = await stRSRP1.getDraftEra()
         expect(draftEra).to.equal(2) // era bumps because queue is empty
 
-        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(2)) // 50% StRSR/RSR depreciation
+        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(4)) // eventually 75% StRSR/RSR depreciation
 
         // Bump draftEra by seizing half the RSR when the queue is empty
         await whileImpersonating(backingManager.address, async (signer) => {
@@ -990,16 +990,14 @@ describe('FacadeRead + FacadeAct + FacadeMonitor contracts', () => {
         draftEra = await stRSRP1.getDraftEra()
         expect(draftEra).to.equal(2) // no era bump
 
-        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(4).add(1)) // 75% depreciation; test rounding
+        await stRSRP1.connect(addr1).unstake(unstakeAmount.mul(4).add(1)) // test rounding
 
         const pendings = await facade.pendingUnstakings(rToken.address, draftEra, addr1.address)
         expect(pendings.length).to.eql(2)
         expect(pendings[0][0]).to.eql(bn(0)) // index
-        console.log(pendings[0][2], unstakeAmount)
         expect(pendings[0][2]).to.eql(unstakeAmount) // RSR amount, not draft amount
 
         expect(pendings[1][0]).to.eql(bn(1)) // index
-        console.log(pendings[1][2])
         expect(pendings[1][2]).to.eql(unstakeAmount) // RSR amount, not draft amount
       })
 


### PR DESCRIPTION
The units in the withdrawal queue are neither RSR amounts nor StRSR amounts. This change fixes `pendingUnstakings` to return amounts in RSR rather than meaningless units internal to StRSR's storage logic. 