### PR TITLE
FacadeRead: use avg price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ New governance param added: `reweightable`
 - stargate: Continue transfers of wrapper tokens if stargate rewards break
 - All plugins with variable refPerTok(): do no revert refresh() when underlying protocol reverts
 
+### Facades
+
+- `FacadeRead`
+  - Use avg prices instead of low prices in `backingOverview()` and `basketBreakdown()`
+
 ### Trading
 
 - `DutchTrade`


### PR DESCRIPTION
should make `FacadeRead.basketBreakdown()` and `FacadeRead.backingOverview()` more accurate when dealing with collateral plugins with different oracleErrors