### PR TITLE
issuance premium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ TODO
 
 Make sure distributor table sums to >10000.
 
+Upgrade ALL collateral plugins
+
 ## Core Protocol Contracts
 
 - `AssetRegistry`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This release prepares the core protocol for veRSR through the introduction of 3 
 
 The release also expands collateral decimal support from 18 to 21, with some caveats about minimum token value. See [docs/solidity-style.md](./docs/solidity-style.md#Collateral-decimals) for more details.
 
+Finally, it adds resistance to toxic issuance by charging more when the collateral is under peg. This has the side-effect of also creating a new revenue source.
+
 ## Upgrade Steps
 
 TODO
@@ -15,10 +17,14 @@ Make sure distributor table sums to >10000.
 ## Core Protocol Contracts
 
 - `AssetRegistry`
+
   - Prevent registering assets that are not in the `AssetPluginRegistry`
   - Add `validateCurrentAssets() view`
+
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
+- `BasketHandler`
+  - Increase `quote()` quantities during issuance when collateral is under peg
 - `Broker`
   - Make setters only callable by `Main`
 - `Distributor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Upgrade ALL collateral plugins
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
-  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens
+  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens, up to 50%
   - Remove `lotPrice()`
 - `Broker`
   - Make setters only callable by `Main`
@@ -47,6 +47,7 @@ Upgrade ALL collateral plugins
 - Support expanded from 18 to 21 decimals, with minimum collateral token value requirement of `$0.001` at-peg.
 - FLOOR rounding added explicitly to `shiftl_toFix`
 - Remove lotPrice()
+- Set a minimum default threshold of 70%
 
 ### Trading
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Make sure distributor table sums to >10000.
 - Remove lotPrice()
 - Set a minimum default threshold of 70%
 
+#### Collateral
+
+Add `savedPegPrice` to `ICollateral` interface
+
 ### Trading
 
 - `GnosisTrade`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Upgrade ALL collateral plugins
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
-  - Increase `quote()` quantities during issuance when collateral is under peg
+  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens
   - Remove `lotPrice()`
 - `Broker`
   - Make setters only callable by `Main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ TODO
 
 Make sure distributor table sums to >10000.
 
-Upgrade ALL collateral plugins
+All collateral plugins _must_ be upgraded to use 4.0.0. It is the responsibility of the upgrade spell (todo) to ensure that upgrades to 4.0.0 revert if any of the registered collateral at end of execution are <4.0.0.
 
 ## Core Protocol Contracts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Make sure distributor table sums to >10000.
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
   - Increase `quote(, CEIL)` quantities during issuance to include an issuance premium for de-pegged tokens
+  - Add `issuancePremium() view returns (uint192)`
   - Add `setIssuancePremiumEnabled(bool)`, callable by governance
   - Remove `lotPrice()`
 - `Broker`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Upgrade ALL collateral plugins
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
-  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens, up to 50%
+  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens
+  - Add `setSkipIssunancePremium()`, callable by governance
   - Remove `lotPrice()`
 - `Broker`
   - Make setters only callable by `Main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ Upgrade ALL collateral plugins
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
-  - Increase `quote()` quantities during issuance to include an issuance premium for de-pegged tokens
-  - Add `setSkipIssunancePremium()`, callable by governance
+  - Increase `quote(, CEIL)` quantities during issuance to include an issuance premium for de-pegged tokens
+  - Add `setIssuancePremiumEnabled(bool)`, callable by governance
   - Remove `lotPrice()`
 - `Broker`
   - Make setters only callable by `Main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ TODO
 
 Make sure distributor table sums to >10000.
 
-All collateral plugins _must_ be upgraded to use 4.0.0. It is the responsibility of the upgrade spell (todo) to ensure that upgrades to 4.0.0 revert if any of the registered collateral at end of execution are <4.0.0.
-
 ## Core Protocol Contracts
 
 - `AssetRegistry`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Upgrade ALL collateral plugins
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`
   - Increase `quote()` quantities during issuance when collateral is under peg
+  - Remove `lotPrice()`
 - `Broker`
   - Make setters only callable by `Main`
 - `Distributor`
@@ -43,9 +44,9 @@ Upgrade ALL collateral plugins
 
 ### Assets
 
-No functional change. FLOOR rounding added explicitly to `shiftl_toFix`.
-
-Support expanded from 18 to 21 decimals, with minimum collateral token value requirement of `$0.001` at-peg.
+- Support expanded from 18 to 21 decimals, with minimum collateral token value requirement of `$0.001` at-peg.
+- FLOOR rounding added explicitly to `shiftl_toFix`
+- Remove lotPrice()
 
 ### Trading
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,8 @@ Make sure distributor table sums to >10000.
 ## Core Protocol Contracts
 
 - `AssetRegistry`
-
   - Prevent registering assets that are not in the `AssetPluginRegistry`
   - Add `validateCurrentAssets() view`
-
 - `BackingManager`
   - Switch from sizing trades using the low price to the high price
 - `BasketHandler`

--- a/contracts/facade/facets/ReadFacet.sol
+++ b/contracts/facade/facets/ReadFacet.sol
@@ -178,7 +178,7 @@ contract ReadFacet {
         // solhint-disable-next-line no-empty-blocks
         try rToken.main().furnace().melt() {} catch {} // <3.1.0 RTokens may revert while frozen
 
-        (erc20s, deposits) = basketHandler.quote(FIX_ONE, CEIL);
+        (erc20s, deposits) = basketHandler.quote(FIX_ONE, FLOOR);
 
         // Calculate uoaAmts
         uint192 uoaSum;

--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -107,7 +107,7 @@ interface ICollateral is IAsset {
 
     /// @dev refresh()
     /// Refresh exchange rates and update default status.
-    /// VERY IMPORTANT: In any valid implemntation, status() MUST become DISABLED in refresh() if
+    /// VERY IMPORTANT: In any valid implementation, status() MUST become DISABLED in refresh() if
     /// refPerTok() has ever decreased since last call.
 
     /// @return The canonical name of this collateral's target unit.

--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -130,6 +130,9 @@ interface ICollateral is IAsset {
 
     /// @return {target/ref} Quantity of whole target units per whole reference unit in the peg
     function targetPerRef() external view returns (uint192);
+
+    /// @return {target/ref} The peg price of the token during the last update
+    function savedPegPrice() external view returns (uint192);
 }
 
 // Used only in Testing. Strictly speaking a Collateral does not need to adhere to this interface

--- a/contracts/interfaces/IAsset.sol
+++ b/contracts/interfaces/IAsset.sol
@@ -32,13 +32,6 @@ interface IAsset is IRewardable {
     /// @return high {UoA/tok} The upper end of the price estimate
     function price() external view returns (uint192 low, uint192 high);
 
-    /// Should not revert
-    /// lotLow should be nonzero when the asset might be worth selling
-    /// @dev Deprecated. Phased out in 3.1.0, but left on interface for backwards compatibility
-    /// @return lotLow {UoA/tok} The lower end of the lot price estimate
-    /// @return lotHigh {UoA/tok} The upper end of the lot price estimate
-    function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh);
-
     /// @return {tok} The balance of the ERC20 in whole tokens
     function bal(address account) external view returns (uint192);
 

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -110,6 +110,7 @@ interface IBasketHandler is IComponent {
     /// @return If the basket is ready to issue and trade
     function isReady() external view returns (bool);
 
+    /// Returns basket quantity rounded up, wihout any issuance premium
     /// @param erc20 The ERC20 token contract for the asset
     /// @return {tok/BU} The redemption quantity of token in the reference basket
     /// Returns 0 if erc20 is not registered or not in the basket
@@ -117,6 +118,7 @@ interface IBasketHandler is IComponent {
     /// Otherwise, returns (token's basket.refAmts / token's Collateral.refPerTok())
     function quantity(IERC20 erc20) external view returns (uint192);
 
+    /// Returns basket quantity rounded up, wihout any issuance premium
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -44,8 +44,8 @@ interface IBasketHandler is IComponent {
     event WarmupPeriodSet(uint48 oldVal, uint48 newVal);
 
     /// Emitted when the issuance premium logic is changed
-    /// @param oldVal The old value of issuancePremiumDisabled
-    /// @param newVal The new value of issuancePremiumDisabled
+    /// @param oldVal The old value of skipIssuancePremium
+    /// @param newVal The new value of skipIssuancePremium
     event SkipIssuancePremiumSet(bool oldVal, bool newVal);
 
     /// Emitted when the status of a basket has changed

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -190,4 +190,8 @@ interface TestIBasketHandler is IBasketHandler {
     function warmupPeriod() external view returns (uint48);
 
     function setWarmupPeriod(uint48 val) external;
+
+    function skipIssuancePremium() external view returns (bool);
+
+    function setSkipIssuancePremium(bool val) external;
 }

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -111,7 +111,7 @@ interface IBasketHandler is IComponent {
     function isReady() external view returns (bool);
 
     /// @param erc20 The ERC20 token contract for the asset
-    /// @return {tok/BU} The whole token quantity of token in the reference basket
+    /// @return {tok/BU} The redemption quantity of token in the reference basket
     /// Returns 0 if erc20 is not registered or not in the basket
     /// Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     /// Otherwise, returns (token's basket.refAmts / token's Collateral.refPerTok())
@@ -120,7 +120,7 @@ interface IBasketHandler is IComponent {
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20
-    /// @return {tok/BU} The whole token quantity of token in the reference basket
+    /// @return {tok/BU} The redemption quantity of token in the reference basket
     /// Returns 0 if erc20 is not registered or not in the basket
     /// Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     /// Otherwise, returns (token's basket.refAmts / token's Collateral.refPerTok())

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -112,7 +112,7 @@ interface IBasketHandler is IComponent {
 
     /// Returns basket quantity rounded up, wihout any issuance premium
     /// @param erc20 The ERC20 token contract for the asset
-    /// @return {tok/BU} The redemption quantity of token in the reference basket
+    /// @return {tok/BU} The redemption quantity of token in the reference basket, rounded up
     /// Returns 0 if erc20 is not registered or not in the basket
     /// Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     /// Otherwise, returns (token's basket.refAmts / token's Collateral.refPerTok())
@@ -122,7 +122,7 @@ interface IBasketHandler is IComponent {
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20
-    /// @return {tok/BU} The redemption quantity of token in the reference basket
+    /// @return {tok/BU} The redemption quantity of token in the reference basket, rounded up
     /// Returns 0 if erc20 is not registered or not in the basket
     /// Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     /// Otherwise, returns (token's basket.refAmts / token's Collateral.refPerTok())

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -193,5 +193,5 @@ interface TestIBasketHandler is IBasketHandler {
 
     function skipIssuancePremium() external view returns (bool);
 
-    function setSkipIssuancePremium(bool val) external;
+    function setIssuancePremiumEnabled(bool val) external;
 }

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -156,13 +156,6 @@ interface IBasketHandler is IComponent {
     /// @return high {UoA/BU} The upper end of the price estimate
     function price() external view returns (uint192 low, uint192 high);
 
-    /// Should not revert
-    /// lotLow should be nonzero if a BU could be worth selling
-    /// @dev Deprecated. Phased out in 3.1.0, but left on interface for backwards compatibility
-    /// @return lotLow {UoA/tok} The lower end of the lot price estimate
-    /// @return lotHigh {UoA/tok} The upper end of the lot price estimate
-    function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh);
-
     /// @return timestamp The timestamp at which the basket was last set
     function timestamp() external view returns (uint48);
 

--- a/contracts/interfaces/IBasketHandler.sol
+++ b/contracts/interfaces/IBasketHandler.sol
@@ -43,6 +43,11 @@ interface IBasketHandler is IComponent {
     /// @param newVal The new warmup period
     event WarmupPeriodSet(uint48 oldVal, uint48 newVal);
 
+    /// Emitted when the issuance premium logic is changed
+    /// @param oldVal The old value of issuancePremiumDisabled
+    /// @param newVal The new value of issuancePremiumDisabled
+    event SkipIssuancePremiumSet(bool oldVal, bool newVal);
+
     /// Emitted when the status of a basket has changed
     /// @param oldStatus The previous basket status
     /// @param newStatus The new basket status

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -406,6 +406,22 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         return _quantity(erc20, ICollateral(address(asset)), false, CEIL);
     }
 
+    /// @return {1} The multiplier to charge on issuance quantities for a collateral
+    function issuancePremium(ICollateral coll) public view returns (uint192) {
+        if (skipIssuancePremium || coll.lastSave() != block.timestamp) return FIX_ONE;
+
+        // on arbitrum the timestamp check doesn't give us exactly what we want
+        // but it's close and better than wasting more gas on calling tryPrice()
+
+        uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
+        if (pegPrice == 0) return FIX_ONE;
+        uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
+        if (pegPrice >= targetPerRef) return FIX_ONE;
+
+        // {tok} = {target/ref} / {target/ref}
+        return targetPerRef.safeDiv(pegPrice, CEIL);
+    }
+
     /// @param erc20 The token contract
     /// @param coll The registered collateral plugin contract
     /// @param applyIssuancePremium Whether to apply an issuance premium to the quantity
@@ -426,14 +442,11 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         q = basket.refAmts[erc20].div(refPerTok, rounding);
 
         // Prevent toxic issuance by charging more when collateral is under peg
-        if (!skipIssuancePremium && applyIssuancePremium && coll.lastSave() == block.timestamp) {
-            uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
-            if (pegPrice == 0) return q;
-            uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
-            if (pegPrice >= targetPerRef) return q;
+        if (applyIssuancePremium) {
+            uint192 premium = issuancePremium(coll); // {1} CEIL
 
-            // {tok} = {tok} * {target/ref} / {target/ref}
-            q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
+            // {tok/BU} = {tok/BU} * {1}
+            if (premium > FIX_ONE) q = q.safeMul(premium, rounding);
         }
     }
 

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -406,7 +406,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         return _quantity(erc20, ICollateral(address(asset)), false, CEIL);
     }
 
-    /// @dev The maximum issuance premium that can be applied is 50%
     /// @param erc20 The token contract
     /// @param coll The registered collateral plugin contract
     /// @param applyIssuancePremium Whether to apply an issuance premium to the quantity
@@ -433,14 +432,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
             if (pegPrice >= targetPerRef) return q;
 
-            // at this point: pegPrice > 0 && pegPrice < targetPerRef
-            if (pegPrice * 3 > targetPerRef * 2) {
-                // {tok} = {tok} * {target/ref} / {target/ref}
-                q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
-            } else {
-                // largest issuance premium possible is 50%
-                q = q + q.divu(2, CEIL);
-            }
+            // {tok} = {tok} * {target/ref} / {target/ref}
+            q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
         }
     }
 

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -447,8 +447,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
             try main.assetRegistry().toColl(basket.erc20s[i]) returns (ICollateral coll) {
-                uint192 lowQ = _quantity(basket.erc20s[i], coll, false, FLOOR); // redemption quantity
-                uint192 highQ = _quantity(basket.erc20s[i], coll, true, CEIL); // issuance quantity
+                uint192 lowQ = _quantity(basket.erc20s[i], coll, false, FLOOR); // redemption
+                uint192 highQ = _quantity(basket.erc20s[i], coll, true, CEIL); // issuance
 
                 (uint192 lowP, uint192 highP) = reg.toAsset(basket.erc20s[i]).price();
 

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -377,6 +377,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             (block.timestamp >= lastStatusTimestamp + warmupPeriod);
     }
 
+    /// Returns basket quantity rounded up, wihout any issuance premium
     /// @param erc20 The token contract to check for quantity for
     /// @return {tok/BU} The redemption token-quantity of an ERC20 token in the basket.
     // Returns 0 if erc20 is not registered or not in the basket
@@ -384,12 +385,13 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
     function quantity(IERC20 erc20) public view returns (uint192) {
         try main.assetRegistry().toColl(erc20) returns (ICollateral coll) {
-            return _quantity(erc20, coll, FLOOR);
+            return _quantity(erc20, coll, false, CEIL);
         } catch {
             return FIX_ZERO;
         }
     }
 
+    /// Returns basket quantity rounded up, wihout any issuance premium
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20
@@ -399,19 +401,20 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
     function quantityUnsafe(IERC20 erc20, IAsset asset) public view returns (uint192) {
         if (!asset.isCollateral()) return FIX_ZERO;
-        return _quantity(erc20, ICollateral(address(asset)), FLOOR);
+        return _quantity(erc20, ICollateral(address(asset)), false, CEIL);
     }
 
-    /// @dev If rounding is CEIL the quantity will include a de-peg premium
     /// @param erc20 The token contract
     /// @param coll The registered collateral plugin contract
-    /// @return q {tok/BU} The token-quantity of an ERC20 token in the basket.
+    /// @param applyIssuancePremium Whether to apply an issuance premium to the quantity
+    /// @return q {tok/BU} The token-quantity of an ERC20 token in the basket
     // Returns 0 if coll is not in the basket
     // Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
     function _quantity(
         IERC20 erc20,
         ICollateral coll,
+        bool applyIssuancePremium,
         RoundingMode rounding
     ) internal view returns (uint192 q) {
         uint192 refPerTok = coll.refPerTok();
@@ -421,15 +424,12 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         q = basket.refAmts[erc20].div(refPerTok, rounding);
 
         // Prevent toxic issuance by charging more when collateral is under peg
-        if (rounding == CEIL && coll.lastSave() == block.timestamp) {
-            // on arbitrum the timestamp check doesn't give us exactly what we want
-            // but it's close and better than wasting more gas on calling tryPrice()
-
+        if (applyIssuancePremium && coll.lastSave() == block.timestamp) {
             uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
             uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
             if (pegPrice != 0 && pegPrice < targetPerRef) {
                 // {tok} = {tok} * {target/ref} / {target/ref}
-                q = q.safeMulDiv(targetPerRef, pegPrice, CEIL);
+                q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
             }
         }
     }
@@ -447,8 +447,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
         for (uint256 i = 0; i < basket.erc20s.length; i++) {
             try main.assetRegistry().toColl(basket.erc20s[i]) returns (ICollateral coll) {
-                uint192 lowQ = _quantity(basket.erc20s[i], coll, FLOOR); // redemption quantity
-                uint192 highQ = _quantity(basket.erc20s[i], coll, CEIL); // issuance quantity
+                uint192 lowQ = _quantity(basket.erc20s[i], coll, false, FLOOR); // redemption quantity
+                uint192 highQ = _quantity(basket.erc20s[i], coll, true, CEIL); // issuance quantity
 
                 (uint192 lowP, uint192 highP) = reg.toAsset(basket.erc20s[i]).price();
 
@@ -472,6 +472,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     }
 
     /// Return the current issuance/redemption value of `amount` BUs
+    /// @param rounding RoundingMode.FLOOR or RoundingMode.CEIL for Redemption vs Issuance
     /// @param amount {BU}
     /// @return erc20s The backing collateral erc20s
     /// @return quantities {qTok} ERC20 token quantities equal to `amount` BUs
@@ -481,6 +482,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         view
         returns (address[] memory erc20s, uint256[] memory quantities)
     {
+        require(rounding != ROUND, "FLOOR or CEIL");
         IAssetRegistry assetRegistry = main.assetRegistry();
         erc20s = new address[](basket.erc20s.length);
         quantities = new uint256[](basket.erc20s.length);
@@ -490,7 +492,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             ICollateral coll = assetRegistry.toColl(IERC20(erc20s[i]));
 
             // {qTok} = {tok/BU} * {BU} * {qTok/tok}
-            quantities[i] = _quantity(basket.erc20s[i], coll, rounding)
+            quantities[i] = _quantity(basket.erc20s[i], coll, rounding == CEIL, rounding)
             .safeMul(amount, rounding)
             .shiftl_toUint(int8(IERC20Metadata(address(basket.erc20s[i])).decimals()), rounding);
         }
@@ -594,14 +596,9 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             ICollateral coll = main.assetRegistry().toColl(basket.erc20s[i]);
             if (coll.status() == CollateralStatus.DISABLED) return BasketRange(FIX_ZERO, FIX_MAX);
 
-            uint192 refPerTok = coll.refPerTok();
-            // If refPerTok is 0, then we have zero of coll's reference unit.
-            // We know that basket.refAmts[basket.erc20s[i]] > 0, so we have no baskets.
-            if (refPerTok == 0) return BasketRange(FIX_ZERO, FIX_MAX);
-
-            // {tok/BU} = {ref/BU} / {ref/tok}.  0-division averted by condition above.
-            uint192 q = basket.refAmts[basket.erc20s[i]].div(refPerTok, CEIL);
-            // q > 0 because q = (n).div(_, CEIL) and n > 0
+            // {tok/BU}
+            uint192 q = _quantity(basket.erc20s[i], coll, false, CEIL);
+            if (q == FIX_MAX) return BasketRange(FIX_ZERO, FIX_MAX);
 
             // {BU} = {tok} / {tok/BU}
             uint192 inBUs = coll.bal(account).div(q);

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -499,7 +499,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
 
                 uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
-                if ((rounding == CEIL && pegPrice < targetPerRef)) {
+                if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
                     amt = amt.mulDiv(targetPerRef, pegPrice, rounding);
                 }

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -409,10 +409,6 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     /// @return {1} The multiplier to charge on issuance quantities for a collateral
     function issuancePremium(ICollateral coll) public view returns (uint192) {
         if (skipIssuancePremium || coll.lastSave() != block.timestamp) return FIX_ONE;
-
-        // on arbitrum the timestamp check doesn't give us exactly what we want
-        // but it's close and better than wasting more gas on calling tryPrice()
-
         uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
         if (pegPrice == 0) return FIX_ONE;
         uint192 targetPerRef = coll.targetPerRef(); // {target/ref}

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -309,8 +309,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             // This is a nice catch to have, but in general it is possible for
             // an ERC20 in the prime basket to have its asset unregistered.
             require(reg.toAsset(erc20s[i]).isCollateral(), "erc20 is not collateral");
-            require(0 < targetAmts[i], "invalid target amount; must be nonzero");
-            require(targetAmts[i] <= MAX_TARGET_AMT, "invalid target amount; too large");
+            require(0 < targetAmts[i], "invalid target amount");
+            require(targetAmts[i] <= MAX_TARGET_AMT, "invalid target amount");
 
             config.erc20s.push(erc20s[i]);
             config.targetAmts[erc20s[i]] = targetAmts[i];

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -501,7 +501,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
                 if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
-                    amt = amt.mulDiv(targetPerRef, pegPrice, rounding);
+                    amt = amt.mulDiv(targetPerRef, pegPrice, CEIL);
                 }
             }
             // else: only use defi rates

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -631,10 +631,11 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         warmupPeriod = val;
     }
 
+    /// @dev Warning: Parameter gets supplied inverted from the variable it sets
     /// @custom:governance
-    function setSkipIssuancePremium(bool val) public governance {
-        emit SkipIssuancePremiumSet(skipIssuancePremium, val);
-        skipIssuancePremium = val;
+    function setIssuancePremiumEnabled(bool val) public governance {
+        emit SkipIssuancePremiumSet(skipIssuancePremium, !val);
+        skipIssuancePremium = !val;
     }
 
     /* _switchBasket computes basket' from three inputs:

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -377,7 +377,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
             (block.timestamp >= lastStatusTimestamp + warmupPeriod);
     }
 
-    /// Returns basket quantity rounded up, wihout any issuance premium
+    /// Basket quantity rounded up, without any issuance premium
     /// @param erc20 The token contract to check for quantity for
     /// @return {tok/BU} The redemption token-quantity of an ERC20 token in the basket.
     // Returns 0 if erc20 is not registered or not in the basket
@@ -391,7 +391,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         }
     }
 
-    /// Returns basket quantity rounded up, wihout any issuance premium
+    /// Basket quantity rounded up, without any issuance premium
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -153,6 +153,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
     // Whether the total weights of the target basket can be changed
     bool public reweightable; // immutable after init
 
+    bool public skipIssuancePremium;
+
     // ==== Invariants ====
     // basket is a valid Basket:
     //   basket.erc20s is a valid collateral array and basket.erc20s == keys(basket.refAmts)
@@ -614,6 +616,12 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         require(val >= MIN_WARMUP_PERIOD && val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
         emit WarmupPeriodSet(warmupPeriod, val);
         warmupPeriod = val;
+    }
+
+    /// @custom:governance
+    function setSkipIssuancePremium(bool val) public governance {
+        emit SkipIssuancePremiumSet(skipIssuancePremium, val);
+        skipIssuancePremium = val;
     }
 
     /* _switchBasket computes basket' from three inputs:

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -335,8 +335,8 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         uint256 max,
         IERC20[] calldata erc20s
     ) external governance {
-        require(max <= MAX_BACKUP_ERC20S, "max too large");
-        require(erc20s.length <= MAX_BACKUP_ERC20S, "erc20s too large");
+        require(max <= MAX_BACKUP_ERC20S, "too large");
+        require(erc20s.length <= MAX_BACKUP_ERC20S, "too large");
         requireValidCollArray(erc20s);
         BackupConfig storage conf = config.backups[targetName];
         conf.max = max;
@@ -526,7 +526,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
         uint192[] memory portions,
         uint192 amount
     ) external view returns (address[] memory erc20s, uint256[] memory quantities) {
-        require(basketNonces.length == portions.length, "bad portions len");
+        require(basketNonces.length == portions.length, "invalid lengths");
 
         IERC20[] memory erc20sAll = new IERC20[](main.assetRegistry().size());
         ICollateral[] memory collsAll = new ICollateral[](erc20sAll.length);

--- a/contracts/p0/BasketHandler.sol
+++ b/contracts/p0/BasketHandler.sol
@@ -501,7 +501,7 @@ contract BasketHandlerP0 is ComponentP0, IBasketHandler {
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
                 if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
-                    amt = amt.mulDiv(targetPerRef, pegPrice, CEIL);
+                    amt = amt.safeMulDiv(targetPerRef, pegPrice, CEIL);
                 }
             }
             // else: only use defi rates

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -236,6 +236,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         for (uint256 i = 0; i < length; ++i) {
             IAsset asset = assetRegistry.toAsset(erc20s[i]);
 
+            // Use same quantity-rounding as BasketHandler.basketsHeldBy()
             // {tok} = {BU} * {tok/BU}
             uint192 req = needed.mul(basketHandler.quantity(erc20s[i]), CEIL);
             uint192 bal = asset.bal(address(this));

--- a/contracts/p1/BackingManager.sol
+++ b/contracts/p1/BackingManager.sol
@@ -287,6 +287,7 @@ contract BackingManagerP1 is TradingP1, IBackingManager {
         ctx.quantities = new uint192[](reg.erc20s.length);
         for (uint256 i = 0; i < reg.erc20s.length; ++i) {
             ctx.quantities[i] = basketHandler.quantityUnsafe(reg.erc20s[i], reg.assets[i]);
+            // quantities round up, without any issuance premium
         }
         ctx.bals = new uint192[](reg.erc20s.length);
         for (uint256 i = 0; i < reg.erc20s.length; ++i) {

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -339,9 +339,9 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             (block.timestamp >= lastStatusTimestamp + warmupPeriod);
     }
 
-    /// Returns basket quantity rounded up, wihout any issuance premium
+    /// Basket quantity rounded up, without any issuance premium
     /// @param erc20 The token contract to check for quantity for
-    /// @return {tok/BU} The redemption token-quantity of an ERC20 token in the basket.
+    /// @return {tok/BU} The token-quantity of an ERC20 token in the basket.
     // Returns 0 if erc20 is not registered or not in the basket
     // Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
@@ -353,7 +353,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         }
     }
 
-    /// Returns basket quantity rounded up, wihout any issuance premium
+    /// Basket quantity rounded up, without any issuance premium
     /// Like quantity(), but unsafe because it DOES NOT CONFIRM THAT THE ASSET IS CORRECT
     /// @param erc20 The ERC20 token contract for the asset
     /// @param asset The registered asset plugin contract for the erc20

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -368,6 +368,8 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
     /// @return {1} The multiplier to charge on issuance quantities for a collateral
     function issuancePremium(ICollateral coll) public view returns (uint192) {
+        // `coll` does not need validation
+
         if (skipIssuancePremium || coll.lastSave() != block.timestamp) return FIX_ONE;
         // on arbitrum the timestamp check doesn't give us exactly what we want
         // but it's close and better than wasting more gas on calling tryPrice()

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -89,6 +89,9 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     uint48 public lastCollateralized; // {basketNonce} most recent full collateralization
 
     // ===
+    // Added in 4.0.0
+
+    bool public skipIssuancePremium;
 
     // ==== Invariants ====
     // basket is a valid Basket:
@@ -386,7 +389,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         q = basket.refAmts[erc20].div(refPerTok, rounding);
 
         // Prevent toxic issuance by charging more when collateral is under peg
-        if (applyIssuancePremium && coll.lastSave() == block.timestamp) {
+        if (!skipIssuancePremium && applyIssuancePremium && coll.lastSave() == block.timestamp) {
             // on arbitrum the timestamp check doesn't give us exactly what we want
             // but it's close and better than wasting more gas on calling tryPrice()
 
@@ -590,6 +593,13 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         require(val >= MIN_WARMUP_PERIOD && val <= MAX_WARMUP_PERIOD, "invalid warmupPeriod");
         emit WarmupPeriodSet(warmupPeriod, val);
         warmupPeriod = val;
+    }
+
+    /// @custom:governance
+    function setSkipIssuancePremium(bool val) public {
+        requireGovernanceOnly();
+        emit SkipIssuancePremiumSet(skipIssuancePremium, val);
+        skipIssuancePremium = val;
     }
 
     // === Private ===

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -370,7 +370,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     /// @return {1} The multiplier to charge on issuance quantities for a collateral
     function issuancePremium(ICollateral coll) public view returns (uint192) {
         if (skipIssuancePremium || coll.lastSave() != block.timestamp) return FIX_ONE;
-
         // on arbitrum the timestamp check doesn't give us exactly what we want
         // but it's close and better than wasting more gas on calling tryPrice()
 

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -559,7 +559,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     ///          .top The number of partial basket units: e.g max(coll.map((c) => c.balAsBUs())
     ///          .bottom The number of whole basket units held by the account
     /// @dev Returns (FIX_ZERO, FIX_MAX) for an empty or DISABLED basket
-    /// @dev Even if a collateral is de-pegged, the upper price
     // Returns:
     //    (0, 0), if (basket.erc20s is empty) or (disabled is true) or (status() is DISABLED)
     //    min(e.balanceOf(account) / quantity(e) for e in basket.erc20s if quantity(e) > 0),

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -292,8 +292,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         IERC20[] calldata erc20s
     ) external {
         requireGovernanceOnly();
-        require(max <= MAX_BACKUP_ERC20S, "max too large");
-        require(erc20s.length <= MAX_BACKUP_ERC20S, "erc20s too large");
+        require(max <= MAX_BACKUP_ERC20S && erc20s.length <= MAX_BACKUP_ERC20S, "too large");
         requireValidCollArray(erc20s);
         BackupConfig storage conf = config.backups[targetName];
         conf.max = max;
@@ -493,7 +492,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         uint192[] memory portions,
         uint192 amount
     ) external view returns (address[] memory erc20s, uint256[] memory quantities) {
-        require(basketNonces.length == portions.length, "bad portions len");
+        require(basketNonces.length == portions.length, "invalid lengths");
 
         IERC20[] memory erc20sAll = new IERC20[](assetRegistry.size());
         ICollateral[] memory collsAll = new ICollateral[](erc20sAll.length);

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -602,11 +602,12 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         warmupPeriod = val;
     }
 
+    /// @dev Warning: Parameter gets supplied inverted from the variable it sets
     /// @custom:governance
-    function setSkipIssuancePremium(bool val) public {
+    function setIssuancePremiumEnabled(bool val) public {
         requireGovernanceOnly();
-        emit SkipIssuancePremiumSet(skipIssuancePremium, val);
-        skipIssuancePremium = val;
+        emit SkipIssuancePremiumSet(skipIssuancePremium, !val);
+        skipIssuancePremium = !val;
     }
 
     // === Private ===

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -408,9 +408,8 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         }
     }
 
-    /// Returns the price of a BU
+    /// Returns the price of a BU, including any issuance premium in the high price
     /// Should not revert
-    /// Not symmetric! Takes issuance premium into account for CEIL rounding
     /// @return low {UoA/BU} The lower end of the price estimate
     /// @return high {UoA/BU} The upper end of the price estimate
     // returns sum(quantity(erc20) * price(erc20) for erc20 in basket.erc20s)

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -340,13 +340,13 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     }
 
     /// @param erc20 The token contract to check for quantity for
-    /// @return {tok/BU} The token-quantity of an ERC20 token in the basket.
+    /// @return {tok/BU} The redemption token-quantity of an ERC20 token in the basket.
     // Returns 0 if erc20 is not registered or not in the basket
     // Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
     function quantity(IERC20 erc20) public view returns (uint192) {
         try assetRegistry.toColl(erc20) returns (ICollateral coll) {
-            return _quantity(erc20, coll, CEIL);
+            return _quantity(erc20, coll, FLOOR);
         } catch {
             return FIX_ZERO;
         }
@@ -361,7 +361,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
     function quantityUnsafe(IERC20 erc20, IAsset asset) public view returns (uint192) {
         if (!asset.isCollateral()) return FIX_ZERO;
-        return _quantity(erc20, ICollateral(address(asset)), CEIL);
+        return _quantity(erc20, ICollateral(address(asset)), FLOOR);
     }
 
     /// @param erc20 The token contract
@@ -388,7 +388,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
             uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
             uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
-            if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
+            if (pegPrice != 0 && pegPrice < targetPerRef) {
                 // {tok} = {tok} * {target/ref} / {target/ref}
                 q = q.safeMulDiv(targetPerRef, pegPrice, CEIL);
             }
@@ -423,21 +423,25 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
         uint256 len = basket.erc20s.length;
         for (uint256 i = 0; i < len; ++i) {
-            uint192 qty = quantity(basket.erc20s[i]); // CEIL rounding
-            if (qty == 0) continue;
+            try assetRegistry.toColl(basket.erc20s[i]) returns (ICollateral coll) {
+                uint192 lowQ = _quantity(basket.erc20s[i], coll, FLOOR); // redemption quantity
+                uint192 highQ = _quantity(basket.erc20s[i], coll, CEIL); // issuance quantity
 
-            (uint192 lowP, uint192 highP) = useLotPrice
-                ? assetRegistry.toAsset(basket.erc20s[i]).lotPrice()
-                : assetRegistry.toAsset(basket.erc20s[i]).price();
+                (uint192 lowP, uint192 highP) = useLotPrice
+                    ? assetRegistry.toAsset(basket.erc20s[i]).lotPrice()
+                    : assetRegistry.toAsset(basket.erc20s[i]).price();
 
-            low256 += qty.safeMul(lowP, RoundingMode.FLOOR);
+                low256 += lowQ.safeMul(lowP, RoundingMode.FLOOR);
 
-            if (high256 < FIX_MAX) {
-                if (highP == FIX_MAX) {
-                    high256 = FIX_MAX;
-                } else {
-                    high256 += qty.safeMul(highP, RoundingMode.CEIL);
+                if (high256 < FIX_MAX) {
+                    if (highP == FIX_MAX) {
+                        high256 = FIX_MAX;
+                    } else {
+                        high256 += highQ.safeMul(highP, RoundingMode.CEIL);
+                    }
                 }
+            } catch {
+                continue;
             }
         }
 

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -463,7 +463,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
                 uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
-                if ((rounding == CEIL && pegPrice < targetPerRef)) {
+                if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
                     amt = amt.mulDiv(targetPerRef, pegPrice, rounding);
                 }

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -367,7 +367,6 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         return _quantity(erc20, ICollateral(address(asset)), false, CEIL);
     }
 
-    /// @dev The maximum issuance premium that can be applied is 50%
     /// @param erc20 The token contract
     /// @param coll The registered collateral plugin contract
     /// @param applyIssuancePremium Whether to apply an issuance premium to the quantity
@@ -397,14 +396,8 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
             if (pegPrice >= targetPerRef) return q;
 
-            // at this point: pegPrice > 0 && pegPrice < targetPerRef
-            if (pegPrice * 3 > targetPerRef * 2) {
-                // {tok} = {tok} * {target/ref} / {target/ref}
-                q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
-            } else {
-                // largest issuance premium possible is 50%
-                q = q + q.divu(2, CEIL);
-            }
+            // {tok} = {tok} * {target/ref} / {target/ref}
+            q = q.safeMulDiv(targetPerRef, pegPrice, rounding);
         }
     }
 

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -453,10 +453,28 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             erc20s[i] = address(basket.erc20s[i]);
             ICollateral coll = assetRegistry.toColl(IERC20(erc20s[i]));
 
-            // {qTok} = {tok/BU} * {BU} * {tok} * {qTok/tok}
-            quantities[i] = _quantity(basket.erc20s[i], coll, rounding)
-            .safeMul(amount, rounding)
-            .shiftl_toUint(int8(IERC20Metadata(address(basket.erc20s[i])).decimals()), rounding);
+            // {tok} = {tok/BU} * {BU}
+            uint192 amt = _quantity(basket.erc20s[i], coll, rounding).safeMul(amount, rounding);
+
+            // Prevent toxic issuance by charging more when collateral is under peg
+            if (rounding == CEIL && coll.lastSave() == block.timestamp) {
+                // on arbitrum the timestamp check doesn't give us exactly what we want
+                // but it's close and better than wasting more gas on calling tryPrice()
+
+                uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
+                uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
+                if ((rounding == CEIL && pegPrice < targetPerRef)) {
+                    // {tok} = {tok} * {target/ref} / {target/ref}
+                    amt = amt.mulDiv(targetPerRef, pegPrice, rounding);
+                }
+            }
+            // else: only use defi rates
+
+            // {qTok} = {tok} * {qTok/tok}
+            quantities[i] = amt.shiftl_toUint(
+                int8(IERC20Metadata(address(basket.erc20s[i])).decimals()),
+                rounding
+            );
         }
     }
 

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -465,7 +465,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
                 if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
-                    amt = amt.mulDiv(targetPerRef, pegPrice, rounding);
+                    amt = amt.mulDiv(targetPerRef, pegPrice, CEIL);
                 }
             }
             // else: only use defi rates

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -366,7 +366,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
 
     /// @param erc20 The token contract
     /// @param coll The registered collateral plugin contract
-    /// @return {tok/BU} The token-quantity of an ERC20 token in the basket.
+    /// @return q {tok/BU} The token-quantity of an ERC20 token in the basket.
     // Returns 0 if coll is not in the basket
     // Returns FIX_MAX (in lieu of +infinity) if Collateral.refPerTok() is 0.
     // Otherwise returns (token's basket.refAmts / token's Collateral.refPerTok())
@@ -374,12 +374,25 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
         IERC20 erc20,
         ICollateral coll,
         RoundingMode rounding
-    ) internal view returns (uint192) {
+    ) internal view returns (uint192 q) {
         uint192 refPerTok = coll.refPerTok();
         if (refPerTok == 0) return FIX_MAX;
 
         // {tok/BU} = {ref/BU} / {ref/tok}
-        return basket.refAmts[erc20].div(refPerTok, rounding);
+        q = basket.refAmts[erc20].div(refPerTok, rounding);
+
+        // Prevent toxic issuance by charging more when collateral is under peg
+        if (rounding == CEIL && coll.lastSave() == block.timestamp) {
+            // on arbitrum the timestamp check doesn't give us exactly what we want
+            // but it's close and better than wasting more gas on calling tryPrice()
+
+            uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
+            uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
+            if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
+                // {tok} = {tok} * {target/ref} / {target/ref}
+                q = q.safeMulDiv(targetPerRef, pegPrice, CEIL);
+            }
+        }
     }
 
     /// Should not revert
@@ -453,28 +466,10 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             erc20s[i] = address(basket.erc20s[i]);
             ICollateral coll = assetRegistry.toColl(IERC20(erc20s[i]));
 
-            // {tok} = {tok/BU} * {BU}
-            uint192 amt = _quantity(basket.erc20s[i], coll, rounding).safeMul(amount, rounding);
-
-            // Prevent toxic issuance by charging more when collateral is under peg
-            if (rounding == CEIL && coll.lastSave() == block.timestamp) {
-                // on arbitrum the timestamp check doesn't give us exactly what we want
-                // but it's close and better than wasting more gas on calling tryPrice()
-
-                uint192 pegPrice = coll.savedPegPrice(); // {target/ref}
-                uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
-                if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
-                    // {tok} = {tok} * {target/ref} / {target/ref}
-                    amt = amt.safeMulDiv(targetPerRef, pegPrice, CEIL);
-                }
-            }
-            // else: only use defi rates
-
-            // {qTok} = {tok} * {qTok/tok}
-            quantities[i] = amt.shiftl_toUint(
-                int8(IERC20Metadata(address(basket.erc20s[i])).decimals()),
-                rounding
-            );
+            // {qTok} = {tok/BU} * {BU} * {qTok/tok}
+            quantities[i] = _quantity(basket.erc20s[i], coll, rounding)
+            .safeMul(amount, rounding)
+            .shiftl_toUint(int8(IERC20Metadata(address(basket.erc20s[i])).decimals()), rounding);
         }
     }
 

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -465,7 +465,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
                 uint192 targetPerRef = coll.targetPerRef(); // {target/ref}
                 if (pegPrice != 0 && (rounding == CEIL && pegPrice < targetPerRef)) {
                     // {tok} = {tok} * {target/ref} / {target/ref}
-                    amt = amt.mulDiv(targetPerRef, pegPrice, CEIL);
+                    amt = amt.safeMulDiv(targetPerRef, pegPrice, CEIL);
                 }
             }
             // else: only use defi rates

--- a/contracts/p1/BasketHandler.sol
+++ b/contracts/p1/BasketHandler.sol
@@ -267,8 +267,7 @@ contract BasketHandlerP1 is ComponentP1, IBasketHandler {
             // This is a nice catch to have, but in general it is possible for
             // an ERC20 in the prime basket to have its asset unregistered.
             require(assetRegistry.toAsset(erc20s[i]).isCollateral(), "erc20 is not collateral");
-            require(0 < targetAmts[i], "invalid target amount; must be nonzero");
-            require(targetAmts[i] <= MAX_TARGET_AMT, "invalid target amount; too large");
+            require(0 < targetAmts[i] && targetAmts[i] <= MAX_TARGET_AMT, "invalid target amount");
 
             config.erc20s.push(erc20s[i]);
             config.targetAmts[erc20s[i]] = targetAmts[i];

--- a/contracts/plugins/assets/AppreciatingFiatCollateral.sol
+++ b/contracts/plugins/assets/AppreciatingFiatCollateral.sol
@@ -104,6 +104,7 @@ abstract contract AppreciatingFiatCollateral is FiatCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -76,6 +76,7 @@ contract FiatCollateral is ICollateral, Asset {
             require(config.delayUntilDefault != 0, "delayUntilDefault zero");
         }
         require(config.delayUntilDefault <= 1209600, "delayUntilDefault too long");
+        require(config.defaultThreshold >= 7e17, "defaultThreshold too low"); // 70%
 
         // Note: This contract is designed to allow setting defaultThreshold = 0 to disable
         // default checks. You can apply the check below to child contracts when required

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -76,7 +76,6 @@ contract FiatCollateral is ICollateral, Asset {
             require(config.delayUntilDefault != 0, "delayUntilDefault zero");
         }
         require(config.delayUntilDefault <= 1209600, "delayUntilDefault too long");
-        require(config.defaultThreshold <= 3e17, "defaultThreshold too high"); // 30%
 
         // Note: This contract is designed to allow setting defaultThreshold = 0 to disable
         // default checks. You can apply the check below to child contracts when required

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -58,6 +58,8 @@ contract FiatCollateral is ICollateral, Asset {
 
     uint192 public immutable pegTop; // {target/ref} The top of the peg
 
+    uint192 public savedPegPrice; // {target/ref} The peg price of the token during the last update
+
     /// @param config.chainlinkFeed Feed units: {UoA/ref}
     constructor(CollateralConfig memory config)
         Asset(
@@ -136,6 +138,7 @@ contract FiatCollateral is ICollateral, Asset {
             if (high != FIX_MAX) {
                 savedLowPrice = low;
                 savedHighPrice = high;
+                savedPegPrice = pegPrice;
                 lastSave = uint48(block.timestamp);
             } else {
                 // must be unpriced

--- a/contracts/plugins/assets/FiatCollateral.sol
+++ b/contracts/plugins/assets/FiatCollateral.sol
@@ -76,7 +76,7 @@ contract FiatCollateral is ICollateral, Asset {
             require(config.delayUntilDefault != 0, "delayUntilDefault zero");
         }
         require(config.delayUntilDefault <= 1209600, "delayUntilDefault too long");
-        require(config.defaultThreshold >= 7e17, "defaultThreshold too low"); // 70%
+        require(config.defaultThreshold <= 3e17, "defaultThreshold too high"); // 30%
 
         // Note: This contract is designed to allow setting defaultThreshold = 0 to disable
         // default checks. You can apply the check below to child contracts when required

--- a/contracts/plugins/assets/L2LSDCollateral.sol
+++ b/contracts/plugins/assets/L2LSDCollateral.sol
@@ -70,6 +70,7 @@ abstract contract L2LSDCollateral is AppreciatingFiatCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/RTokenAsset.sol
+++ b/contracts/plugins/assets/RTokenAsset.sol
@@ -57,6 +57,8 @@ contract RTokenAsset is IAsset, VersionedAsset, IRTokenOracle {
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
     function tryPrice() external view virtual returns (uint192 low, uint192 high) {
+        // Get the BU price /w issuance premium. This means in UoA terms that the
+        // high price of a BU stays just above peg, even in the midst of a default.
         (uint192 lowBUPrice, uint192 highBUPrice) = basketHandler.price(); // {UoA/BU}
         require(lowBUPrice != 0 && highBUPrice != FIX_MAX, "invalid price");
         assert(lowBUPrice <= highBUPrice); // not obviously true just by inspection
@@ -88,7 +90,7 @@ contract RTokenAsset is IAsset, VersionedAsset, IRTokenOracle {
     }
 
     /// Should not revert
-    /// @dev See `tryPrice` caveat about possible compounding error in calculating price
+    /// @dev See `tryPrice` caveats
     /// @return {UoA/tok} The lower end of the price estimate
     /// @return {UoA/tok} The upper end of the price estimate
     function price() public view virtual returns (uint192, uint192) {

--- a/contracts/plugins/assets/RTokenAsset.sol
+++ b/contracts/plugins/assets/RTokenAsset.sol
@@ -57,9 +57,10 @@ contract RTokenAsset is IAsset, VersionedAsset, IRTokenOracle {
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
     function tryPrice() external view virtual returns (uint192 low, uint192 high) {
-        // Get the BU price /w issuance premium. This means in UoA terms that the
-        // high price of a BU stays just above peg, even in the midst of a default.
+        // Get the BU price /w issuance premium
         (uint192 lowBUPrice, uint192 highBUPrice) = basketHandler.price(); // {UoA/BU}
+        // highBUPrice will not change during a default because quantities increase to compensate
+
         require(lowBUPrice != 0 && highBUPrice != FIX_MAX, "invalid price");
         assert(lowBUPrice <= highBUPrice); // not obviously true just by inspection
 
@@ -69,8 +70,8 @@ contract RTokenAsset is IAsset, VersionedAsset, IRTokenOracle {
 
         if (supply == 0) return (lowBUPrice, highBUPrice);
 
-        // The RToken's price is not symmetric like other assets!
-        // range.bottom is lower because of the slippage from the shortfall
+        // The RToken's basket range is not symmetric!
+        // range.bottom is additionally lower because of the slippage from the shortfall
         BasketRange memory range = basketRange(); // {BU}
 
         // {UoA/tok} = {BU} * {UoA/BU} / {tok}

--- a/contracts/plugins/assets/compoundv3/CTokenV3Collateral.sol
+++ b/contracts/plugins/assets/compoundv3/CTokenV3Collateral.sol
@@ -84,6 +84,7 @@ contract CTokenV3Collateral is AppreciatingFiatCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
@@ -71,7 +71,7 @@ contract CurveAppreciatingRTokenFiatCollateral is CurveStableCollateral {
             }
 
             // Check for soft default + save prices
-            try this.tryPrice() returns (uint192 low, uint192 high, uint192) {
+            try this.tryPrice() returns (uint192 low, uint192 high, uint192 pegPrice) {
                 // {UoA/tok}, {UoA/tok}, {UoA/tok}
                 // (0, 0) is a valid price; (0, FIX_MAX) is unpriced
 
@@ -79,6 +79,7 @@ contract CurveAppreciatingRTokenFiatCollateral is CurveStableCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
@@ -79,7 +79,7 @@ contract CurveAppreciatingRTokenFiatCollateral is CurveStableCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
-                    savedPegPrice = pegPrice; // TODO return to
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
@@ -79,7 +79,7 @@ contract CurveAppreciatingRTokenFiatCollateral is CurveStableCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
-                    savedPegPrice = pegPrice;
+                    savedPegPrice = pegPrice; // TODO return to
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveRecursiveCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveRecursiveCollateral.sol
@@ -70,7 +70,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
 
         // Get reference token price
         (uint192 refLow, uint192 refHigh) = this.tokenPrice(0); // reference token
-        pegPrice = (refLow + refHigh) / 2;
+        pegPrice = refLow.plus(refHigh).divu(2, FLOOR);
 
         // Multiply by the underlyingRefPerTok()
         uint192 rate = underlyingRefPerTok();

--- a/contracts/plugins/assets/curve/CurveRecursiveCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveRecursiveCollateral.sol
@@ -51,7 +51,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
     /// Should NOT be manipulable by MEV
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
-    /// @return {target/ref} Unused. Always 0
+    /// @return pegPrice {target/ref} The actual price observed in the peg
     function tryPrice()
         external
         view
@@ -60,7 +60,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
         returns (
             uint192 low,
             uint192 high,
-            uint192
+            uint192 pegPrice
         )
     {
         // This pricing method is MEV-resistant, but only gives a lower-bound
@@ -70,6 +70,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
 
         // Get reference token price
         (uint192 refLow, uint192 refHigh) = this.tokenPrice(0); // reference token
+        pegPrice = (refLow + refHigh) / 2;
 
         // Multiply by the underlyingRefPerTok()
         uint192 rate = underlyingRefPerTok();
@@ -77,7 +78,6 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
         high = refHigh.mul(rate, CEIL);
 
         assert(low <= high); // not obviously true by inspection
-        return (low, high, 0);
     }
 
     /// Should not revert
@@ -123,7 +123,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
             // === Check for soft default ===
 
             // Check for soft default + save prices
-            try this.tryPrice() returns (uint192 low, uint192 high, uint192) {
+            try this.tryPrice() returns (uint192 low, uint192 high, uint192 pegPrice) {
                 // {UoA/tok}, {UoA/tok}, {UoA/tok}
                 // (0, 0) is a valid price; (0, FIX_MAX) is unpriced
 
@@ -131,6 +131,7 @@ contract CurveRecursiveCollateral is CurveStableCollateral {
                 if (high < FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -95,8 +95,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        // {target/ref} = ({target/tok} + {target/tok}) / {ref/tok}
-        pegPrice = low.plus(high).divu(2, FLOOR).div(underlyingRefPerTok(), FLOOR);
+        pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
     }
 
     /// Should not revert

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -95,9 +95,8 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        // TODO
-        // pegPrice =
-        pegPrice;
+        // {target/ref} = ({target/tok} + {target/tok}) / {ref/tok}
+        pegPrice = low.plus(high).divu(2, FLOOR).div(underlyingRefPerTok(), FLOOR);
     }
 
     /// Should not revert

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -96,6 +96,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         assert(low <= high); // not obviously true just by inspection
 
         pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
+        // not protected from toxic issuance
     }
 
     /// Should not revert

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -52,7 +52,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
     /// @dev Override this when pricing is more complicated than just a single pool
     /// @return low {UoA/tok} The low price estimate
     /// @return high {UoA/tok} The high price estimate
-    /// @return {target/ref} Unused. Always 0
+    /// @return pegPrice {target/ref} The actual price observed in the peg
     function tryPrice()
         external
         view
@@ -61,7 +61,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         returns (
             uint192 low,
             uint192 high,
-            uint192
+            uint192 pegPrice
         )
     {
         // Assumption: the pool is balanced
@@ -95,7 +95,9 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        return (low, high, 0);
+        // TODO
+        // pegPrice =
+        pegPrice;
     }
 
     /// Should not revert
@@ -121,7 +123,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
             }
 
             // Check for soft default + save prices
-            try this.tryPrice() returns (uint192 low, uint192 high, uint192) {
+            try this.tryPrice() returns (uint192 low, uint192 high, uint192 pegPrice) {
                 // {UoA/tok}, {UoA/tok}, {UoA/tok}
                 // (0, 0) is a valid price; (0, FIX_MAX) is unpriced
 
@@ -129,6 +131,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/assets/curve/CurveStableCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableCollateral.sol
@@ -96,7 +96,7 @@ contract CurveStableCollateral is AppreciatingFiatCollateral, PoolTokens {
         assert(low <= high); // not obviously true just by inspection
 
         pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
-        // not protected from toxic issuance
+        // no issuance premium! more dangerous to be used inside RTokens as a result
     }
 
     /// Should not revert

--- a/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
@@ -123,6 +123,7 @@ contract CurveStableMetapoolCollateral is CurveStableCollateral {
         assert(low <= high); // not obviously true just by inspection
 
         pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
+        // not protected from toxic issuance
     }
 
     /// Can revert, used by `_anyDepeggedOutsidePool()`

--- a/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
@@ -122,9 +122,8 @@ contract CurveStableMetapoolCollateral is CurveStableCollateral {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        // TODO
-        // pegPrice =
-        pegPrice;
+        // {target/ref} = ({target/tok} + {target/tok}) / {ref/tok}
+        pegPrice = low.plus(high).divu(2, FLOOR).div(underlyingRefPerTok(), FLOOR);
     }
 
     /// Can revert, used by `_anyDepeggedOutsidePool()`

--- a/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
@@ -123,7 +123,7 @@ contract CurveStableMetapoolCollateral is CurveStableCollateral {
         assert(low <= high); // not obviously true just by inspection
 
         pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
-        // not protected from toxic issuance
+        // no issuance premium! more dangerous to be used inside RTokens as a result
     }
 
     /// Can revert, used by `_anyDepeggedOutsidePool()`

--- a/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
@@ -122,7 +122,9 @@ contract CurveStableMetapoolCollateral is CurveStableCollateral {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        return (low, high, 0);
+        // TODO
+        // pegPrice =
+        pegPrice;
     }
 
     /// Can revert, used by `_anyDepeggedOutsidePool()`

--- a/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableMetapoolCollateral.sol
@@ -122,8 +122,7 @@ contract CurveStableMetapoolCollateral is CurveStableCollateral {
         high = aumHigh.div(supply, CEIL);
         assert(low <= high); // not obviously true just by inspection
 
-        // {target/ref} = ({target/tok} + {target/tok}) / {ref/tok}
-        pegPrice = low.plus(high).divu(2, FLOOR).div(underlyingRefPerTok(), FLOOR);
+        pegPrice = 0; // can't deduce from MEV-manipulable pricing unfortunately
     }
 
     /// Can revert, used by `_anyDepeggedOutsidePool()`

--- a/contracts/plugins/assets/curve/CurveStableRTokenMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableRTokenMetapoolCollateral.sol
@@ -73,7 +73,7 @@ contract CurveStableRTokenMetapoolCollateral is CurveStableMetapoolCollateral {
             }
 
             // Check for soft default + save prices
-            try this.tryPrice() returns (uint192 low, uint192 high, uint192) {
+            try this.tryPrice() returns (uint192 low, uint192 high, uint192 pegPrice) {
                 // {UoA/tok}, {UoA/tok}, {UoA/tok}
                 // (0, 0) is a valid price; (0, FIX_MAX) is unpriced
 
@@ -81,6 +81,7 @@ contract CurveStableRTokenMetapoolCollateral is CurveStableMetapoolCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 } else {
                     // must be unpriced

--- a/contracts/plugins/mocks/BadCollateralPlugin.sol
+++ b/contracts/plugins/mocks/BadCollateralPlugin.sol
@@ -55,6 +55,7 @@ contract BadCollateralPlugin is ATokenFiatCollateral {
                     // Save prices
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 }
 

--- a/contracts/plugins/mocks/FraxAggregator.sol
+++ b/contracts/plugins/mocks/FraxAggregator.sol
@@ -6,6 +6,15 @@ import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 interface FraxAggregatorV3Interface is AggregatorV3Interface {
     function priceSource() external view returns (address);
 
+    function getPrices()
+        external
+        view
+        returns (
+            bool _isBadData,
+            uint256 _priceLow,
+            uint256 _priceHigh
+        );
+
     function addRoundData(
         bool _isBadData,
         uint104 _priceLow,

--- a/contracts/plugins/mocks/InvalidRefPerTokCollateral.sol
+++ b/contracts/plugins/mocks/InvalidRefPerTokCollateral.sol
@@ -33,7 +33,7 @@ contract InvalidRefPerTokCollateralMock is AppreciatingFiatCollateral {
             exposedReferencePrice = hiddenReferencePrice;
 
             // Check for soft default + save prices
-            try this.tryPrice() returns (uint192 low, uint192 high, uint192) {
+            try this.tryPrice() returns (uint192 low, uint192 high, uint192 pegPrice) {
                 // {UoA/tok}, {UoA/tok}, {target/ref}
                 // (0, 0) is a valid price; (0, FIX_MAX) is unpriced
 
@@ -41,6 +41,7 @@ contract InvalidRefPerTokCollateralMock is AppreciatingFiatCollateral {
                 if (high != FIX_MAX) {
                     savedLowPrice = low;
                     savedHighPrice = high;
+                    savedPegPrice = pegPrice;
                     lastSave = uint48(block.timestamp);
                 }
             } catch (bytes memory errData) {

--- a/contracts/plugins/mocks/RTokenCollateral.sol
+++ b/contracts/plugins/mocks/RTokenCollateral.sol
@@ -34,6 +34,8 @@ contract RTokenCollateral is RTokenAsset, ICollateral {
     // targetName: The canonical name of this collateral's target unit.
     bytes32 public immutable targetName;
 
+    uint192 public savedPegPrice; // {target/ref} The peg price of the token during the last update
+
     /// @param maxTradeVolume_ {UoA} The max trade volume, in UoA
     constructor(
         IRToken erc20_,

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -365,8 +365,6 @@ A Collateral plugin may become `DISABLED` for other reasons as well. For instanc
 
 As long as it observes such a price irregularity, the Collateral's `status()` should return `IFFY`. It is up to the collateral how long the `IFFY` period lasts before the collateral becomes `DISABLED`, but it is critical that this period is finite and relatively short; this duration should probably be an argument in the plugin's constructor.
 
-The maximum tolerated de-peg deviation is 30%. A collateral MUST NOT be SOUND if the peg is more than 30% below the `targetPerRef()`.
-
 Lastly, once a collateral becomes `DISABLED`, it must remain `DISABLED`.
 
 ### price() `{UoA/tok}`

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -42,7 +42,7 @@ interface IAsset is IRewardable {
   function refresh() external;
 
   /// Should not revert
-  /// low should be nonzero when the asset might be worth selling
+  /// low should be nonzero if the asset could be worth selling
   /// @return low {UoA/tok} The lower end of the price estimate
   /// @return high {UoA/tok} The upper end of the price estimate
   function price() external view returns (uint192 low, uint192 high);
@@ -90,7 +90,7 @@ interface ICollateral is IAsset {
 
   /// @dev refresh()
   /// Refresh exchange rates and update default status.
-  /// VERY IMPORTANT: In any valid implementation, status() MUST become DISABLED in refresh() if
+  /// VERY IMPORTANT: In any valid implemntation, status() MUST become DISABLED in refresh() if
   /// refPerTok() has ever decreased since last call.
 
   /// @return The canonical name of this collateral's target unit.
@@ -106,6 +106,9 @@ interface ICollateral is IAsset {
 
   /// @return {target/ref} Quantity of whole target units per whole reference unit in the peg
   function targetPerRef() external view returns (uint192);
+
+  /// @return {target/ref} The peg price of the token during the last update
+  function savedPegPrice() external view returns (uint192);
 }
 
 ```

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -414,6 +414,14 @@ The target name is just a bytes32 serialization of the target unit string. Here 
 
 For a collateral plugin that uses a novel target unit, get the targetName with `ethers.utils.formatBytes32String(unitName)`.
 
+### savedPegPrice() `{target/ref}`
+
+A return value of 0 indicates _no_ issuance premium should be applied to this collateral during de-peg. Collateral that return 0 are more dangerous to be used inside RTokens as a result.
+
+Should never revert.
+
+Should be gas-efficient.
+
 ## Practical Advice from Previous Work
 
 In most cases [Fiat Collateral](../contracts/plugins/assets/FiatCollateral.sol) or [AppreciatingFiatCollateral.sol](../contracts/plugins/assets/AppreciatingFiatCollateral.sol) can be extended, pretty easily, to support a new collateral type. This allows the collateral developer to limit their attention to the overriding of three functions: `tryPrice()`, `refPerTok()`, `targetPerRef()`.

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -47,13 +47,6 @@ interface IAsset is IRewardable {
   /// @return high {UoA/tok} The upper end of the price estimate
   function price() external view returns (uint192 low, uint192 high);
 
-  /// Should not revert
-  /// lotLow should be nonzero when the asset might be worth selling
-  /// @dev Deprecated. Phased out in 3.1.0, but left on interface for backwards compatibility
-  /// @return lotLow {UoA/tok} The lower end of the lot price estimate
-  /// @return lotHigh {UoA/tok} The upper end of the lot price estimate
-  function lotPrice() external view returns (uint192 lotLow, uint192 lotHigh);
-
   /// @return {tok} The balance of the ERC20 in whole tokens
   function bal(address account) external view returns (uint192);
 
@@ -386,12 +379,6 @@ Under no price data, the low estimate shoulddecay downwards and high estimate up
 Should return `(0, FIX_MAX)` if pricing data is _completely_ unavailable or stale.
 
 Should be gas-efficient.
-
-### lotPrice() `{UoA/tok}`
-
-Deprecated. Phased out in 3.1.0, but left on interface for backwards compatibility.
-
-Recommend implement `lotPrice()` by calling `price()`. If you are inheriting from any of our existing collateral plugins, this is already done for you. See [Asset.sol](../contracts/plugins/Asset.sol) for the implementation.
 
 ### refPerTok() `{ref/tok}`
 

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -365,6 +365,8 @@ A Collateral plugin may become `DISABLED` for other reasons as well. For instanc
 
 As long as it observes such a price irregularity, the Collateral's `status()` should return `IFFY`. It is up to the collateral how long the `IFFY` period lasts before the collateral becomes `DISABLED`, but it is critical that this period is finite and relatively short; this duration should probably be an argument in the plugin's constructor.
 
+The maximum tolerated de-peg deviation is 30%. A collateral MUST NOT be SOUND if the peg is more than 30% below the `targetPerRef()`.
+
 Lastly, once a collateral becomes `DISABLED`, it must remain `DISABLED`.
 
 ### price() `{UoA/tok}`

--- a/docs/collateral.md
+++ b/docs/collateral.md
@@ -90,7 +90,7 @@ interface ICollateral is IAsset {
 
   /// @dev refresh()
   /// Refresh exchange rates and update default status.
-  /// VERY IMPORTANT: In any valid implemntation, status() MUST become DISABLED in refresh() if
+  /// VERY IMPORTANT: In any valid implementation, status() MUST become DISABLED in refresh() if
   /// refPerTok() has ever decreased since last call.
 
   /// @return The canonical name of this collateral's target unit.

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1849,11 +1849,11 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
         const newBH = await newBasketHandler()
         await newBH.init(main.address, config.warmupPeriod, false)
         await expect(newBH.connect(owner).setPrimeBasket([token0.address], [0])).to.be.revertedWith(
-          'invalid target amount; must be nonzero'
+          'invalid target amount'
         )
         await expect(
           newBH.connect(owner).forceSetPrimeBasket([token0.address], [0])
-        ).to.be.revertedWith('invalid target amount; must be nonzero')
+        ).to.be.revertedWith('invalid target amount')
       })
 
       it('Should be able to set exactly same basket', async () => {
@@ -2115,10 +2115,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
         // not possible on non-fresh basketHandler
         await expect(
           indexBH.connect(owner).setPrimeBasket([token0.address], [MAX_TARGET_AMT.add(1)])
-        ).to.be.revertedWith('invalid target amount; too large')
+        ).to.be.revertedWith('invalid target amount')
         await expect(
           indexBH.connect(owner).forceSetPrimeBasket([token0.address], [MAX_TARGET_AMT.add(1)])
-        ).to.be.revertedWith('invalid target amount; too large')
+        ).to.be.revertedWith('invalid target amount')
       })
 
       it('Should not allow to set prime Basket with an empty basket', async () => {
@@ -2133,10 +2133,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       it('Should not allow to set prime Basket with a zero amount', async () => {
         await expect(
           indexBH.connect(owner).setPrimeBasket([token0.address], [0])
-        ).to.be.revertedWith('invalid target amount; must be nonzero')
+        ).to.be.revertedWith('invalid target amount')
         await expect(
           indexBH.connect(owner).forceSetPrimeBasket([token0.address], [0])
-        ).to.be.revertedWith('invalid target amount; must be nonzero')
+        ).to.be.revertedWith('invalid target amount')
       })
 
       it('Should be able to set exactly same basket', async () => {

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -3167,10 +3167,8 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       // Check BU price -- 1/4 of the basket has lost half its value
       const avgPrice = fp('0.875')
       let [lowPrice, highPrice] = await basketHandler.price()
-      const delta = avgPrice.mul(ORACLE_ERROR).div(fp('1'))
-      const expectedLow = avgPrice.sub(delta)
-      const expectedHigh = avgPrice.add(delta).add(fp('0.063125'))
-      // high price isn't _quite_ up at peg because the price decrease was >30% so we have max issuance premium
+      const expectedLow = avgPrice.sub(avgPrice.mul(ORACLE_ERROR).div(fp('1')))
+      const expectedHigh = fp('1').add(fp('1').mul(ORACLE_ERROR).div(fp('1'))) // at-peg!
 
       const tolerance = avgPrice.div(bn('1e15'))
       expect(lowPrice).to.be.closeTo(expectedLow, tolerance)

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -1762,10 +1762,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       it('Should not allow to set prime Basket with invalid length', async () => {
         await expect(
           basketHandler.connect(owner).setPrimeBasket([token0.address], [])
-        ).to.be.revertedWith('len mismatch')
+        ).to.be.revertedWith('invalid lengths')
         await expect(
           basketHandler.connect(owner).forceSetPrimeBasket([token0.address], [])
-        ).to.be.revertedWith('len mismatch')
+        ).to.be.revertedWith('invalid lengths')
       })
 
       it('Should not allow to set prime Basket with non-collateral tokens', async () => {
@@ -1830,10 +1830,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
 
       it('Should not allow to set prime Basket with an empty basket', async () => {
         await expect(basketHandler.connect(owner).setPrimeBasket([], [])).to.be.revertedWith(
-          'empty basket'
+          'invalid lengths'
         )
         await expect(basketHandler.connect(owner).forceSetPrimeBasket([], [])).to.be.revertedWith(
-          'empty basket'
+          'invalid lengths'
         )
       })
 
@@ -2065,10 +2065,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       it('Should not allow to set prime Basket with invalid length', async () => {
         await expect(
           indexBH.connect(owner).setPrimeBasket([token0.address], [])
-        ).to.be.revertedWith('len mismatch')
+        ).to.be.revertedWith('invalid lengths')
         await expect(
           indexBH.connect(owner).forceSetPrimeBasket([token0.address], [])
-        ).to.be.revertedWith('len mismatch')
+        ).to.be.revertedWith('invalid lengths')
       })
 
       it('Should not allow to set prime Basket with non-collateral tokens', async () => {
@@ -2123,10 +2123,10 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
 
       it('Should not allow to set prime Basket with an empty basket', async () => {
         await expect(indexBH.connect(owner).setPrimeBasket([], [])).to.be.revertedWith(
-          'empty basket'
+          'invalid lengths'
         )
         await expect(indexBH.connect(owner).forceSetPrimeBasket([], [])).to.be.revertedWith(
-          'empty basket'
+          'invalid lengths'
         )
       })
 
@@ -3536,15 +3536,6 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
 
       // Check BU price
       await expectPrice(basketHandler.address, fp('0.75'), ORACLE_ERROR, true)
-    })
-
-    it('lotPrice (deprecated) is equal to price()', async () => {
-      const lotPrice = await basketHandler.lotPrice()
-      const price = await basketHandler.price()
-      expect(price.length).to.equal(2)
-      expect(lotPrice.length).to.equal(price.length)
-      expect(lotPrice[0]).to.equal(price[0])
-      expect(lotPrice[1]).to.equal(price[1])
     })
 
     it('Should not put backup tokens with different targetName in the basket', async () => {

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -2391,7 +2391,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
         const amount = fp('10000')
         await expect(
           indexBH.quoteCustomRedemption(basketNonces, portions, amount)
-        ).to.be.revertedWith('bad portions len')
+        ).to.be.revertedWith('invalid lengths')
       })
 
       it('Should correctly quote the current basket, same as quote()', async () => {
@@ -2978,7 +2978,7 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
         basketHandler
           .connect(owner)
           .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(1), erc20s)
-      ).to.not.be.revertedWith('erc20s too large')
+      ).to.not.be.revertedWith('too large')
 
       // Should fail at 65
       erc20s.push(ONE_ADDRESS)
@@ -2986,21 +2986,21 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
         basketHandler
           .connect(owner)
           .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(1), erc20s)
-      ).to.be.revertedWith('erc20s too large')
+      ).to.be.revertedWith('too large')
 
       // Should succeed at 64
       await expect(
         basketHandler
           .connect(owner)
           .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(64), [])
-      ).to.not.be.revertedWith('max too large')
+      ).to.not.be.revertedWith('too large')
 
       // Should fail at 65
       await expect(
         basketHandler
           .connect(owner)
           .setBackupConfig(ethers.utils.formatBytes32String('USD'), bn(65), [])
-      ).to.be.revertedWith('max too large')
+      ).to.be.revertedWith('too large')
     })
 
     it('Should allow to set backup Config if OWNER', async () => {

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -970,13 +970,13 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       expect(await basketHandler.skipIssuancePremium()).to.equal(false)
 
       // If not owner cannot update
-      await expect(basketHandler.connect(other).setSkipIssuancePremium(newValue)).to.be.reverted
+      await expect(basketHandler.connect(other).setIssuancePremiumEnabled(!newValue)).to.be.reverted
 
       // Check value did not change
       expect(await basketHandler.skipIssuancePremium()).to.equal(false)
 
       // Update with owner
-      await expect(basketHandler.connect(owner).setSkipIssuancePremium(newValue))
+      await expect(basketHandler.connect(owner).setIssuancePremiumEnabled(!newValue))
         .to.emit(basketHandler, 'SkipIssuancePremiumSet')
         .withArgs(false, newValue)
 

--- a/test/Main.test.ts
+++ b/test/Main.test.ts
@@ -963,6 +963,27 @@ describe(`MainP${IMPLEMENTATION} contract`, () => {
       ).to.be.revertedWith('invalid warmupPeriod')
     })
 
+    it('Should allow to update skipIssuancePremium if OWNER', async () => {
+      const newValue = true
+
+      // Check existing value
+      expect(await basketHandler.skipIssuancePremium()).to.equal(false)
+
+      // If not owner cannot update
+      await expect(basketHandler.connect(other).setSkipIssuancePremium(newValue)).to.be.reverted
+
+      // Check value did not change
+      expect(await basketHandler.skipIssuancePremium()).to.equal(false)
+
+      // Update with owner
+      await expect(basketHandler.connect(owner).setSkipIssuancePremium(newValue))
+        .to.emit(basketHandler, 'SkipIssuancePremiumSet')
+        .withArgs(false, newValue)
+
+      // Check value was updated
+      expect(await basketHandler.skipIssuancePremium()).to.equal(newValue)
+    })
+
     it('Should allow to update tradingDelay if OWNER and perform validations', async () => {
       const newValue: BigNumber = bn('360')
 

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -474,18 +474,9 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         await setOraclePrice(collateral0.address, bn('7e7'))
         await collateral0.refresh()
         await token0.connect(addr1).transfer(rTokenTrader.address, issueAmount)
-        const rtokenPrice = await basketHandler.price()
-        const realRtokenPrice = rtokenPrice.low.add(rtokenPrice.high).div(2)
-        const minBuyAmt = await toMinBuyAmt(issueAmount, fp('0.7'), realRtokenPrice)
         await expect(rTokenTrader.manageTokens([token0.address], [TradeKind.BATCH_AUCTION]))
           .to.emit(rTokenTrader, 'TradeStarted')
-          .withArgs(
-            anyValue,
-            token0.address,
-            rToken.address,
-            issueAmount,
-            withinTolerance(minBuyAmt)
-          )
+          .withArgs(anyValue, token0.address, rToken.address, issueAmount, anyValue)
       })
 
       it('Should forward revenue to traders', async () => {
@@ -1004,7 +995,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       })
 
       it('Should launch revenue auction if DISABLED with nonzero minBuyAmount', async () => {
-        await setOraclePrice(collateral0.address, bn('0.5e8'))
+        await setOraclePrice(collateral0.address, bn('0.7e8'))
         await collateral0.refresh()
         await advanceTime((await collateral0.delayUntilDefault()).toString())
         expect(await collateral0.status()).to.equal(CollateralStatus.DISABLED)
@@ -1016,7 +1007,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         // Trade should have extremely nonzero worst-case price
         const trade = await getTrade(rTokenTrader, token0.address)
         expect(await trade.initBal()).to.equal(issueAmount)
-        expect(await trade.worstCasePrice()).to.be.gte(fp('0.775').mul(bn('1e9'))) // D27 precision
+        expect(await trade.worstCasePrice()).to.be.gte(fp('0.679').mul(bn('1e9'))) // D27 precision
       })
 
       it('Should claim COMP and handle revenue auction correctly - small amount processed in single auction', async () => {

--- a/test/Revenues.test.ts
+++ b/test/Revenues.test.ts
@@ -995,7 +995,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
       })
 
       it('Should launch revenue auction if DISABLED with nonzero minBuyAmount', async () => {
-        await setOraclePrice(collateral0.address, bn('0.7e8'))
+        await setOraclePrice(collateral0.address, bn('0.5e8'))
         await collateral0.refresh()
         await advanceTime((await collateral0.delayUntilDefault()).toString())
         expect(await collateral0.status()).to.equal(CollateralStatus.DISABLED)
@@ -1007,7 +1007,7 @@ describe(`Revenues - P${IMPLEMENTATION}`, () => {
         // Trade should have extremely nonzero worst-case price
         const trade = await getTrade(rTokenTrader, token0.address)
         expect(await trade.initBal()).to.equal(issueAmount)
-        expect(await trade.worstCasePrice()).to.be.gte(fp('0.679').mul(bn('1e9'))) // D27 precision
+        expect(await trade.worstCasePrice()).to.be.gte(fp('0.485').mul(bn('1e9'))) // D27 precision
       })
 
       it('Should claim COMP and handle revenue auction correctly - small amount processed in single auction', async () => {

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -2425,10 +2425,13 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         await expect(rToken.connect(addr1).issue(issueAmount)).to.emit(rToken, 'Issuance')
 
         // Check Balances after
-        expect(await usdt.balanceOf(backingManager.address)).to.equal(toBNDecimals(issueAmount, 6)) //1 full unit
+        const usdtBal = toBNDecimals(issueAmount, 6)
+        expect(await usdt.balanceOf(backingManager.address)).to.be.gt(usdtBal)
+        expect(await usdt.balanceOf(backingManager.address)).to.be.closeTo(usdtBal, 1000) //1 full unit
+
         // Balances for user
         expect(await usdt.balanceOf(addr1.address)).to.equal(
-          toBNDecimals(initialBal.sub(issueAmount), 6)
+          toBNDecimals(initialBal.sub(await usdt.balanceOf(backingManager.address)), 6)
         )
 
         // Check RTokens issued to user

--- a/test/integration/AssetPlugins.test.ts
+++ b/test/integration/AssetPlugins.test.ts
@@ -2430,9 +2430,11 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect(await usdt.balanceOf(backingManager.address)).to.be.closeTo(usdtBal, 1000) //1 full unit
 
         // Balances for user
-        expect(await usdt.balanceOf(addr1.address)).to.equal(
-          toBNDecimals(initialBal.sub(await usdt.balanceOf(backingManager.address)), 6)
+        const expected = toBNDecimals(
+          initialBal.sub(await usdt.balanceOf(backingManager.address)),
+          6
         )
+        expect(await usdt.balanceOf(addr1.address)).to.be.closeTo(expected, point1Pct(expected))
 
         // Check RTokens issued to user
         expect(await rToken.balanceOf(addr1.address)).to.equal(issueAmount)
@@ -2452,11 +2454,11 @@ describeFork(`Asset Plugins - Integration - Mainnet Forking P${IMPLEMENTATION}`,
         expect(await rToken.balanceOf(addr1.address)).to.equal(0)
         expect(await rToken.totalSupply()).to.equal(0)
 
-        // Check balances after - Backing Manager is empty
-        expect(await usdt.balanceOf(backingManager.address)).to.equal(0)
+        // Check balances after - Backing Manager is basically empty
+        expect(await usdt.balanceOf(backingManager.address)).to.be.closeTo(0, 1000)
 
         // Check funds returned to user
-        expect(await usdt.balanceOf(addr1.address)).to.equal(toBNDecimals(initialBal, 6))
+        expect(await usdt.balanceOf(addr1.address)).to.be.closeTo(toBNDecimals(initialBal, 6), 1000)
 
         //  Check asset value left
         expect(await facadeTest.callStatic.totalAssetValue(rToken.address)).to.be.closeTo(

--- a/test/integration/fork-block-numbers.ts
+++ b/test/integration/fork-block-numbers.ts
@@ -8,6 +8,7 @@ const forkBlockNumber = {
   'facade-monitor': 18742016, // Ethereum
   'old-curve-plugins': 16915576, // Ethereum
   'new-curve-plugins': 19626711, // Ethereum
+  'mainnet-3.4.0': 20328530, // Ethereum
 
   // TODO add all the block numbers we fork from to benefit from caching
   default: 19742528, // Ethereum

--- a/test/integration/mainnet-test/IssuancePremium.test.ts
+++ b/test/integration/mainnet-test/IssuancePremium.test.ts
@@ -1,0 +1,290 @@
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import hre, { ethers } from 'hardhat'
+import { evmRevert, evmSnapshot } from '../utils'
+import { bn, fp } from '../../../common/numbers'
+import { IMPLEMENTATION } from '../../fixtures'
+import { getChainId } from '../../../common/blockchain-utils'
+import { networkConfig } from '../../../common/configuration'
+import forkBlockNumber from '../fork-block-numbers'
+import { whileImpersonating } from '../../utils/impersonation'
+import {
+  AssetRegistryP1,
+  BasketHandlerP1,
+  EmaPriceOracleStableSwapMock,
+  LidoStakedEthCollateral,
+  SFraxEthCollateral,
+  RethCollateral,
+} from '../../../typechain'
+import { useEnv } from '#/utils/env'
+import { combinedError } from '#/scripts/deployment/utils'
+
+const describeFork = useEnv('FORK') ? describe : describe.skip
+
+const ASSET_REGISTRY_ADDR = '0xf526f058858E4cD060cFDD775077999562b31bE0' // ETH+ asset registry
+const BASKET_HANDLER_ADDR = '0x56f40A33e3a3fE2F1614bf82CBeb35987ac10194' // ETH+ basket handler
+const BASKET_LIB_ADDR = '0xf383dC60D29A5B9ba461F40A0606870d80d1EA88' // BasketLibP1
+const OWNER = '0x5d8A7DC9405F08F14541BA918c1Bf7eb2dACE556' // ETH+ timelock
+
+// run on mainnet only
+
+describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, function () {
+  let assetRegistry: AssetRegistryP1
+  let basketHandler: BasketHandlerP1
+  let chainId: string
+
+  let snap: string
+
+  let oldPrice: BigNumber[] // <4.0.0
+  let newPrice: BigNumber[] // >= 4.0.0
+  let oldQuantities: BigNumber[] // <4.0.0
+  let newQuantities: BigNumber[] // >= 4.0.0
+
+  let sfrxETH: SFraxEthCollateral
+  let sfraxEmaOracle: EmaPriceOracleStableSwapMock
+
+  // Setup test environment
+  const setup = async (blockNumber: number) => {
+    // Use Mainnet fork
+    await hre.network.provider.request({
+      method: 'hardhat_reset',
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: useEnv('MAINNET_RPC_URL'),
+            blockNumber: blockNumber,
+          },
+        },
+      ],
+    })
+  }
+
+  before(async () => {
+    await setup(forkBlockNumber['mainnet-3.4.0'])
+
+    chainId = await getChainId(hre)
+    if (!networkConfig[chainId]) {
+      throw new Error(`Missing network configuration for ${hre.network.name}`)
+    }
+
+    assetRegistry = <AssetRegistryP1>(
+      await ethers.getContractAt('AssetRegistryP1', ASSET_REGISTRY_ADDR)
+    )
+    basketHandler = <BasketHandlerP1>(
+      await ethers.getContractAt('BasketHandlerP1', BASKET_HANDLER_ADDR)
+    )
+
+    oldPrice = await basketHandler.price()
+    oldQuantities = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    // frxETH/ETH EMA oracle
+    const currentEmaOracle = await ethers.getContractAt(
+      'contracts/plugins/assets/frax-eth/SFraxEthCollateral.sol:IEmaPriceOracleStableSwap',
+      networkConfig[chainId].CURVE_POOL_WETH_FRXETH!
+    )
+    const EmaPriceOracleStableSwapMockFactory = await ethers.getContractFactory(
+      'EmaPriceOracleStableSwapMock'
+    )
+    sfraxEmaOracle = <EmaPriceOracleStableSwapMock>(
+      await EmaPriceOracleStableSwapMockFactory.deploy(await currentEmaOracle.price_oracle())
+    )
+
+    // === Upgrade to 4.0.0 (minimally)===
+
+    // BasketHandler
+    const BasketHandlerFactory = await ethers.getContractFactory('BasketHandlerP1', {
+      libraries: {
+        BasketLibP1: BASKET_LIB_ADDR,
+      },
+    })
+    const newBasketHandlerImpl = await BasketHandlerFactory.deploy()
+
+    // SFraxEthCollateral
+    const SFraxEthCollateralFactory = await hre.ethers.getContractFactory('SFraxEthCollateral')
+    let oracleError = combinedError(fp('0.005'), fp('0.0002')) // 0.5% & 0.02%
+    const newSfrxETH = <SFraxEthCollateral>await SFraxEthCollateralFactory.deploy(
+      {
+        priceTimeout: '604800',
+        chainlinkFeed: networkConfig[chainId].chainlinkFeeds.ETH!,
+        oracleError: oracleError.toString(),
+        erc20: networkConfig[chainId].tokens.sfrxETH!,
+        maxTradeVolume: fp('1e6').toString(), // $1m,
+        oracleTimeout: '3600', // 1 hr
+        targetName: hre.ethers.utils.formatBytes32String('ETH'),
+        defaultThreshold: fp('0.02').add(oracleError).toString(), // ~2.5%
+        delayUntilDefault: bn('86400').toString(), // 24h
+      },
+      fp('1e-4').toString(), // revenueHiding = 0.01%
+      sfraxEmaOracle.address
+    )
+    sfrxETH = newSfrxETH
+    await sfrxETH.refresh()
+
+    // LidoStakedEthCollateral
+    const WSTETHCollateralFactory = await hre.ethers.getContractFactory('LidoStakedEthCollateral')
+    const newWstETH = <LidoStakedEthCollateral>await WSTETHCollateralFactory.deploy(
+      {
+        priceTimeout: '604800',
+        chainlinkFeed: networkConfig[chainId].chainlinkFeeds.stETHUSD!,
+        oracleError: fp('0.01').toString(), // 1%: only for stETHUSD feed
+        erc20: networkConfig[chainId].tokens.wstETH!,
+        maxTradeVolume: fp('1e6').toString(), // $1m,
+        oracleTimeout: '3600', // 1 hr,
+        targetName: hre.ethers.utils.formatBytes32String('ETH'),
+        defaultThreshold: fp('0.025').toString(), // 2.5% = 2% + 0.5% stethEth feed oracleError
+        delayUntilDefault: bn('86400').toString(), // 24h
+      },
+      fp('1e-4').toString(), // revenueHiding = 0.01%
+      networkConfig[chainId].chainlinkFeeds.stETHETH!, // targetPerRefChainlinkFeed
+      '86400' // targetPerRefChainlinkTimeout
+    )
+    await newWstETH.refresh()
+
+    // RethCollateral
+    const RethCollateralFactory = await hre.ethers.getContractFactory('RethCollateral')
+    oracleError = combinedError(fp('0.005'), fp('0.02')) // 0.5% & 2%
+    const newRETH = <RethCollateral>await RethCollateralFactory.deploy(
+      {
+        priceTimeout: '604800',
+        chainlinkFeed: networkConfig[chainId].chainlinkFeeds.ETH!,
+        oracleError: oracleError.toString(), // 1%: only for rETH feed
+        erc20: networkConfig[chainId].tokens.rETH!,
+        maxTradeVolume: fp('1e6').toString(), // $1m,
+        oracleTimeout: '3600', // 1 hr,
+        targetName: hre.ethers.utils.formatBytes32String('ETH'),
+        defaultThreshold: fp('0.02').add(oracleError).toString(), // ~4.5%
+        delayUntilDefault: bn('86400').toString(), // 24h
+      },
+      fp('1e-4').toString(), // revenueHiding = 0.01%
+      networkConfig[chainId].chainlinkFeeds.rETH!,
+      '86400' // refPerTokChainlinkTimeout
+    )
+    await newRETH.refresh()
+
+    // Putting it all together...
+    await whileImpersonating(OWNER, async (timelockSigner) => {
+      await basketHandler.connect(timelockSigner).upgradeTo(newBasketHandlerImpl.address)
+      await assetRegistry.connect(timelockSigner).swapRegistered(newSfrxETH.address)
+      await assetRegistry.connect(timelockSigner).swapRegistered(newWstETH.address)
+      await assetRegistry.connect(timelockSigner).swapRegistered(newRETH.address)
+    })
+    await basketHandler.refreshBasket()
+    expect(await basketHandler.status()).to.equal(0)
+    expect(await basketHandler.fullyCollateralized()).to.equal(true)
+
+    newPrice = await basketHandler.price()
+    newQuantities = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    snap = await evmSnapshot() // what are testing frameworks for if not this in all its glory
+  })
+
+  beforeEach(async () => {
+    await evmRevert(snap)
+    snap = await evmSnapshot()
+  })
+
+  after(async () => {
+    await evmRevert(snap)
+  })
+
+  it('from 3.4.0 to 4.0.0', async () => {
+    // this test case compares the state before the 4.0.0 upgrade to the state after the 4.0.0 upgrade
+    // Issuance costs rise ~0.04% due to sfrxETH's ~0.12% premium
+
+    const lowPriceChange = newPrice[0].sub(oldPrice[0]).mul(fp('1')).div(oldPrice[0])
+    const highPriceChange = newPrice[1].sub(oldPrice[1]).mul(fp('1')).div(oldPrice[1])
+    expect(lowPriceChange).to.be.closeTo(fp('-0.000008'), fp('1e-6')) // low price -0.0008%
+    expect(highPriceChange).to.be.closeTo(fp('0.000437'), fp('1e-6')) // high price +0.04%
+
+    const sfrxETHChange = newQuantities[0].sub(oldQuantities[0]).mul(fp('1')).div(oldQuantities[0])
+    const wstETHChange = newQuantities[1].sub(oldQuantities[1]).mul(fp('1')).div(oldQuantities[1])
+    const rETHChange = newQuantities[2].sub(oldQuantities[2]).mul(fp('1')).div(oldQuantities[2])
+    expect(sfrxETHChange).to.be.closeTo(fp('0.001201'), fp('1e-6')) // sFraxETH +0.12%
+    expect(wstETHChange).to.be.closeTo(fp('0.000126'), fp('1e-6')) // wstETH +0.012%
+    expect(rETHChange).to.be.equal(0) // rETH no change
+  })
+
+  it('from 4.0.0 to 4.0.0 at-peg', async () => {
+    // this test case compares the state after the 4.0.0 upgrade to the state when frxETH is at peg
+    // issuance costs fall by 0.042 bps, which is not noticeable
+
+    await sfraxEmaOracle.setPrice(fp('1'))
+
+    const parPrice = await basketHandler.price()
+    const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    const lowPriceChange = parPrice[0].sub(newPrice[0]).mul(fp('1')).div(newPrice[0])
+    const highPriceChange = parPrice[1].sub(newPrice[1]).mul(fp('1')).div(newPrice[1])
+    expect(lowPriceChange).to.be.closeTo(fp('0.000411'), fp('1e-6')) // low price +0.04%
+    expect(highPriceChange).to.be.closeTo(fp('-0.000042'), fp('1e-6')) // high price -0.0004%
+
+    const sfrxETHChange = parQs[0].sub(newQuantities[0]).mul(fp('1')).div(newQuantities[0])
+    const wstETHChange = parQs[1].sub(newQuantities[1]).mul(fp('1')).div(newQuantities[1])
+    const rETHChange = parQs[2].sub(newQuantities[2]).mul(fp('1')).div(newQuantities[2])
+    expect(sfrxETHChange).to.be.closeTo(fp('-0.00122654'), fp('1e-6')) // sFraxETH -0.12%%
+    expect(wstETHChange).to.be.closeTo(fp('-0.0001267'), fp('1e-6')) // wstETH -0.01%
+    expect(rETHChange).to.be.equal(0) // rETH no change
+  })
+
+  it('from 4.0.0 at-peg to 2% below peg', async () => {
+    // this test case compares the state from at-peg to the state after a 2% de-peg of frxETH, within the default threshold
+    // issuance costs do not change since the premium compensates
+
+    await sfraxEmaOracle.setPrice(fp('1'))
+
+    const parPrice = await basketHandler.price()
+    const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    // de-peg by 2%
+
+    await sfraxEmaOracle.setPrice(fp('0.98'))
+    await sfrxETH.refresh()
+    expect(await sfrxETH.savedPegPrice()).to.equal(fp('0.98'))
+
+    const depeggedPrice = await basketHandler.price()
+    const depeggedQs = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    const lowPriceChange = depeggedPrice[0].sub(parPrice[0]).mul(fp('1')).div(parPrice[0])
+    const highPriceChange = depeggedPrice[1].sub(parPrice[1]).mul(fp('1')).div(parPrice[1])
+    expect(lowPriceChange).to.be.closeTo(fp('-0.006706'), fp('1e-6')) // low price -0.67%
+    expect(highPriceChange).be.closeTo(0, fp('1e-6')) // high price no change
+
+    const sfrxETHChange = depeggedQs[0].sub(parQs[0]).mul(fp('1')).div(parQs[0])
+    const wstETHChange = depeggedQs[1].sub(parQs[1]).mul(fp('1')).div(parQs[1])
+    const rETHChange = depeggedQs[2].sub(parQs[2]).mul(fp('1')).div(parQs[2])
+    expect(sfrxETHChange).to.be.closeTo(fp('0.020408'), fp('1e-6')) // sFraxETH +2%
+    expect(wstETHChange).to.be.closeTo(0, fp('1e-6')) // wstETH no change
+    expect(rETHChange).to.be.equal(0) // rETH no change
+  })
+
+  it('from 4.0.0 at-peg to 50% below peg', async () => {
+    // this test case compares the state from at-peg to the state after a 50% de-peg of frxETH
+    // issuance costs do not change in USD terms, but sfrxETH increases quantities 100% to compensate
+
+    await sfraxEmaOracle.setPrice(fp('1'))
+
+    const parPrice = await basketHandler.price()
+    const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    // de-peg by 50%
+
+    await sfraxEmaOracle.setPrice(fp('0.5'))
+    await sfrxETH.refresh()
+    expect(await sfrxETH.savedPegPrice()).to.equal(fp('0.5'))
+
+    const depeggedPrice = await basketHandler.price()
+    const depeggedQs = (await basketHandler.quote(fp('1'), 2)).quantities
+
+    const lowPriceChange = depeggedPrice[0].sub(parPrice[0]).mul(fp('1')).div(parPrice[0])
+    const highPriceChange = depeggedPrice[1].sub(parPrice[1]).mul(fp('1')).div(parPrice[1])
+    expect(lowPriceChange).to.be.closeTo(fp('-0.167646'), fp('1e-6')) // low price -16.7%
+    expect(highPriceChange).be.closeTo(0, fp('1e-6')) // high price no change
+
+    const sfrxETHChange = depeggedQs[0].sub(parQs[0]).mul(fp('1')).div(parQs[0])
+    const wstETHChange = depeggedQs[1].sub(parQs[1]).mul(fp('1')).div(parQs[1])
+    const rETHChange = depeggedQs[2].sub(parQs[2]).mul(fp('1')).div(parQs[2])
+    expect(sfrxETHChange).to.be.closeTo(fp('1'), fp('1e-6')) // sFraxETH +100%
+    expect(wstETHChange).to.be.closeTo(0, fp('1e-6')) // wstETH -0.12%
+    expect(rETHChange).to.be.equal(0) // rETH no change
+  })
+})

--- a/test/integration/mainnet-test/IssuancePremium.test.ts
+++ b/test/integration/mainnet-test/IssuancePremium.test.ts
@@ -13,6 +13,7 @@ import {
   BasketHandlerP1,
   EmaPriceOracleStableSwapMock,
   LidoStakedEthCollateral,
+  RTokenAsset,
   SFraxEthCollateral,
   RethCollateral,
 } from '../../../typechain'
@@ -24,6 +25,7 @@ const describeFork = useEnv('FORK') ? describe : describe.skip
 const ASSET_REGISTRY_ADDR = '0xf526f058858E4cD060cFDD775077999562b31bE0' // ETH+ asset registry
 const BASKET_HANDLER_ADDR = '0x56f40A33e3a3fE2F1614bf82CBeb35987ac10194' // ETH+ basket handler
 const BASKET_LIB_ADDR = '0xf383dC60D29A5B9ba461F40A0606870d80d1EA88' // BasketLibP1
+const RTOKEN_ASSET_ADDR = '0x3f11C47E7ed54b24D7EFC222FD406d8E1F49Fb69' // ETH+ RTokenAsset
 const OWNER = '0x5d8A7DC9405F08F14541BA918c1Bf7eb2dACE556' // ETH+ timelock
 
 // run on mainnet only
@@ -31,14 +33,17 @@ const OWNER = '0x5d8A7DC9405F08F14541BA918c1Bf7eb2dACE556' // ETH+ timelock
 describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, function () {
   let assetRegistry: AssetRegistryP1
   let basketHandler: BasketHandlerP1
+  let rTokenAsset: RTokenAsset
   let chainId: string
 
   let snap: string
 
+  let oldRTokenPrice: BigNumber[] // <4.0.0
+  let newRTokenPrice: BigNumber[] // >= <4.0.0
   let oldPrice: BigNumber[] // <4.0.0
   let newPrice: BigNumber[] // >= 4.0.0
-  let oldQuantities: BigNumber[] // <4.0.0
-  let newQuantities: BigNumber[] // >= 4.0.0
+  let oldQs: BigNumber[] // <4.0.0 quantities
+  let newQs: BigNumber[] // >= 4.0.0 quantities
 
   let sfrxETH: SFraxEthCollateral
   let sfraxEmaOracle: EmaPriceOracleStableSwapMock
@@ -73,9 +78,11 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
     basketHandler = <BasketHandlerP1>(
       await ethers.getContractAt('BasketHandlerP1', BASKET_HANDLER_ADDR)
     )
+    rTokenAsset = <RTokenAsset>await ethers.getContractAt('RTokenAsset', RTOKEN_ASSET_ADDR)
 
+    oldRTokenPrice = await rTokenAsset.price()
     oldPrice = await basketHandler.price()
-    oldQuantities = (await basketHandler.quote(fp('1'), 2)).quantities
+    oldQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
     // frxETH/ETH EMA oracle
     const currentEmaOracle = await ethers.getContractAt(
@@ -172,8 +179,9 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
     expect(await basketHandler.status()).to.equal(0)
     expect(await basketHandler.fullyCollateralized()).to.equal(true)
 
+    newRTokenPrice = await rTokenAsset.price()
     newPrice = await basketHandler.price()
-    newQuantities = (await basketHandler.quote(fp('1'), 2)).quantities
+    newQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
     snap = await evmSnapshot() // what are testing frameworks for if not this in all its glory
   })
@@ -189,103 +197,164 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
 
   it('from 3.4.0 to 4.0.0', async () => {
     // this test case compares the state before the 4.0.0 upgrade to the state after the 4.0.0 upgrade
-    // Issuance costs rise ~0.04% due to sfrxETH's ~0.12% premium
+    // USD issuance costs rise ~0.04% due to sfrxETH's ~0.12% premium
 
+    // basketHandler.price()
     const lowPriceChange = newPrice[0].sub(oldPrice[0]).mul(fp('1')).div(oldPrice[0])
     const highPriceChange = newPrice[1].sub(oldPrice[1]).mul(fp('1')).div(oldPrice[1])
     expect(lowPriceChange).to.be.closeTo(fp('-0.000008'), fp('1e-6')) // low price -0.0008%
     expect(highPriceChange).to.be.closeTo(fp('0.000437'), fp('1e-6')) // high price +0.04%
 
-    const sfrxETHChange = newQuantities[0].sub(oldQuantities[0]).mul(fp('1')).div(oldQuantities[0])
-    const wstETHChange = newQuantities[1].sub(oldQuantities[1]).mul(fp('1')).div(oldQuantities[1])
-    const rETHChange = newQuantities[2].sub(oldQuantities[2]).mul(fp('1')).div(oldQuantities[2])
+    // basketHandler.quote()
+    const sfrxETHChange = newQs[0].sub(oldQs[0]).mul(fp('1')).div(oldQs[0])
+    const wstETHChange = newQs[1].sub(oldQs[1]).mul(fp('1')).div(oldQs[1])
+    const rETHChange = newQs[2].sub(oldQs[2]).mul(fp('1')).div(oldQs[2])
     expect(sfrxETHChange).to.be.closeTo(fp('0.001201'), fp('1e-6')) // sFraxETH +0.12%
     expect(wstETHChange).to.be.closeTo(fp('0.000126'), fp('1e-6')) // wstETH +0.012%
     expect(rETHChange).to.be.equal(0) // rETH no change
+
+    // rTokenAsset.price()
+    const lowRTokenPriceChange = newRTokenPrice[0]
+      .sub(oldRTokenPrice[0])
+      .mul(fp('1'))
+      .div(oldRTokenPrice[0])
+    const highRTokenPriceChange = newRTokenPrice[1]
+      .sub(oldRTokenPrice[1])
+      .mul(fp('1'))
+      .div(oldRTokenPrice[1])
+    expect(lowRTokenPriceChange).to.be.closeTo(fp('-0.000006'), fp('1e-6')) // low RToken price -0.0006%
+    expect(highRTokenPriceChange).to.be.closeTo(fp('0.000441'), fp('1e-6')) // high RToken price +0.04%
   })
 
   it('from 4.0.0 to 4.0.0 at-peg', async () => {
     // this test case compares the state after the 4.0.0 upgrade to the state when frxETH is at peg
-    // issuance costs fall by 0.0004%, which is not noticeable
+    // USD issuance costs fall by 0.0004%, which is not noticeable
 
     await sfraxEmaOracle.setPrice(fp('1'))
 
+    const parRTokenPrice = await rTokenAsset.price()
     const parPrice = await basketHandler.price()
     const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
+    // basketHandler.price()
     const lowPriceChange = parPrice[0].sub(newPrice[0]).mul(fp('1')).div(newPrice[0])
     const highPriceChange = parPrice[1].sub(newPrice[1]).mul(fp('1')).div(newPrice[1])
     expect(lowPriceChange).to.be.closeTo(fp('0.000411'), fp('1e-6')) // low price +0.04%
     expect(highPriceChange).to.be.closeTo(fp('-0.000042'), fp('1e-6')) // high price -0.0004%
 
-    const sfrxETHChange = parQs[0].sub(newQuantities[0]).mul(fp('1')).div(newQuantities[0])
-    const wstETHChange = parQs[1].sub(newQuantities[1]).mul(fp('1')).div(newQuantities[1])
-    const rETHChange = parQs[2].sub(newQuantities[2]).mul(fp('1')).div(newQuantities[2])
+    // basketHandler.quote()
+    const sfrxETHChange = parQs[0].sub(newQs[0]).mul(fp('1')).div(newQs[0])
+    const wstETHChange = parQs[1].sub(newQs[1]).mul(fp('1')).div(newQs[1])
+    const rETHChange = parQs[2].sub(newQs[2]).mul(fp('1')).div(newQs[2])
     expect(sfrxETHChange).to.be.closeTo(fp('-0.00122654'), fp('1e-6')) // sFraxETH -0.12%%
     expect(wstETHChange).to.be.closeTo(fp('-0.0001267'), fp('1e-6')) // wstETH -0.01%
     expect(rETHChange).to.be.equal(0) // rETH no change
+
+    // rTokenAsset.price()
+    const lowRTokenPriceChange = parRTokenPrice[0]
+      .sub(newRTokenPrice[0])
+      .mul(fp('1'))
+      .div(newRTokenPrice[0])
+    const highRTokenPriceChange = parRTokenPrice[1]
+      .sub(newRTokenPrice[1])
+      .mul(fp('1'))
+      .div(newRTokenPrice[1])
+    expect(lowRTokenPriceChange).to.be.closeTo(fp('0.000411'), fp('1e-6')) // low price +0.04%
+    expect(highRTokenPriceChange).to.be.closeTo(fp('-0.000042'), fp('1e-6')) // high price -0.0004%
   })
 
   it('from 4.0.0 at-peg to 2% below peg', async () => {
     // this test case compares the state from at-peg to the state after a 2% de-peg of frxETH
     // which is well within the default threshold.
-    // issuance costs do not change since the premium compensates completely
+    // USD issuance costs do not change since the premium compensates completely
 
     await sfraxEmaOracle.setPrice(fp('1'))
 
+    const parRTokenPrice = await rTokenAsset.price()
     const parPrice = await basketHandler.price()
     const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
     // de-peg by 2%
 
     await sfraxEmaOracle.setPrice(fp('0.98'))
+    const depeggedRTokenPrice = await rTokenAsset.price()
     await sfrxETH.refresh()
     expect(await sfrxETH.savedPegPrice()).to.equal(fp('0.98'))
 
     const depeggedPrice = await basketHandler.price()
     const depeggedQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
+    // basketHandler.price()
     const lowPriceChange = depeggedPrice[0].sub(parPrice[0]).mul(fp('1')).div(parPrice[0])
     const highPriceChange = depeggedPrice[1].sub(parPrice[1]).mul(fp('1')).div(parPrice[1])
     expect(lowPriceChange).to.be.closeTo(fp('-0.006706'), fp('1e-6')) // low price -0.67%
     expect(highPriceChange).be.closeTo(0, fp('1e-6')) // high price no change
 
+    // basketHandler.quote()
     const sfrxETHChange = depeggedQs[0].sub(parQs[0]).mul(fp('1')).div(parQs[0])
     const wstETHChange = depeggedQs[1].sub(parQs[1]).mul(fp('1')).div(parQs[1])
     const rETHChange = depeggedQs[2].sub(parQs[2]).mul(fp('1')).div(parQs[2])
     expect(sfrxETHChange).to.be.closeTo(fp('0.020408'), fp('1e-6')) // sFraxETH +2%
     expect(wstETHChange).to.be.closeTo(0, fp('1e-6')) // wstETH no change
     expect(rETHChange).to.be.equal(0) // rETH no change
+
+    // rTokenAsset.price()
+    const lowRTokenPriceChange = depeggedRTokenPrice[0]
+      .sub(parRTokenPrice[0])
+      .mul(fp('1'))
+      .div(parRTokenPrice[0])
+    const highRTokenPriceChange = depeggedRTokenPrice[1]
+      .sub(parRTokenPrice[1])
+      .mul(fp('1'))
+      .div(parRTokenPrice[1])
+    expect(lowRTokenPriceChange).to.be.closeTo(fp('-0.006706'), fp('1e-6')) // low RToken price -0.67%
+    expect(highRTokenPriceChange).be.closeTo(fp('-0.006596'), fp('1e-6')) // high RToken -0.65%
   })
 
   it('from 4.0.0 at-peg to 50% below peg', async () => {
     // this test case compares the state from at-peg to the state after a 50% de-peg of frxETH
-    // issuance costs do not change since the premium compensates completely
+    // USD issuance costs do not change since the premium compensates completely
 
     await sfraxEmaOracle.setPrice(fp('1'))
 
+    const parRTokenPrice = await rTokenAsset.price()
     const parPrice = await basketHandler.price()
     const parQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
     // de-peg by 50%
 
     await sfraxEmaOracle.setPrice(fp('0.5'))
+    const depeggedRTokenPrice = await rTokenAsset.price()
     await sfrxETH.refresh()
     expect(await sfrxETH.savedPegPrice()).to.equal(fp('0.5'))
 
     const depeggedPrice = await basketHandler.price()
     const depeggedQs = (await basketHandler.quote(fp('1'), 2)).quantities
 
+    // basketHandler.price()
     const lowPriceChange = depeggedPrice[0].sub(parPrice[0]).mul(fp('1')).div(parPrice[0])
     const highPriceChange = depeggedPrice[1].sub(parPrice[1]).mul(fp('1')).div(parPrice[1])
     expect(lowPriceChange).to.be.closeTo(fp('-0.167646'), fp('1e-6')) // low price -16.7%
     expect(highPriceChange).be.closeTo(0, fp('1e-6')) // high price no change
 
+    // basketHandler.quote()
     const sfrxETHChange = depeggedQs[0].sub(parQs[0]).mul(fp('1')).div(parQs[0])
     const wstETHChange = depeggedQs[1].sub(parQs[1]).mul(fp('1')).div(parQs[1])
     const rETHChange = depeggedQs[2].sub(parQs[2]).mul(fp('1')).div(parQs[2])
     expect(sfrxETHChange).to.be.closeTo(fp('1'), fp('1e-6')) // sFraxETH +100%
     expect(wstETHChange).to.be.closeTo(0, fp('1e-6')) // wstETH -0.12%
     expect(rETHChange).to.be.equal(0) // rETH no change
+
+    // rTokenAsset.price()
+    const lowRTokenPriceChange = depeggedRTokenPrice[0]
+      .sub(parRTokenPrice[0])
+      .mul(fp('1'))
+      .div(parRTokenPrice[0])
+    const highRTokenPriceChange = depeggedRTokenPrice[1]
+      .sub(parRTokenPrice[1])
+      .mul(fp('1'))
+      .div(parRTokenPrice[1])
+    expect(lowRTokenPriceChange).to.be.closeTo(fp('-0.167646'), fp('1e-6')) // low RToken price -16.7%
+    expect(highRTokenPriceChange).to.be.closeTo(fp('-0.164901'), fp('1e-6')) // high RToken price -16.4%
   })
 })

--- a/test/integration/mainnet-test/IssuancePremium.test.ts
+++ b/test/integration/mainnet-test/IssuancePremium.test.ts
@@ -206,7 +206,7 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
 
   it('from 4.0.0 to 4.0.0 at-peg', async () => {
     // this test case compares the state after the 4.0.0 upgrade to the state when frxETH is at peg
-    // issuance costs fall by 0.042 bps, which is not noticeable
+    // issuance costs fall by 0.0004%, which is not noticeable
 
     await sfraxEmaOracle.setPrice(fp('1'))
 
@@ -227,8 +227,9 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
   })
 
   it('from 4.0.0 at-peg to 2% below peg', async () => {
-    // this test case compares the state from at-peg to the state after a 2% de-peg of frxETH, within the default threshold
-    // issuance costs do not change since the premium compensates
+    // this test case compares the state from at-peg to the state after a 2% de-peg of frxETH
+    // which is well within the default threshold.
+    // issuance costs do not change since the premium compensates completely
 
     await sfraxEmaOracle.setPrice(fp('1'))
 
@@ -259,7 +260,7 @@ describeFork(`ETH+ Issuance Premium - Mainnet Forking P${IMPLEMENTATION}`, funct
 
   it('from 4.0.0 at-peg to 50% below peg', async () => {
     // this test case compares the state from at-peg to the state after a 50% de-peg of frxETH
-    // issuance costs do not change in USD terms, but sfrxETH increases quantities 100% to compensate
+    // issuance costs do not change since the premium compensates completely
 
     await sfraxEmaOracle.setPrice(fp('1'))
 

--- a/test/plugins/Collateral.test.ts
+++ b/test/plugins/Collateral.test.ts
@@ -397,58 +397,6 @@ describe('Collateral contracts', () => {
       ).to.be.revertedWith('delayUntilDefault too long')
     })
 
-    it('Should not allow low defaultThreshold', async () => {
-      await expect(
-        FiatCollateralFactory.deploy({
-          priceTimeout: PRICE_TIMEOUT,
-          chainlinkFeed: await tokenCollateral.chainlinkFeed(),
-          oracleError: ORACLE_ERROR,
-          erc20: token.address,
-          maxTradeVolume: config.rTokenMaxTradeVolume,
-          oracleTimeout: ORACLE_TIMEOUT,
-          targetName: ethers.utils.formatBytes32String('USD'),
-          defaultThreshold: fp('0.31'),
-          delayUntilDefault: bn(1),
-        })
-      ).to.be.revertedWith('defaultThreshold too high')
-
-      // ATokenFiatCollateral
-      await expect(
-        ATokenFiatCollateralFactory.deploy(
-          {
-            priceTimeout: PRICE_TIMEOUT,
-            chainlinkFeed: await tokenCollateral.chainlinkFeed(),
-            oracleError: ORACLE_ERROR,
-            erc20: aToken.address,
-            maxTradeVolume: config.rTokenMaxTradeVolume,
-            oracleTimeout: ORACLE_TIMEOUT,
-            targetName: ethers.utils.formatBytes32String('USD'),
-            defaultThreshold: fp('0.31'),
-            delayUntilDefault: bn(1),
-          },
-          REVENUE_HIDING
-        )
-      ).to.be.revertedWith('defaultThreshold too high')
-
-      // CTokenFiatCollateral
-      await expect(
-        CTokenFiatCollateralFactory.deploy(
-          {
-            priceTimeout: PRICE_TIMEOUT,
-            chainlinkFeed: await tokenCollateral.chainlinkFeed(),
-            oracleError: ORACLE_ERROR,
-            erc20: cToken.address,
-            maxTradeVolume: config.rTokenMaxTradeVolume,
-            oracleTimeout: ORACLE_TIMEOUT,
-            targetName: ethers.utils.formatBytes32String('USD'),
-            defaultThreshold: fp('0.31'),
-            delayUntilDefault: bn(1),
-          },
-          REVENUE_HIDING
-        )
-      ).to.be.revertedWith('defaultThreshold too high')
-    })
-
     it('Should not allow missing referenceERC20Decimals', async () => {
       // CTokenFiatCollateral with decimals = 0 in underlying
       const token0decimals: BadERC20 = await (

--- a/test/plugins/Collateral.test.ts
+++ b/test/plugins/Collateral.test.ts
@@ -407,10 +407,10 @@ describe('Collateral contracts', () => {
           maxTradeVolume: config.rTokenMaxTradeVolume,
           oracleTimeout: ORACLE_TIMEOUT,
           targetName: ethers.utils.formatBytes32String('USD'),
-          defaultThreshold: fp('0.69'),
+          defaultThreshold: fp('0.31'),
           delayUntilDefault: bn(1),
         })
-      ).to.be.revertedWith('defaultThreshold too low')
+      ).to.be.revertedWith('defaultThreshold too high')
 
       // ATokenFiatCollateral
       await expect(
@@ -423,12 +423,12 @@ describe('Collateral contracts', () => {
             maxTradeVolume: config.rTokenMaxTradeVolume,
             oracleTimeout: ORACLE_TIMEOUT,
             targetName: ethers.utils.formatBytes32String('USD'),
-            defaultThreshold: fp('0.69'),
+            defaultThreshold: fp('0.31'),
             delayUntilDefault: bn(1),
           },
           REVENUE_HIDING
         )
-      ).to.be.revertedWith('defaultThreshold too low')
+      ).to.be.revertedWith('defaultThreshold too high')
 
       // CTokenFiatCollateral
       await expect(
@@ -441,12 +441,12 @@ describe('Collateral contracts', () => {
             maxTradeVolume: config.rTokenMaxTradeVolume,
             oracleTimeout: ORACLE_TIMEOUT,
             targetName: ethers.utils.formatBytes32String('USD'),
-            defaultThreshold: fp('0.69'),
+            defaultThreshold: fp('0.31'),
             delayUntilDefault: bn(1),
           },
           REVENUE_HIDING
         )
-      ).to.be.revertedWith('defaultThreshold too low')
+      ).to.be.revertedWith('defaultThreshold too high')
     })
 
     it('Should not allow missing referenceERC20Decimals', async () => {

--- a/test/plugins/Collateral.test.ts
+++ b/test/plugins/Collateral.test.ts
@@ -397,6 +397,58 @@ describe('Collateral contracts', () => {
       ).to.be.revertedWith('delayUntilDefault too long')
     })
 
+    it('Should not allow low defaultThreshold', async () => {
+      await expect(
+        FiatCollateralFactory.deploy({
+          priceTimeout: PRICE_TIMEOUT,
+          chainlinkFeed: await tokenCollateral.chainlinkFeed(),
+          oracleError: ORACLE_ERROR,
+          erc20: token.address,
+          maxTradeVolume: config.rTokenMaxTradeVolume,
+          oracleTimeout: ORACLE_TIMEOUT,
+          targetName: ethers.utils.formatBytes32String('USD'),
+          defaultThreshold: fp('0.69'),
+          delayUntilDefault: bn(1),
+        })
+      ).to.be.revertedWith('defaultThreshold too low')
+
+      // ATokenFiatCollateral
+      await expect(
+        ATokenFiatCollateralFactory.deploy(
+          {
+            priceTimeout: PRICE_TIMEOUT,
+            chainlinkFeed: await tokenCollateral.chainlinkFeed(),
+            oracleError: ORACLE_ERROR,
+            erc20: aToken.address,
+            maxTradeVolume: config.rTokenMaxTradeVolume,
+            oracleTimeout: ORACLE_TIMEOUT,
+            targetName: ethers.utils.formatBytes32String('USD'),
+            defaultThreshold: fp('0.69'),
+            delayUntilDefault: bn(1),
+          },
+          REVENUE_HIDING
+        )
+      ).to.be.revertedWith('defaultThreshold too low')
+
+      // CTokenFiatCollateral
+      await expect(
+        CTokenFiatCollateralFactory.deploy(
+          {
+            priceTimeout: PRICE_TIMEOUT,
+            chainlinkFeed: await tokenCollateral.chainlinkFeed(),
+            oracleError: ORACLE_ERROR,
+            erc20: cToken.address,
+            maxTradeVolume: config.rTokenMaxTradeVolume,
+            oracleTimeout: ORACLE_TIMEOUT,
+            targetName: ethers.utils.formatBytes32String('USD'),
+            defaultThreshold: fp('0.69'),
+            delayUntilDefault: bn(1),
+          },
+          REVENUE_HIDING
+        )
+      ).to.be.revertedWith('defaultThreshold too low')
+    })
+
     it('Should not allow missing referenceERC20Decimals', async () => {
       // CTokenFiatCollateral with decimals = 0 in underlying
       const token0decimals: BadERC20 = await (

--- a/test/scenario/NestedRTokens.test.ts
+++ b/test/scenario/NestedRTokens.test.ts
@@ -374,19 +374,29 @@ describe(`Nested RTokens - P${IMPLEMENTATION}`, () => {
         {
           contract: one.rToken,
           name: 'Transfer',
-          args: [ZERO_ADDRESS, one.backingManager.address, issueAmt.div(2).sub(75)],
+          args: [
+            ZERO_ADDRESS,
+            one.backingManager.address,
+            withinTolerance(issueAmt.div(2).sub(75)),
+          ],
           emitted: true,
         },
         {
           contract: one.rToken,
           name: 'Transfer',
-          args: [one.rTokenTrader.address, one.furnace.address, rTokSellAmt],
+          args: [one.rTokenTrader.address, one.furnace.address, withinTolerance(rTokSellAmt)],
           emitted: true,
         },
         {
           contract: one.rsrTrader,
           name: 'TradeStarted',
-          args: [anyValue, one.rToken.address, one.rsr.address, rsrSellAmt, rsrMinBuyAmt],
+          args: [
+            anyValue,
+            one.rToken.address,
+            one.rsr.address,
+            withinTolerance(rsrSellAmt),
+            withinTolerance(rsrMinBuyAmt),
+          ],
           emitted: true,
         },
       ])


### PR DESCRIPTION
Add issuance premium to BasketHandler that begins on and can be toggled off by governance.

One of the bigger things to note is that this changes the price of a BU pretty significantly, since the upper BU price now takes into account any issuance premium that may apply. Interestingly this means during a de-peg the BU high price remains at $1.01, or just above its peg, instead of falling with the low price. This part should get some special attention, it feels more potentially dangerous to me than the actual issuance quantity change. 

Had to do a few things to reduce BasketHandler contract size as well, such as finally deleting `lotPrice()`