### PR TITLE
DRAFT: Feat/on chain redemptions

### DIFF
--- a/contracts/facade/redeem/EthPlusIntoEth.sol
+++ b/contracts/facade/redeem/EthPlusIntoEth.sol
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: BlueOak-1.0.0
+pragma solidity 0.8.19;
+
+import { IRToken } from "../../interfaces/IRToken.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+interface IRETHRouter {
+    function swapTo(
+        uint256 _uniswapPortion,
+        uint256 _balancerPortion,
+        uint256 _minTokensOut,
+        uint256 _idealTokensOut
+    ) external payable;
+
+    function swapFrom(
+        uint256 _uniswapPortion,
+        uint256 _balancerPortion,
+        uint256 _minTokensOut,
+        uint256 _idealTokensOut,
+        uint256 _tokensIn
+    ) external;
+
+    function optimiseSwapTo(uint256 _amount, uint256 _steps)
+        external
+        returns (uint256[2] memory portions, uint256 amountOut);
+
+    function optimiseSwapFrom(uint256 _amount, uint256 _steps)
+        external
+        returns (uint256[2] memory portions, uint256 amountOut);
+}
+
+interface IWSTETH is IERC20 {
+    function unwrap(uint256 _wstETHAmount) external returns (uint256);
+}
+
+interface IUniswapV2Like {
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        // is ignored, but can be empty
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path)
+        external
+        view
+        returns (uint256[] memory amounts);
+}
+
+interface ICurveETHstETHStableSwap {
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 minDy
+    ) external payable returns (uint256);
+}
+
+interface ICurveStableSwap {
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 minDy,
+        address receiver
+    ) external returns (uint256);
+}
+
+contract EthPlusIntoEth is IUniswapV2Like {
+    using SafeERC20 for IERC20;
+
+    IRToken private constant ETH_PLUS = IRToken(0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8);
+
+    IERC20 private constant RETH = IERC20(0xae78736Cd615f374D3085123A210448E74Fc6393);
+    IRETHRouter private constant RETH_ROUTER =
+        IRETHRouter(0x16D5A408e807db8eF7c578279BEeEe6b228f1c1C);
+
+    IWSTETH private constant WSTETH = IWSTETH(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+    IERC20 private constant STETH = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
+
+    IERC4626 private constant SFRXETH = IERC4626(0xac3E018457B222d93114458476f3E3416Abbe38F);
+    IERc20 private constant FRXETH = IERc20(0x5E8422345238F34275888049021821E8E08CAa1f);
+    ICurveETHstETHStableSwap private constant CURVE_ETHSTETH_STABLE_SWAP =
+        ICurveETHstETHStableSwap(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
+    ICurveStableSwap private constant CURVE_FRXETH_WETH =
+        ICurveStableSwap(0x9c3B46C0Ceb5B9e304FCd6D88Fc50f7DD24B31Bc);
+
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        // is ignored, but can be empty
+        // solhint-disable-next-line unused-ignore
+        address[] calldata,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts) {
+        require(deadline >= block.timestamp, "deadline");
+        ETH_PLUS.transferFrom(msg.sender, address(this), amountIn);
+        ETH_PLUS.redeem(ETH_PLUS.balanceOf(address(this)));
+
+        // reth -> eth
+        {
+            uint256 rethBalance = RETH.balanceOf(address(this));
+            (uint256[2] memory portions, uint256 expectedETHOut) = RETH_ROUTER.optimiseSwapFrom(
+                rethBalance,
+                2
+            );
+            RETH.approve(address(rethRouter), rethBalance);
+            RETH_ROUTER.swapFrom(
+                portions[0],
+                portions[1],
+                expectedETHOut,
+                expectedETHOut,
+                rethBalance
+            );
+        }
+
+        // wsteth -> eth
+        {
+            WSTETH.unwrap(WSTETH.balanceOf(address(this)));
+            uint256 stethBalance = STETH.balanceOf(address(this));
+            STETH.approve(address(CURVE_ETHSTETH_STABLE_SWAP), stethBalance);
+            CURVE_ETHSTETH_STABLE_SWAP.exchange(1, 0, sfrxethBalance, 0);
+        }
+
+        // sfrxeth -> eth
+        {
+            uint256 sfrxethBalance = SFRXETH.balanceOf(address(this));
+            SFRXETH.redeem(sfrxethBalance, address(this), address(this));
+            uint256 frxethBalance = FRXETH.balanceOf(address(this));
+            FRXETH.approve(address(CURVE_FRXETH_WETH), frxethBalance);
+
+            // frxeth -> weth
+            CURVE_FRXETH_WETH.exchange(1, 0, frxethBalance, 0);
+
+            // weth -> eth
+            WETH.withdraw(WETH.balanceOf(address(this)));
+        }
+
+        // solhint-disable-next-line custom-errors
+        require(this.balance >= amountOutMin, "INSUFFICIENT_OUTPUT_AMOUNT");
+        this.transfer(to, this.balance);
+    }
+
+    receive() external payable {}
+}

--- a/contracts/facade/redeem/EthPlusIntoEth.sol
+++ b/contracts/facade/redeem/EthPlusIntoEth.sol
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: BlueOak-1.0.0
 pragma solidity 0.8.19;
 
-import { IRToken } from "../../interfaces/IRToken.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IBasketHandler } from "../../interfaces/IBasketHandler.sol";
+import { IRToken } from "../../interfaces/IRToken.sol";
+import { RoundingMode, FixLib } from "../../libraries/Fixed.sol";
+
+interface IWETH is IERC20 {
+    function withdraw(uint256 wad) external;
+}
 
 interface IRETHRouter {
     function swapTo(
@@ -33,22 +39,8 @@ interface IRETHRouter {
 
 interface IWSTETH is IERC20 {
     function unwrap(uint256 _wstETHAmount) external returns (uint256);
-}
 
-interface IUniswapV2Like {
-    function swapExactTokensForETH(
-        uint256 amountIn,
-        uint256 amountOutMin,
-        // is ignored, but can be empty
-        address[] calldata path,
-        address to,
-        uint256 deadline
-    ) external returns (uint256[] memory amounts);
-
-    function getAmountsOut(uint256 amountIn, address[] calldata path)
-        external
-        view
-        returns (uint256[] memory amounts);
+    function getStETHByWstETH(uint256 _wstETHAmount) external view returns (uint256);
 }
 
 interface ICurveETHstETHStableSwap {
@@ -58,6 +50,18 @@ interface ICurveETHstETHStableSwap {
         uint256 dx,
         uint256 minDy
     ) external payable returns (uint256);
+
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+}
+
+interface IRETH is IERC20 {
+    function burn(uint256 rethAmt) external;
+
+    function getEthValue(uint256 rethAmt) external view returns (uint256);
 }
 
 interface ICurveStableSwap {
@@ -68,14 +72,42 @@ interface ICurveStableSwap {
         uint256 minDy,
         address receiver
     ) external returns (uint256);
+
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
 }
 
+interface IUniswapV2Like {
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        // is ignored, can be empty
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function getAmountsOut(
+        uint256 amountIn,
+        // is ignored, can be empty
+        address[] calldata path
+    ) external view returns (uint256[] memory amounts);
+}
+
+/** Small utility contract to swap ETH+ for ETH by redeeming ETH+ and swapping.
+ */
 contract EthPlusIntoEth is IUniswapV2Like {
     using SafeERC20 for IERC20;
 
     IRToken private constant ETH_PLUS = IRToken(0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8);
 
-    IERC20 private constant RETH = IERC20(0xae78736Cd615f374D3085123A210448E74Fc6393);
+    IRETH private constant RETH = IRETH(0xae78736Cd615f374D3085123A210448E74Fc6393);
+
+    IWETH private constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
     IRETHRouter private constant RETH_ROUTER =
         IRETHRouter(0x16D5A408e807db8eF7c578279BEeEe6b228f1c1C);
 
@@ -83,48 +115,81 @@ contract EthPlusIntoEth is IUniswapV2Like {
     IERC20 private constant STETH = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
 
     IERC4626 private constant SFRXETH = IERC4626(0xac3E018457B222d93114458476f3E3416Abbe38F);
-    IERc20 private constant FRXETH = IERc20(0x5E8422345238F34275888049021821E8E08CAa1f);
+    IERC20 private constant FRXETH = IERC20(0x5E8422345238F34275888049021821E8E08CAa1f);
     ICurveETHstETHStableSwap private constant CURVE_ETHSTETH_STABLE_SWAP =
         ICurveETHstETHStableSwap(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
     ICurveStableSwap private constant CURVE_FRXETH_WETH =
         ICurveStableSwap(0x9c3B46C0Ceb5B9e304FCd6D88Fc50f7DD24B31Bc);
 
+    function getETHPlusRedemptionQuantities(uint256 amt) external returns (uint256[] memory) {
+        IBasketHandler handler = ETH_PLUS.main().basketHandler();
+        uint256 supply = ETH_PLUS.totalSupply();
+        (, uint256[] memory quantities) = handler.quote(
+            FixLib.muluDivu(ETH_PLUS.basketsNeeded(), amt, supply, RoundingMode.CEIL),
+            RoundingMode.FLOOR
+        );
+        return quantities;
+    }
+
+    function getAmountsOut(uint256 amountIn, address[] calldata)
+        external
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
+        require(amountIn != 0, "INVALID_AMOUNT_IN");
+        amounts = new uint256[](2);
+        amounts[0] = amountIn;
+
+        IBasketHandler handler = ETH_PLUS.main().basketHandler();
+        (, bytes memory data) = address(this).staticcall(
+            abi.encodeWithSignature("getETHPlusRedemptionQuantities(uint256)", amountIn)
+        );
+        uint256[] memory quantities = abi.decode(data, (uint256[]));
+
+        {
+            amounts[1] += RETH.getEthValue(quantities[2]);
+        }
+
+        {
+            uint256 stEthAmt = WSTETH.getStETHByWstETH(quantities[1]);
+
+            amounts[1] += CURVE_ETHSTETH_STABLE_SWAP.get_dy(1, 0, stEthAmt);
+        }
+
+        {
+            uint256 frxEthAmt = SFRXETH.convertToAssets(quantities[0]);
+            amounts[1] += CURVE_FRXETH_WETH.get_dy(1, 0, frxEthAmt);
+        }
+
+        return amounts;
+    }
+
     function swapExactTokensForETH(
         uint256 amountIn,
         uint256 amountOutMin,
-        // is ignored, but can be empty
+        // is ignored so can be both empty, or token path, or anything
         // solhint-disable-next-line unused-ignore
         address[] calldata,
         address to,
         uint256 deadline
-    ) external returns (uint256[] memory amounts) {
-        require(deadline >= block.timestamp, "deadline");
+    ) external override returns (uint256[] memory amounts) {
+        // solhint-disable-next-line custom-errors
+        require(deadline >= block.timestamp, "DEADLINE");
+        require(to != address(0), "INVALID_TO");
+        require(amountIn != 0, "INVALID_AMOUNT_IN");
         ETH_PLUS.transferFrom(msg.sender, address(this), amountIn);
         ETH_PLUS.redeem(ETH_PLUS.balanceOf(address(this)));
 
         // reth -> eth
-        {
-            uint256 rethBalance = RETH.balanceOf(address(this));
-            (uint256[2] memory portions, uint256 expectedETHOut) = RETH_ROUTER.optimiseSwapFrom(
-                rethBalance,
-                2
-            );
-            RETH.approve(address(rethRouter), rethBalance);
-            RETH_ROUTER.swapFrom(
-                portions[0],
-                portions[1],
-                expectedETHOut,
-                expectedETHOut,
-                rethBalance
-            );
-        }
+        RETH.burn(RETH.balanceOf(address(this)));
 
         // wsteth -> eth
         {
             WSTETH.unwrap(WSTETH.balanceOf(address(this)));
             uint256 stethBalance = STETH.balanceOf(address(this));
             STETH.approve(address(CURVE_ETHSTETH_STABLE_SWAP), stethBalance);
-            CURVE_ETHSTETH_STABLE_SWAP.exchange(1, 0, sfrxethBalance, 0);
+            CURVE_ETHSTETH_STABLE_SWAP.exchange(1, 0, stethBalance, 0);
         }
 
         // sfrxeth -> eth
@@ -135,15 +200,21 @@ contract EthPlusIntoEth is IUniswapV2Like {
             FRXETH.approve(address(CURVE_FRXETH_WETH), frxethBalance);
 
             // frxeth -> weth
-            CURVE_FRXETH_WETH.exchange(1, 0, frxethBalance, 0);
+            CURVE_FRXETH_WETH.exchange(1, 0, frxethBalance, 0, address(this));
 
             // weth -> eth
             WETH.withdraw(WETH.balanceOf(address(this)));
         }
+        amounts = new uint256[](2);
+        amounts[0] = amountIn;
+        amounts[1] = address(this).balance;
 
         // solhint-disable-next-line custom-errors
-        require(this.balance >= amountOutMin, "INSUFFICIENT_OUTPUT_AMOUNT");
-        this.transfer(to, this.balance);
+        require(address(this).balance >= amountOutMin, "INSUFFICIENT_OUTPUT_AMOUNT");
+        (bool success, ) = to.call{ value: address(this).balance }("");
+
+        // solhint-disable-next-line custom-errors
+        require(success, "ETH_TRANSFER_FAILED");
     }
 
     receive() external payable {}

--- a/test/rtoken-redemptions/EthPlusIntoEth.test.ts
+++ b/test/rtoken-redemptions/EthPlusIntoEth.test.ts
@@ -1,0 +1,60 @@
+import { setBalance } from '@nomicfoundation/hardhat-network-helpers'
+import { EthPlusIntoEth } from '@typechain/EthPlusIntoEth'
+import { IERC20 } from '@typechain/IERC20'
+import { formatEther, parseEther } from 'ethers/lib/utils'
+import hardhat, { ethers } from 'hardhat'
+import { whileImpersonating } from '../utils/impersonation'
+import { forkRpcs, Network } from '#/utils/fork'
+import { useEnv } from '#/utils/env'
+import { expect } from 'chai'
+
+describe('EthPlusIntoEth', () => {
+  it('swapExactTokensForETH', async () => {
+    await hardhat.network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: forkRpcs[useEnv('FORK_NETWORK', 'mainnet') as Network],
+            blockNumber: 20190000,
+          },
+        },
+      ],
+    })
+
+    await whileImpersonating('0x7cc1bfab73be4e02bb53814d1059a98cf7e49644', async (signer) => {
+      await setBalance('0x7cc1bfab73be4e02bb53814d1059a98cf7e49644', parseEther('100'))
+
+      const ethPlusToETH: EthPlusIntoEth = (await ethers.deployContract(
+        'EthPlusIntoEth',
+        signer
+      )) as any
+
+      const reth: IERC20 = await ethers.getContractAt(
+        'IERC20Metadata',
+        '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8',
+        signer
+      )
+      await reth.approve(ethPlusToETH.address, ethers.utils.parseEther('1'))
+
+      const simuOutput = await ethPlusToETH.callStatic.getAmountsOut(ethers.utils.parseEther('1'), [], {
+        gasLimit: 10_000_000n,
+      })
+
+      const realOutput = await ethPlusToETH.callStatic.swapExactTokensForETH(
+        ethers.utils.parseEther('1'),
+        0,
+        [],
+        '0x7cc1bfab73be4e02bb53814d1059a98cf7e49644',
+        Math.floor(Date.now() / 1000) + 10000,
+        {
+          gasLimit: 10_000_000n,
+        }
+      )
+      
+      expect(
+        Math.abs(parseFloat(formatEther(simuOutput[1].sub(realOutput[1]))))
+      ).to.be.lt(0.00001)
+    })
+  })
+})


### PR DESCRIPTION
I'm not entirely sure where this would fit in so i'm pushing it here for now.

This script will redeem ETH+ directly for ETH and follows an interview that mimicks uniswap v2. It only works for ETH+ into ETH, it actually performs relatively well for smaller amounts at least ignoring gas costs.

Perhaps this could make a sort of routers part of the `Facade`, and add a few predefined and maintained ways to exit an RToken position into a single underlying? @tbrent 