### PR TITLE
Governance as timelock canceller

### DIFF
--- a/contracts/facade/FacadeWrite.sol
+++ b/contracts/facade/FacadeWrite.sol
@@ -166,6 +166,8 @@ contract FacadeWrite is IFacadeWrite {
             timelock.grantRole(timelock.PROPOSER_ROLE(), governance); // Gov only proposer
             // Set Guardian as canceller, if address(0) then no one can cancel
             timelock.grantRole(timelock.CANCELLER_ROLE(), govRoles.guardian);
+            // Set Governance as canceller to enable killing timelock-stuck proposals
+            timelock.grantRole(timelock.CANCELLER_ROLE(), governance);
             timelock.grantRole(timelock.EXECUTOR_ROLE(), governance); // Gov only executor
             timelock.revokeRole(timelock.TIMELOCK_ADMIN_ROLE(), address(this)); // Revoke admin role
 

--- a/test/FacadeWrite.test.ts
+++ b/test/FacadeWrite.test.ts
@@ -689,6 +689,9 @@ describe('FacadeWrite contract', () => {
           expect(await timelock.hasRole(await timelock.EXECUTOR_ROLE(), governor.address)).to.equal(
             true
           )
+          expect(
+            await timelock.hasRole(await timelock.CANCELLER_ROLE(), governor.address)
+          ).to.equal(true)
         })
 
         it('Should setup owner, freezer and pauser correctly', async () => {


### PR DESCRIPTION
This doesn't change functionality, just legibility. After an era change a proposal can get stuck in the timelock. This change allows it to be legibly cancelled so that dapp frontends will not continue to show it for all time. 