### PR TITLE
implement optimization on Curve/CVX plugins

### DIFF
--- a/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveAppreciatingRTokenFiatCollateral.sol
@@ -47,10 +47,9 @@ contract CurveAppreciatingRTokenFiatCollateral is CurveStableCollateral {
     /// Refresh exchange rates and update default status.
     /// Have to override to add custom default checks
     function refresh() public virtual override {
-        // solhint-disable-next-line no-empty-blocks
-        try pairedAssetRegistry.refresh() {} catch {
-            // must allow failure since cannot brick refresh()
-        }
+        // Note: Intentionally not refreshing AssetRegistry as an acceptable trade-off
+        // Issuance throttle becomes worst-case outcome in case of issuance frontruns in
+        // response to picking up bad collateral
 
         CollateralStatus oldStatus = status();
 

--- a/contracts/plugins/assets/curve/CurveStableRTokenMetapoolCollateral.sol
+++ b/contracts/plugins/assets/curve/CurveStableRTokenMetapoolCollateral.sol
@@ -49,10 +49,9 @@ contract CurveStableRTokenMetapoolCollateral is CurveStableMetapoolCollateral {
     /// Refresh exchange rates and update default status.
     /// Have to override to add custom default checks
     function refresh() public virtual override {
-        // solhint-disable-next-line no-empty-blocks
-        try pairedAssetRegistry.refresh() {} catch {
-            // must allow failure since cannot brick refresh()
-        }
+        // Note: Intentionally not refreshing AssetRegistry as an acceptable trade-off
+        // Issuance throttle becomes worst-case outcome in case of issuance frontruns in
+        // response to picking up bad collateral
 
         CollateralStatus oldStatus = status();
 

--- a/test/plugins/individual-collateral/curve/crv/CrvStableRTokenMetapoolTestSuite.test.ts
+++ b/test/plugins/individual-collateral/curve/crv/CrvStableRTokenMetapoolTestSuite.test.ts
@@ -245,7 +245,7 @@ const collateralSpecificStatusTests = () => {
     await collateral.refresh()
   })
 
-  it('Regression test -- refreshes inner RTokenAsset on refresh()', async () => {
+  it('Regression test -- does not refresh inner RTokenAsset on refresh()', async () => {
     const [collateral] = await deployCollateral({})
     const initialPrice = await collateral.price()
     expect(initialPrice[0]).to.be.gt(0)
@@ -276,8 +276,8 @@ const collateralSpecificStatusTests = () => {
     // Refresh CurveStableRTokenMetapoolCollateral
     await collateral.refresh()
 
-    // Stale should be false again
-    expect(await mockRTokenAsset.stale()).to.be.false
+    // Stale remains true
+    expect(await mockRTokenAsset.stale()).to.be.true
   })
 }
 

--- a/test/plugins/individual-collateral/curve/cvx/CvxAppreciatingRTokenSelfReferential.test.ts
+++ b/test/plugins/individual-collateral/curve/cvx/CvxAppreciatingRTokenSelfReferential.test.ts
@@ -262,7 +262,7 @@ const collateralSpecificStatusTests = () => {
     expect(await mockRTokenAsset.stale()).to.be.true
   })
 
-  it.only('Regression test -- stays IFFY throughout inner RToken default + rebalancing', async () => {
+  it('Regression test -- stays IFFY throughout inner RToken default + rebalancing', async () => {
     const [collateral, opts] = await deployCollateral({})
     const ethplusAssetRegistry = await ethers.getContractAt(
       'IAssetRegistry',

--- a/test/plugins/individual-collateral/curve/cvx/CvxStableRTokenMetapoolTestSuite.test.ts
+++ b/test/plugins/individual-collateral/curve/cvx/CvxStableRTokenMetapoolTestSuite.test.ts
@@ -289,7 +289,7 @@ const collateralSpecificStatusTests = () => {
     expect(await mockRTokenAsset.stale()).to.be.true
   })
 
-  it.only('Regression test -- stays IFFY throughout inner RToken default + rebalancing', async () => {
+  it('Regression test -- stays IFFY throughout inner RToken default + rebalancing', async () => {
     const [collateral, opts] = await deployCollateral({})
     const eusdAssetRegistry = await ethers.getContractAt('IAssetRegistry', EUSD_ASSET_REGISTRY)
     const eusdBasketHandler = await ethers.getContractAt('TestIBasketHandler', EUSD_BASKET_HANDLER)


### PR DESCRIPTION
Avoid refreshing AssetRegistry on `refresh()`

* Implemented it in two contracts: 
- `CurveAppreciatingRTokenFiatCollateral.sol`
- `CurveStableRTokenMetapoolCollateral.sol`