### PR TITLE
OETH plugin - Mainnet - Increase `toleranceDivisor` from 1e2 to 1e9.

### DIFF
--- a/test/plugins/individual-collateral/origin/OETHCollateral.test.ts
+++ b/test/plugins/individual-collateral/origin/OETHCollateral.test.ts
@@ -205,7 +205,7 @@ const getExpectedPrice = async (ctx: WOETHCollateralFixtureContext): Promise<Big
   const targetPerRefChainlinkFeedAnswer = await ctx.chainlinkFeed.latestAnswer()
   const targetPerRefChainlinkFeedDecimals = await ctx.chainlinkFeed.decimals()
 
-  const refPerTok = await ctx.collateral.refPerTok()
+  const refPerTok = await ctx.collateral.underlyingRefPerTok()
 
   const result = uoaPerTargetChainlinkFeedAnswer
     .mul(targetPerRefChainlinkFeedAnswer)
@@ -253,7 +253,7 @@ const opts = {
   itIsPricedByPeg: true,
   itHasOracleRefPerTok: false,
   targetNetwork: 'mainnet',
-  toleranceDivisor: bn('1e2'),
+  toleranceDivisor: bn('1e9'),
 }
 
 collateralTests(opts)

--- a/test/plugins/individual-collateral/origin/OETHCollateralL2Base.test.ts
+++ b/test/plugins/individual-collateral/origin/OETHCollateralL2Base.test.ts
@@ -205,7 +205,7 @@ const getExpectedPrice = async (ctx: WSUPEROETHBCollateralFixtureContext): Promi
   const uoaPerTargetChainlinkFeedAnswer = await ctx.uoaPerTargetChainlinkFeed.latestAnswer()
   const uoaPerTargetChainlinkFeedDecimals = await ctx.uoaPerTargetChainlinkFeed.decimals()
 
-  const refPerTok = await ctx.collateral.refPerTok()
+  const refPerTok = await ctx.collateral.underlyingRefPerTok()
 
   const result = uoaPerTargetChainlinkFeedAnswer
     .mul(bn(10).pow(18 - uoaPerTargetChainlinkFeedDecimals))
@@ -253,7 +253,7 @@ const opts = {
   itIsPricedByPeg: true,
   itHasOracleRefPerTok: true,
   targetNetwork: 'base',
-  toleranceDivisor: bn('1e2'),
+  toleranceDivisor: bn('1e9'),
 }
 
 collateralTests(opts)


### PR DESCRIPTION
@julianmrodri I found the issue, instead of using `underlyingRefPerTok()` to fetch the underlyingRefPerTok price and compute the expectedPrice on test, I was calling `refPerToken()`.

I've fixed it and managed to increase `toleranceDivisor` from `1e2`to `1e9`. 

I also took the opportunity to make the change on OETHBase test too.