### PR TITLE
fix revenue hiding test

### DIFF
--- a/test/plugins/individual-collateral/mountain/USDMCollateral.test.ts
+++ b/test/plugins/individual-collateral/mountain/USDMCollateral.test.ts
@@ -204,7 +204,7 @@ const collateralSpecificStatusTests = () => {
     const [, alice] = await ethers.getSigners()
     const tempCtx = await makeCollateralFixtureContext(alice, {
       erc20: ARB_WUSDM,
-      revenueHiding: fp('0.01'),
+      revenueHiding: fp('0.0101'),
     })()
 
     // Set correct price to maintain peg


### PR DESCRIPTION
Add a little buffer to the revenue hiding test just like we did with all the other plugins