### PR TITLE
Version trading plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ All collateral plugins should be upgraded. The compound-v2 ERC20 wrapper will be
 - yearn-v2
   - Make `price()` more resistant to manipulation by MEV
 
+### Trading
+
+- `GnosisTrade`
+  - Add `version()` getter
+- `DutchTrade`
+  - Add `version()` getter
+
 ### Facades
 
 - `FacadeMonitor.sol`

--- a/contracts/interfaces/ITrade.sol
+++ b/contracts/interfaces/ITrade.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "./IBroker.sol";
+import "./IVersioned.sol";
 
 enum TradeStatus {
     NOT_STARTED, // before init()
@@ -17,7 +18,7 @@ enum TradeStatus {
  *
  * Usage: if (canSettle()) settle()
  */
-interface ITrade {
+interface ITrade is IVersioned {
     /// Complete the trade and transfer tokens back to the origin trader
     /// @return soldAmt {qSellTok} The quantity of tokens sold
     /// @return boughtAmt {qBuyTok} The quantity of tokens bought

--- a/contracts/mixins/Versioned.sol
+++ b/contracts/mixins/Versioned.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "../interfaces/IVersioned.sol";
 
 // This value should be updated on each release
-string constant VERSION = "3.2.0";
+string constant VERSION = "3.3.0";
 
 /**
  * @title Versioned

--- a/contracts/plugins/assets/VersionedAsset.sol
+++ b/contracts/plugins/assets/VersionedAsset.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import "../../interfaces/IVersioned.sol";
 
 // This value should be updated on each release
-string constant ASSET_VERSION = "3.2.0";
+string constant ASSET_VERSION = "3.3.0";
 
 /**
  * @title VersionedAsset

--- a/contracts/plugins/trading/DutchTrade.sol
+++ b/contracts/plugins/trading/DutchTrade.sol
@@ -8,6 +8,7 @@ import "../../libraries/NetworkConfigLib.sol";
 import "../../interfaces/IAsset.sol";
 import "../../interfaces/IBroker.sol";
 import "../../interfaces/ITrade.sol";
+import "../../mixins/Versioned.sol";
 
 interface IDutchTradeCallee {
     function dutchTradeCallback(
@@ -83,7 +84,7 @@ uint192 constant ONE_POINT_FIVE = 150e16; // {1} 1.5
  * 3. Wait until the desired block is reached (hopefully not in the first 20% of the auction)
  * 4. Call bid()
  */
-contract DutchTrade is ITrade {
+contract DutchTrade is ITrade, Versioned {
     using FixLib for uint192;
     using SafeERC20 for IERC20Metadata;
 

--- a/contracts/plugins/trading/GnosisTrade.sol
+++ b/contracts/plugins/trading/GnosisTrade.sol
@@ -9,11 +9,12 @@ import "../../libraries/Fixed.sol";
 import "../../interfaces/IBroker.sol";
 import "../../interfaces/IGnosis.sol";
 import "../../interfaces/ITrade.sol";
+import "../../mixins/Versioned.sol";
 
 // Modifications to this contract's state must only ever be made when status=PENDING!
 
 /// Trade contract against the Gnosis EasyAuction mechanism
-contract GnosisTrade is ITrade {
+contract GnosisTrade is ITrade, Versioned {
     using FixLib for uint192;
     using SafeERC20Upgradeable for IERC20Upgradeable;
 

--- a/test/Broker.test.ts
+++ b/test/Broker.test.ts
@@ -46,6 +46,7 @@ import {
   ORACLE_TIMEOUT,
   PRICE_TIMEOUT,
   SLOW,
+  VERSION,
 } from './fixtures'
 import snapshotGasCost from './utils/snapshotGasCost'
 import {
@@ -1109,6 +1110,10 @@ describe(`BrokerP${IMPLEMENTATION} contract #fast`, () => {
         expect(await trade.canSettle()).to.equal(false)
       })
 
+      it('Should have version()', async () => {
+        expect(await trade.version()).to.equal(VERSION)
+      })
+
       it('Should initialize DutchTrade correctly - only once', async () => {
         // Fund trade and initialize
         await token0.connect(owner).mint(trade.address, amount)
@@ -1553,6 +1558,10 @@ describe(`BrokerP${IMPLEMENTATION} contract #fast`, () => {
         TradeFactory = await ethers.getContractFactory('GnosisTrade')
         newTrade = <GnosisTrade>await TradeFactory.deploy()
         await setStorageAt(newTrade.address, 0, 0)
+      })
+
+      it('Should have version()', async () => {
+        expect(await newTrade.version()).to.equal(VERSION)
       })
 
       it('Open Trade ', async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -94,7 +94,7 @@ export const ORACLE_ERROR = fp('0.01') // 1% oracle error
 export const REVENUE_HIDING = fp('0') // no revenue hiding by default; test individually
 
 // This will have to be updated on each release
-export const VERSION = '3.2.0'
+export const VERSION = '3.3.0'
 
 export type Collateral =
   | FiatCollateral


### PR DESCRIPTION
- Add `version() returns (string memory)` getter to `DutchTrade` and ` GnosisTrade`
- Set version to "3.3.0"