### PR TITLE
docs(deployment): replace dead ethgasstation.info reference

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -185,7 +185,7 @@ yarn deploy:check_env --network mainnet
 
 If this passes successfully it will print the deployer address and the current ETH balance. Next:
 
-1. Send at least 6 ETH to this address (check ethgasstation.info; if gas prices are > 30gwei then we may need more)
+1. Send at least 6 ETH to this address (check current gas prices on [Etherscan Gas Tracker](https://etherscan.io/gastracker) or the [OpenChainBench gas benchmark](https://openchainbench.com/benchmarks/gas-estimation); if gas prices are > 30gwei then we may need more)
 2. Close the current terminal session.
 
 End state: Your `.env` file is known to be good. You did all of this without screensharing and are now at the end of the private-portion of the deployment process.


### PR DESCRIPTION
## Summary

Line 188 of `docs/deployment.md` currently instructs deployers to check gas prices on ethgasstation.info, but that domain has been dead since around 2023:

\`\`\`
$ curl -sI https://ethgasstation.info/
HTTP/2 403
server: cloudflare
\`\`\`

A deployer following this doc today lands on a Cloudflare-parked page and has no way to check gas prices as instructed.

## Change

One line updated to point to two live alternatives: Etherscan Gas Tracker (widely used industry standard) and the OpenChainBench gas benchmark (independent multi-provider gas oracle accuracy comparison, CC BY 4.0 open data). No other changes.

## Disclosure

I maintain OpenChainBench. Happy to swap the second reference for any other live gas oracle if that fits the doc style guide better, or drop it entirely and keep only the Etherscan Gas Tracker reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to use Etherscan Gas Tracker and OpenChainBench for current gas-price information (replacing the previous source).
  * Kept the rule of thumb that gas prices above 30 gwei may require sending additional ETH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->