### PR TITLE
Document up to 21 decimals supported

### DIFF
--- a/contracts/plugins/trading/GnosisTrade.sol
+++ b/contracts/plugins/trading/GnosisTrade.sol
@@ -14,7 +14,9 @@ import "../../mixins/Versioned.sol";
 // Modifications to this contract's state must only ever be made when status=PENDING!
 
 /// Trade contract against the Gnosis EasyAuction mechanism
-/// Only supports sell/buy tokens with up to 21 decimals
+/// Limitations on decimals due to Gnosis Auction limitations:
+///   - 27 decimal tokens are not supported in practice: max auction size is ~8e1 whole tokens
+///   - 21 decimal tokens are supported, with caveats: max auction size is ~8e7 whole tokens
 contract GnosisTrade is ITrade, Versioned {
     using FixLib for uint192;
     using SafeERC20Upgradeable for IERC20Upgradeable;

--- a/contracts/plugins/trading/GnosisTrade.sol
+++ b/contracts/plugins/trading/GnosisTrade.sol
@@ -14,6 +14,7 @@ import "../../mixins/Versioned.sol";
 // Modifications to this contract's state must only ever be made when status=PENDING!
 
 /// Trade contract against the Gnosis EasyAuction mechanism
+/// Only supports sell/buy tokens with up to 21 decimals
 contract GnosisTrade is ITrade, Versioned {
     using FixLib for uint192;
     using SafeERC20Upgradeable for IERC20Upgradeable;

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -250,6 +250,10 @@ To use a rebasing token as collateral backing, the rebasing ERC20 needs to be re
 
 There is a simple ERC20 wrapper that can be easily extended at [RewardableERC20Wrapper.sol](../contracts/plugins/assets/erc20/RewardableERC20Wrapper.sol). You may add additional logic by extending `_afterDeposit()` or `_beforeWithdraw()`.
 
+### Token decimals should be <= 21
+
+The protocol currently supports collateral tokens with up to 21 decimals.
+
 ### `refresh()` should never revert
 
 Because it’s called at the beginning of many transactions, `refresh()` should never revert. If `refresh()` encounters a critical error, it should change the Collateral contract’s state so that `status()` becomes `DISABLED`.

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -252,7 +252,12 @@ There is a simple ERC20 wrapper that can be easily extended at [RewardableERC20W
 
 ### Token decimals should be <= 21
 
-The protocol currently supports collateral tokens with up to 21 decimals.
+The protocol currently supports collateral tokens with up to 21 decimals. There are some caveats to know about:
+
+- For a token with 21 decimals, batch auctions can only process up to ~8e7 whole tokens in a single auction. Dollar-pegged tokens thus fit nicely within this constraint, but 21 decimal tokens that are worth <$0.1 per whole token may not. Therefore, the protocol should not be used with **low-value 21-decimal tokens**.
+- For a token with 18 decimals, batch auctions can only process up to ~8e10 whole tokens in a single auction.
+
+Dutch auctions do not have this constraint. As long as they remain enabled they can process a larger number of tokens.
 
 ### `refresh()` should never revert
 

--- a/docs/solidity-style.md
+++ b/docs/solidity-style.md
@@ -139,7 +139,9 @@ This should work without change for around 9M years, which is more than enough.
 
 `{decimals}`: [6, 21]
 
-The protocol only supports collateral tokens up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing restrictions in GnosisTrade / EasyAuction, and end up in rounding issues accross the protocol.
+The protocol only supports collateral tokens up to 21 decimals, and for these cases only supports balances up to `~8e28`. Exceeding this could end up overflowing restrictions in GnosisTrade / EasyAuction, and end up in rounding issues accross the protocol.
+
+21 decimal tokens must also be sufficiently valued, where that is defined as a whole token worth >$0.1.
 
 ## Function annotations
 

--- a/docs/solidity-style.md
+++ b/docs/solidity-style.md
@@ -135,6 +135,12 @@ That is, we expect timestamps to be any uint48 value.
 
 This should work without change for around 9M years, which is more than enough.
 
+### Collateral decimals
+
+`{decimals}`: [6, 21]
+
+The protocol only supports collateral tokens up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing restrictions in GnosisTrade / EasyAuction, and end up in rounding issues accross the protocol.
+
 ## Function annotations
 
 All core functions that can be called from outside our system are classified into one of the following 3 categories:

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -172,9 +172,9 @@ The "best plausible price" is equal to the exchange rate at the high price of th
 
 ### Collateral decimals restriction
 
-The protocol only supports collateral tokens with up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing the `uint96` restrictions in GnosisTrade / EasyAuction. We expect `~70e6` whole tokens (for 21 decimals) to always be worth more than the `minTradeVolume`.
+The protocol only supports collateral tokens with up to 21 decimals, and for these cases only supports balances up to `~8e28`. Exceeding this could end up overflowing the `uint96` restrictions in GnosisTrade / EasyAuction. We expect `~70e6` whole tokens (for 21 decimals) to always be worth more than the `minTradeVolume`. Note that even when this assumption breaks, the protocol behaves gracefully and downsizes the GnosisTrade to be within the limits.
 
-In terms of rounding, with a 21 decimals token, we lose 3 decimal places when rounding down to our 18 decimal fixed point numbers (up to 999 wei). Even if one whole token is worth 1 billion USD, `1e3` wei will only be worth `1e-9` USD in that case.
+In terms of rounding, with a 21 decimals token, we lose 3 decimal places when rounding down to our 18 decimal fixed point numbers (up to 999 wei). Even if one whole token is worth 1 billion USD, `1e3` wei will only be worth `1e-9` USD in that case. This is an acceptable loss.
 
 #### Trade violation fallback
 

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -170,6 +170,12 @@ The `dutchAuctionLength` can be configured to be any value. The suggested defaul
 
 The "best plausible price" is equal to the exchange rate at the high price of the sell token and the low price of the buy token. The "worst-case price" is equal to the exchange rate at the low price of the sell token and the high price of the sell token, plus an additional discount equal to `maxTradeSlippage`.
 
+### Collateral decimals restriction
+
+The protocol only supports collateral tokens with up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing the  `uint96` restrictions in GnosisTrade / EasyAuction. We expect `~70e6` whole tokens (for 21 decimals) to always be worth more than the `minTradeVolume`.
+
+In terms of rounding, with a 21 decimals token, we lose 3 decimal places when rounding down to our 18 decimal fixed point numbers (up to 999 wei). Even if one whole token is worth 1 billion USD, `1e3` wei will only be worth `1e-9` USD in that case.
+
 #### Trade violation fallback
 
 Dutch auctions become disabled for an asset being traded if a trade clears in the geometric phase. The rationale is that a trade that clears in this range (multiples above the plausible price) only does so because either 1) the auctioned asset's price was manipulated downwards, or 2) the bidding asset was manipulated upwards, such that the protocol accepts an unfavorable trade. All subsequent trades for that particular trading pair will be forced to use the batch auctions as a result. Dutch auctions for disabled assets must be manually re-enabled by governance.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -172,7 +172,7 @@ The "best plausible price" is equal to the exchange rate at the high price of th
 
 ### Collateral decimals restriction
 
-The protocol only supports collateral tokens with up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing the  `uint96` restrictions in GnosisTrade / EasyAuction. We expect `~70e6` whole tokens (for 21 decimals) to always be worth more than the `minTradeVolume`.
+The protocol only supports collateral tokens with up to 21 decimals, and for these cases only supports balances up to `70e27`. Exceeding this could end up overflowing the `uint96` restrictions in GnosisTrade / EasyAuction. We expect `~70e6` whole tokens (for 21 decimals) to always be worth more than the `minTradeVolume`.
 
 In terms of rounding, with a 21 decimals token, we lose 3 decimal places when rounding down to our 18 decimal fixed point numbers (up to 999 wei). Even if one whole token is worth 1 billion USD, `1e3` wei will only be worth `1e-9` USD in that case.
 


### PR DESCRIPTION
Document our protocol currently supports up to 21 decimals for collateral tokens.

Pending topic:  27 decimal test cases already in the repo